### PR TITLE
Clean up warning suppressions and achieve zero-warning build

### DIFF
--- a/makefile
+++ b/makefile
@@ -52,6 +52,7 @@ PLATFORM=linux
 else ifeq ($(ARCH),macos)
 # Yes that's weird, but the build on macos works the same way as on linux
 PLATFORM=linux
+COMMON_CFLAGS += -DGL_SILENCE_DEPRECATION
 LDFLAGS += -framework Cocoa -framework OpenGL
 else
 $(error Unknown ARCH. Supported ones are linux, win32 and win64.)
@@ -169,7 +170,11 @@ TEST_OBJECTS:=$(TEST_DEPENDS:.d=.o)
 WARNINGS = -Wall -Wextra -Wzero-as-null-pointer-constant -Wformat=2 -Wold-style-cast -Wmissing-include-dirs -Woverloaded-virtual -Wpointer-arith -Wredundant-decls
 COMMON_CFLAGS += -std=c++17 $(IPATHS)
 DEBUG_FLAGS = -Werror -g -O0 -DDEBUG
-RELEASE_FLAGS = -O2 -funroll-loops -ffast-math -fomit-frame-pointer -finline-functions -s
+RELEASE_FLAGS = -O2 -funroll-loops -ffast-math -fomit-frame-pointer -finline-functions
+# Strip symbols in release builds (linker flag; skipped on macOS where it's unsupported by clang)
+ifneq ($(ARCH),macos)
+RELEASE_FLAGS += -s
+endif
 
 ifeq ($(findstring "g++",$(CXX)),"g++")
 WARNINGS += -Wlogical-op

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -23,7 +23,7 @@ namespace config
 
   std::istream& Config::parseStream(std::istream& configStream)
   {
-    std::streamsize maxSize = 256;
+    constexpr std::streamsize maxSize = 256;
     char chLine[maxSize];
     std::string section;
     while(configStream.good())

--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -1359,9 +1359,8 @@ void printer_stop ()
 
 
 
-void audio_update(void *userdata __attribute__((unused)), SDL_AudioStream *stream, int additional_amount, int total_amount)
+void audio_update([[maybe_unused]] void *userdata, SDL_AudioStream *stream, int additional_amount, [[maybe_unused]] int total_amount)
 {
-  (void)total_amount;
   if (CPC.snd_ready) {
     int len = additional_amount;
     if (len > static_cast<int>(CPC.snd_buffersize)) len = static_cast<int>(CPC.snd_buffersize);

--- a/src/koncepcja_ipc_server.cpp
+++ b/src/koncepcja_ipc_server.cpp
@@ -953,6 +953,7 @@ std::string handle_command(const std::string& line) {
       }
       char fname[512];
       if (pattern.find('%') != std::string::npos) {
+        // User-provided printf format (e.g. "/tmp/frame_%04d.png") — non-literal by design
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-nonliteral"
         snprintf(fname, sizeof(fname), pattern.c_str(), i);

--- a/src/macos_menu.mm
+++ b/src/macos_menu.mm
@@ -10,7 +10,7 @@ extern "C" void koncpc_menu_action(int action);
 @implementation KoncepcjaMenuTarget
 - (void)menuAction:(id)sender {
   NSInteger action = [sender tag];
-  koncpc_menu_action((int)action);
+  koncpc_menu_action(static_cast<int>(action));
 }
 @end
 
@@ -80,7 +80,7 @@ static void add_menu_group(NSMenu *mainMenu, KoncepcjaMenuTarget *target, NSStri
     NSString *itemTitle = [NSString stringWithUTF8String:entry->title];
     NSMenuItem *item = [[NSMenuItem alloc] initWithTitle:itemTitle action:@selector(menuAction:) keyEquivalent:@""];
     [item setTarget:target];
-    [item setTag:(NSInteger)entry->action];
+    [item setTag:static_cast<NSInteger>(entry->action)];
     applyShortcut(item, entry->shortcut);
     [submenu addItem:item];
   }

--- a/src/slotshandler.cpp
+++ b/src/slotshandler.cpp
@@ -1208,7 +1208,7 @@ int tape_insert_cdt (FILE *pfile)
 
          default: // "extension rule"
             if (remaining() < 4) {
-               LOG_ERROR("Truncated CDT block 0x" << std::hex << (int)bID);
+               LOG_ERROR("Truncated CDT block 0x" << std::hex << static_cast<int>(bID));
                return ERR_TAP_INVALID;
             }
             iBlockLength = *reinterpret_cast<dword *>(pbBlock) + 4;
@@ -1216,7 +1216,7 @@ int tape_insert_cdt (FILE *pfile)
 
       // Validate block doesn't extend past end of file
       if (iBlockLength < 0 || pbBlock + iBlockLength > pbTapeImageEnd) {
-         LOG_ERROR("CDT block 0x" << std::hex << (int)bID << " extends past end of file");
+         LOG_ERROR("CDT block 0x" << std::hex << static_cast<int>(bID) << " extends past end of file");
          return ERR_TAP_INVALID;
       }
 

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -539,7 +539,7 @@ void glscale_setpal(SDL_Color* c)
   }
 }
 
-void glscale_flip(video_plugin* t __attribute__((unused)))
+void glscale_flip([[maybe_unused]] video_plugin* t)
 {
   eglDisable(GL_BLEND);
   eglClearColor(0,0,0,1);
@@ -1252,7 +1252,7 @@ void filter_scale2x(Uint8 *srcPtr, Uint32 srcPitch,
   }
 }
 
-void scale2x_flip(video_plugin* t __attribute__((unused)))
+void scale2x_flip([[maybe_unused]] video_plugin* t)
 {
   if (SDL_MUSTLOCK(scaled))
     SDL_LockSurface(scaled);
@@ -1459,7 +1459,7 @@ void filter_ascale2x (Uint8 *srcPtr, Uint32 srcPitch,
 
 
 
-void ascale2x_flip(video_plugin* t __attribute__((unused)))
+void ascale2x_flip([[maybe_unused]] video_plugin* t)
 {
   if (SDL_MUSTLOCK(scaled))
     SDL_LockSurface(scaled);
@@ -1506,7 +1506,7 @@ void filter_tv2x(Uint8 *srcPtr, Uint32 srcPitch,
   }
 }
 
-void tv2x_flip(video_plugin* t __attribute__((unused)))
+void tv2x_flip([[maybe_unused]] video_plugin* t)
 {
   if (SDL_MUSTLOCK(scaled))
     SDL_LockSurface(scaled);
@@ -1549,7 +1549,7 @@ void filter_bilinear(Uint8 *srcPtr, Uint32 srcPitch,
   }
 }
 
-void swbilin_flip(video_plugin* t __attribute__((unused)))
+void swbilin_flip([[maybe_unused]] video_plugin* t)
 {
   if (SDL_MUSTLOCK(scaled))
     SDL_LockSurface(scaled);
@@ -1639,7 +1639,7 @@ void filter_bicubic(Uint8 *srcPtr, Uint32 srcPitch,
   }
 }
 
-void swbicub_flip(video_plugin* t __attribute__((unused)))
+void swbicub_flip([[maybe_unused]] video_plugin* t)
 {
   if (SDL_MUSTLOCK(scaled))
     SDL_LockSurface(scaled);
@@ -1690,7 +1690,7 @@ void filter_dotmatrix(Uint8 *srcPtr, Uint32 srcPitch,
   }
 }
 
-void dotmat_flip(video_plugin* t __attribute__((unused)))
+void dotmat_flip([[maybe_unused]] video_plugin* t)
 {
   if (SDL_MUSTLOCK(scaled))
     SDL_LockSurface(scaled);


### PR DESCRIPTION
## Summary
- Replace GCC `__attribute__((unused))` with C++17 `[[maybe_unused]]` across video.cpp and kon_cpc_ja.cpp
- Fix VLA warning with `constexpr` in configuration.cpp
- Replace C-style casts with `static_cast` in slotshandler.cpp and macos_menu.mm
- Skip `-s` linker flag on macOS (unsupported by clang)
- Add `-DGL_SILENCE_DEPRECATION` for macOS OpenGL headers
- Result: **zero warnings in project code** on clean build

## Remaining justified suppressions
- `koncepcja_ipc_server.cpp`: `#pragma GCC diagnostic ignored "-Wformat-nonliteral"` — user-provided printf format for frame filenames
- `capsimg/ignore_warnings.h`: third-party IPF library
- `gif_recorder.cpp`: pragma wrapper around `msf_gif.h` include
- `log.h`, `glfuncs.h`: NOLINT on macros (intentional design)

## Test plan
- [x] `make clean && make` — zero warnings in project code (312 vendor-only)
- [x] `./test_runner` — 240/240 pass