### PR TITLE
Add Auto-Type with WinAPE ~KEY~ syntax (Feature 3a)

### DIFF
--- a/src/autotype.cpp
+++ b/src/autotype.cpp
@@ -1,0 +1,229 @@
+#include "autotype.h"
+#include "keyboard.h"
+#include <map>
+#include <cctype>
+#include <cstdlib>
+
+AutoTypeQueue g_autotype_queue;
+
+// Key name map: matches ipc_key_names from koncepcja_ipc_server.cpp
+static const std::map<std::string, CPC_KEYS> autotype_key_names = {
+  {"ESC", CPC_ESC}, {"RETURN", CPC_RETURN}, {"ENTER", CPC_RETURN},
+  {"SPACE", CPC_SPACE}, {"TAB", CPC_TAB}, {"DEL", CPC_DEL},
+  {"COPY", CPC_COPY}, {"CONTROL", CPC_CONTROL}, {"CTRL", CPC_CONTROL},
+  {"SHIFT", CPC_LSHIFT}, {"LSHIFT", CPC_LSHIFT}, {"RSHIFT", CPC_RSHIFT},
+  {"UP", CPC_CUR_UP}, {"DOWN", CPC_CUR_DOWN},
+  {"LEFT", CPC_CUR_LEFT}, {"RIGHT", CPC_CUR_RIGHT},
+  {"CLR", CPC_CLR},
+  {"F0", CPC_F0}, {"F1", CPC_F1}, {"F2", CPC_F2}, {"F3", CPC_F3},
+  {"F4", CPC_F4}, {"F5", CPC_F5}, {"F6", CPC_F6}, {"F7", CPC_F7},
+  {"F8", CPC_F8}, {"F9", CPC_F9},
+  // Joystick
+  {"J0_UP", CPC_J0_UP}, {"J0_DOWN", CPC_J0_DOWN},
+  {"J0_LEFT", CPC_J0_LEFT}, {"J0_RIGHT", CPC_J0_RIGHT},
+  {"J0_FIRE1", CPC_J0_FIRE1}, {"J0_FIRE2", CPC_J0_FIRE2},
+  {"J1_UP", CPC_J1_UP}, {"J1_DOWN", CPC_J1_DOWN},
+  {"J1_LEFT", CPC_J1_LEFT}, {"J1_RIGHT", CPC_J1_RIGHT},
+  {"J1_FIRE1", CPC_J1_FIRE1}, {"J1_FIRE2", CPC_J1_FIRE2},
+};
+
+// Char-to-key map: matches ipc_char_to_key from koncepcja_ipc_server.cpp
+static const std::map<char, CPC_KEYS> autotype_char_to_key = {
+  {'a', CPC_a}, {'b', CPC_b}, {'c', CPC_c}, {'d', CPC_d}, {'e', CPC_e},
+  {'f', CPC_f}, {'g', CPC_g}, {'h', CPC_h}, {'i', CPC_i}, {'j', CPC_j},
+  {'k', CPC_k}, {'l', CPC_l}, {'m', CPC_m}, {'n', CPC_n}, {'o', CPC_o},
+  {'p', CPC_p}, {'q', CPC_q}, {'r', CPC_r}, {'s', CPC_s}, {'t', CPC_t},
+  {'u', CPC_u}, {'v', CPC_v}, {'w', CPC_w}, {'x', CPC_x}, {'y', CPC_y},
+  {'z', CPC_z},
+  {'A', CPC_A}, {'B', CPC_B}, {'C', CPC_C}, {'D', CPC_D}, {'E', CPC_E},
+  {'F', CPC_F}, {'G', CPC_G}, {'H', CPC_H}, {'I', CPC_I}, {'J', CPC_J},
+  {'K', CPC_K}, {'L', CPC_L}, {'M', CPC_M}, {'N', CPC_N}, {'O', CPC_O},
+  {'P', CPC_P}, {'Q', CPC_Q}, {'R', CPC_R}, {'S', CPC_S}, {'T', CPC_T},
+  {'U', CPC_U}, {'V', CPC_V}, {'W', CPC_W}, {'X', CPC_X}, {'Y', CPC_Y},
+  {'Z', CPC_Z},
+  {'0', CPC_0}, {'1', CPC_1}, {'2', CPC_2}, {'3', CPC_3}, {'4', CPC_4},
+  {'5', CPC_5}, {'6', CPC_6}, {'7', CPC_7}, {'8', CPC_8}, {'9', CPC_9},
+  {' ', CPC_SPACE}, {'\n', CPC_RETURN}, {'\r', CPC_RETURN},
+  {'.', CPC_PERIOD}, {',', CPC_COMMA}, {';', CPC_SEMICOLON},
+  {':', CPC_COLON}, {'-', CPC_MINUS}, {'+', CPC_PLUS},
+  {'/', CPC_SLASH}, {'*', CPC_ASTERISK}, {'=', CPC_EQUAL},
+  {'(', CPC_LEFTPAREN}, {')', CPC_RIGHTPAREN},
+  {'[', CPC_LBRACKET}, {']', CPC_RBRACKET},
+  {'{', CPC_LCBRACE}, {'}', CPC_RCBRACE},
+  {'<', CPC_LESS}, {'>', CPC_GREATER},
+  {'?', CPC_QUESTION}, {'!', CPC_EXCLAMATN},
+  {'@', CPC_AT}, {'#', CPC_HASH}, {'$', CPC_DOLLAR},
+  {'%', CPC_PERCENT}, {'^', CPC_POWER}, {'&', CPC_AMPERSAND},
+  {'|', CPC_PIPE}, {'\\', CPC_BACKSLASH},
+  {'"', CPC_DBLQUOTE}, {'\'', CPC_QUOTE},
+  {'`', CPC_BACKQUOTE}, {'_', CPC_UNDERSCORE},
+};
+
+// Resolve a key name (case-insensitive) to CPC_KEYS enum value.
+// Returns -1 if not found.
+static int resolve_key_name(const std::string& name) {
+  std::string upper = name;
+  for (auto& c : upper) c = static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
+  auto it = autotype_key_names.find(upper);
+  if (it != autotype_key_names.end()) return static_cast<int>(it->second);
+  // Single char: try char map
+  if (name.size() == 1) {
+    auto cit = autotype_char_to_key.find(name[0]);
+    if (cit != autotype_char_to_key.end()) return static_cast<int>(cit->second);
+  }
+  return -1;
+}
+
+std::string AutoTypeQueue::enqueue(const std::string& text) {
+  std::deque<AutoTypeAction> parsed;
+
+  for (size_t i = 0; i < text.size(); ) {
+    if (text[i] == '~') {
+      // Check for literal tilde: ~~
+      if (i + 1 < text.size() && text[i + 1] == '~') {
+        // Literal tilde character - but tilde is not in the CPC char map,
+        // so we skip it (same as unmappable chars in input type)
+        i += 2;
+        continue;
+      }
+
+      // Find closing ~
+      size_t close = text.find('~', i + 1);
+      if (close == std::string::npos) {
+        return "unclosed ~ at position " + std::to_string(i);
+      }
+
+      std::string tag = text.substr(i + 1, close - i - 1);
+      if (tag.empty()) {
+        return "empty ~~ tag at position " + std::to_string(i);
+      }
+
+      // Check for PAUSE
+      if (tag.size() > 6 && tag.substr(0, 6) == "PAUSE ") {
+        std::string num_str = tag.substr(6);
+        char* endptr = nullptr;
+        long frames = std::strtol(num_str.c_str(), &endptr, 10);
+        if (endptr == num_str.c_str() || *endptr != '\0' || frames < 1) {
+          return "bad PAUSE value: " + tag;
+        }
+        AutoTypeAction a;
+        a.type = AutoTypeAction::PAUSE;
+        a.cpc_key = 0;
+        a.pause_frames = static_cast<int>(frames);
+        parsed.push_back(a);
+        i = close + 1;
+        continue;
+      }
+
+      // Check for key hold: ~+KEY~ or ~-KEY~
+      if (tag.size() >= 2 && (tag[0] == '+' || tag[0] == '-')) {
+        bool press = (tag[0] == '+');
+        std::string key_name = tag.substr(1);
+        int key = resolve_key_name(key_name);
+        if (key < 0) {
+          return "unknown key: " + key_name;
+        }
+        AutoTypeAction a;
+        a.type = press ? AutoTypeAction::KEY_PRESS : AutoTypeAction::KEY_RELEASE;
+        a.cpc_key = static_cast<uint16_t>(key);
+        a.pause_frames = 0;
+        parsed.push_back(a);
+        i = close + 1;
+        continue;
+      }
+
+      // Regular special key: ~RETURN~, ~SPACE~, etc.
+      int key = resolve_key_name(tag);
+      if (key < 0) {
+        return "unknown key: " + tag;
+      }
+      AutoTypeAction a;
+      a.type = AutoTypeAction::CHAR_PRESS_RELEASE;
+      a.cpc_key = static_cast<uint16_t>(key);
+      a.pause_frames = 0;
+      parsed.push_back(a);
+      i = close + 1;
+      continue;
+    }
+
+    // Regular character
+    char ch = text[i];
+    auto cit = autotype_char_to_key.find(ch);
+    if (cit == autotype_char_to_key.end()) {
+      // Skip unmappable characters (consistent with input type behavior)
+      i++;
+      continue;
+    }
+    AutoTypeAction a;
+    a.type = AutoTypeAction::CHAR_PRESS_RELEASE;
+    a.cpc_key = static_cast<uint16_t>(cit->second);
+    a.pause_frames = 0;
+    parsed.push_back(a);
+    i++;
+  }
+
+  // Append parsed actions to existing queue
+  for (auto& a : parsed) {
+    queue_.push_back(a);
+  }
+  return "";
+}
+
+bool AutoTypeQueue::tick(const AutoTypeKeyFunc& apply_key) {
+  // Handle pending release from previous CHAR_PRESS_RELEASE
+  if (awaiting_release_) {
+    apply_key(pending_release_key_, false);
+    awaiting_release_ = false;
+    pending_release_key_ = 0;
+    return !queue_.empty();
+  }
+
+  // Handle active pause
+  if (pause_counter_ > 0) {
+    pause_counter_--;
+    return true;
+  }
+
+  if (queue_.empty()) return false;
+
+  AutoTypeAction action = queue_.front();
+  queue_.pop_front();
+
+  switch (action.type) {
+    case AutoTypeAction::CHAR_PRESS_RELEASE:
+      // Press key this frame, release next frame
+      apply_key(action.cpc_key, true);
+      awaiting_release_ = true;
+      pending_release_key_ = action.cpc_key;
+      return true;
+
+    case AutoTypeAction::KEY_PRESS:
+      apply_key(action.cpc_key, true);
+      return !queue_.empty() || awaiting_release_;
+
+    case AutoTypeAction::KEY_RELEASE:
+      apply_key(action.cpc_key, false);
+      return !queue_.empty() || awaiting_release_;
+
+    case AutoTypeAction::PAUSE:
+      pause_counter_ = action.pause_frames - 1;  // -1 because this frame counts
+      return true;
+  }
+
+  return false;
+}
+
+bool AutoTypeQueue::is_active() const {
+  return !queue_.empty() || awaiting_release_ || pause_counter_ > 0;
+}
+
+size_t AutoTypeQueue::remaining() const {
+  return queue_.size();
+}
+
+void AutoTypeQueue::clear() {
+  queue_.clear();
+  pause_counter_ = 0;
+  awaiting_release_ = false;
+  pending_release_key_ = 0;
+}

--- a/src/autotype.h
+++ b/src/autotype.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <string>
+#include <deque>
+#include <cstdint>
+#include <functional>
+
+struct AutoTypeAction {
+  enum Type { CHAR_PRESS_RELEASE, KEY_PRESS, KEY_RELEASE, PAUSE };
+  Type type;
+  uint16_t cpc_key;       // CPC_KEYS enum value
+  int pause_frames;       // for PAUSE type
+};
+
+// Callback type for applying a key press/release.
+// Parameters: cpc_key (CPC_KEYS enum value), pressed (true=press, false=release)
+using AutoTypeKeyFunc = std::function<void(uint16_t cpc_key, bool pressed)>;
+
+class AutoTypeQueue {
+public:
+  // Parse WinAPE ~KEY~ syntax into action queue.
+  // Returns empty string on success, error message on failure.
+  std::string enqueue(const std::string& text);
+
+  // Called once per frame from main loop. Applies next action(s)
+  // using the provided key function for matrix manipulation.
+  // Returns true if there are more actions pending.
+  bool tick(const AutoTypeKeyFunc& apply_key);
+
+  // Status
+  bool is_active() const;
+  size_t remaining() const;
+
+  // Clear queue
+  void clear();
+
+  // Access internal queue for testing
+  const std::deque<AutoTypeAction>& actions() const { return queue_; }
+
+private:
+  std::deque<AutoTypeAction> queue_;
+  int pause_counter_ = 0;
+  // For CHAR_PRESS_RELEASE: press on one frame, release on next
+  bool awaiting_release_ = false;
+  uint16_t pending_release_key_ = 0;
+};
+
+extern AutoTypeQueue g_autotype_queue;

--- a/test/autotype.cpp
+++ b/test/autotype.cpp
@@ -1,0 +1,388 @@
+#include <gtest/gtest.h>
+#include <vector>
+#include <utility>
+#include "autotype.h"
+#include "keyboard.h"
+
+// Record of key apply calls for testing
+struct KeyCall {
+  uint16_t cpc_key;
+  bool pressed;
+};
+
+class AutoTypeTest : public ::testing::Test {
+protected:
+  AutoTypeQueue queue;
+  std::vector<KeyCall> calls;
+
+  AutoTypeKeyFunc recorder() {
+    return [this](uint16_t cpc_key, bool pressed) {
+      calls.push_back({cpc_key, pressed});
+    };
+  }
+
+  void SetUp() override {
+    queue.clear();
+    calls.clear();
+  }
+};
+
+// --- Parser tests ---
+
+TEST_F(AutoTypeTest, BasicText) {
+  auto err = queue.enqueue("HELLO");
+  EXPECT_EQ(err, "");
+  // H E L L O = 5 chars, each CHAR_PRESS_RELEASE
+  EXPECT_EQ(queue.remaining(), 5u);
+  auto& actions = queue.actions();
+  EXPECT_EQ(actions[0].type, AutoTypeAction::CHAR_PRESS_RELEASE);
+  EXPECT_EQ(actions[0].cpc_key, static_cast<uint16_t>(CPC_H));
+  EXPECT_EQ(actions[1].cpc_key, static_cast<uint16_t>(CPC_E));
+  EXPECT_EQ(actions[2].cpc_key, static_cast<uint16_t>(CPC_L));
+  EXPECT_EQ(actions[3].cpc_key, static_cast<uint16_t>(CPC_L));
+  EXPECT_EQ(actions[4].cpc_key, static_cast<uint16_t>(CPC_O));
+}
+
+TEST_F(AutoTypeTest, LowercaseText) {
+  auto err = queue.enqueue("abc");
+  EXPECT_EQ(err, "");
+  EXPECT_EQ(queue.remaining(), 3u);
+  auto& actions = queue.actions();
+  EXPECT_EQ(actions[0].cpc_key, static_cast<uint16_t>(CPC_a));
+  EXPECT_EQ(actions[1].cpc_key, static_cast<uint16_t>(CPC_b));
+  EXPECT_EQ(actions[2].cpc_key, static_cast<uint16_t>(CPC_c));
+}
+
+TEST_F(AutoTypeTest, SpecialKeyReturn) {
+  auto err = queue.enqueue("~RETURN~");
+  EXPECT_EQ(err, "");
+  EXPECT_EQ(queue.remaining(), 1u);
+  auto& actions = queue.actions();
+  EXPECT_EQ(actions[0].type, AutoTypeAction::CHAR_PRESS_RELEASE);
+  EXPECT_EQ(actions[0].cpc_key, static_cast<uint16_t>(CPC_RETURN));
+}
+
+TEST_F(AutoTypeTest, SpecialKeySpace) {
+  auto err = queue.enqueue("~SPACE~");
+  EXPECT_EQ(err, "");
+  EXPECT_EQ(queue.remaining(), 1u);
+  EXPECT_EQ(queue.actions()[0].cpc_key, static_cast<uint16_t>(CPC_SPACE));
+}
+
+TEST_F(AutoTypeTest, SpecialKeyCaseInsensitive) {
+  auto err = queue.enqueue("~return~");
+  EXPECT_EQ(err, "");
+  EXPECT_EQ(queue.remaining(), 1u);
+  EXPECT_EQ(queue.actions()[0].cpc_key, static_cast<uint16_t>(CPC_RETURN));
+}
+
+TEST_F(AutoTypeTest, LiteralTilde) {
+  // ~~ should produce nothing (tilde not in CPC char map)
+  auto err = queue.enqueue("a~~b");
+  EXPECT_EQ(err, "");
+  EXPECT_EQ(queue.remaining(), 2u);  // just 'a' and 'b', tilde skipped
+  EXPECT_EQ(queue.actions()[0].cpc_key, static_cast<uint16_t>(CPC_a));
+  EXPECT_EQ(queue.actions()[1].cpc_key, static_cast<uint16_t>(CPC_b));
+}
+
+TEST_F(AutoTypeTest, KeyHoldPress) {
+  auto err = queue.enqueue("~+SHIFT~");
+  EXPECT_EQ(err, "");
+  EXPECT_EQ(queue.remaining(), 1u);
+  EXPECT_EQ(queue.actions()[0].type, AutoTypeAction::KEY_PRESS);
+  EXPECT_EQ(queue.actions()[0].cpc_key, static_cast<uint16_t>(CPC_LSHIFT));
+}
+
+TEST_F(AutoTypeTest, KeyHoldRelease) {
+  auto err = queue.enqueue("~-SHIFT~");
+  EXPECT_EQ(err, "");
+  EXPECT_EQ(queue.remaining(), 1u);
+  EXPECT_EQ(queue.actions()[0].type, AutoTypeAction::KEY_RELEASE);
+  EXPECT_EQ(queue.actions()[0].cpc_key, static_cast<uint16_t>(CPC_LSHIFT));
+}
+
+TEST_F(AutoTypeTest, KeyHoldSingleChar) {
+  auto err = queue.enqueue("~+A~");
+  EXPECT_EQ(err, "");
+  EXPECT_EQ(queue.remaining(), 1u);
+  EXPECT_EQ(queue.actions()[0].type, AutoTypeAction::KEY_PRESS);
+  EXPECT_EQ(queue.actions()[0].cpc_key, static_cast<uint16_t>(CPC_A));
+}
+
+TEST_F(AutoTypeTest, PauseFrames) {
+  auto err = queue.enqueue("~PAUSE 5~");
+  EXPECT_EQ(err, "");
+  EXPECT_EQ(queue.remaining(), 1u);
+  EXPECT_EQ(queue.actions()[0].type, AutoTypeAction::PAUSE);
+  EXPECT_EQ(queue.actions()[0].pause_frames, 5);
+}
+
+TEST_F(AutoTypeTest, PauseLargeValue) {
+  auto err = queue.enqueue("~PAUSE 100~");
+  EXPECT_EQ(err, "");
+  EXPECT_EQ(queue.actions()[0].pause_frames, 100);
+}
+
+TEST_F(AutoTypeTest, MixedRunQuote) {
+  // RUN"<RETURN> is a common CPC command
+  auto err = queue.enqueue("RUN\"~RETURN~");
+  EXPECT_EQ(err, "");
+  EXPECT_EQ(queue.remaining(), 5u);  // R U N " RETURN
+  auto& a = queue.actions();
+  EXPECT_EQ(a[0].cpc_key, static_cast<uint16_t>(CPC_R));
+  EXPECT_EQ(a[1].cpc_key, static_cast<uint16_t>(CPC_U));
+  EXPECT_EQ(a[2].cpc_key, static_cast<uint16_t>(CPC_N));
+  EXPECT_EQ(a[3].cpc_key, static_cast<uint16_t>(CPC_DBLQUOTE));
+  EXPECT_EQ(a[4].cpc_key, static_cast<uint16_t>(CPC_RETURN));
+}
+
+TEST_F(AutoTypeTest, ErrorUnrecognizedKey) {
+  auto err = queue.enqueue("~FOO~");
+  EXPECT_NE(err, "");
+  EXPECT_NE(err.find("FOO"), std::string::npos);
+  // Queue should be empty since enqueue failed before appending
+  EXPECT_EQ(queue.remaining(), 0u);
+}
+
+TEST_F(AutoTypeTest, ErrorUnclosedTilde) {
+  auto err = queue.enqueue("hello~RETURN");
+  EXPECT_NE(err, "");
+  EXPECT_NE(err.find("unclosed"), std::string::npos);
+}
+
+TEST_F(AutoTypeTest, ErrorBadPause) {
+  auto err = queue.enqueue("~PAUSE abc~");
+  EXPECT_NE(err, "");
+}
+
+TEST_F(AutoTypeTest, ErrorPauseZero) {
+  auto err = queue.enqueue("~PAUSE 0~");
+  EXPECT_NE(err, "");
+}
+
+TEST_F(AutoTypeTest, FunctionKeys) {
+  auto err = queue.enqueue("~F0~~F9~");
+  EXPECT_EQ(err, "");
+  EXPECT_EQ(queue.remaining(), 2u);
+  EXPECT_EQ(queue.actions()[0].cpc_key, static_cast<uint16_t>(CPC_F0));
+  EXPECT_EQ(queue.actions()[1].cpc_key, static_cast<uint16_t>(CPC_F9));
+}
+
+TEST_F(AutoTypeTest, CursorKeys) {
+  auto err = queue.enqueue("~UP~~DOWN~~LEFT~~RIGHT~");
+  EXPECT_EQ(err, "");
+  EXPECT_EQ(queue.remaining(), 4u);
+  EXPECT_EQ(queue.actions()[0].cpc_key, static_cast<uint16_t>(CPC_CUR_UP));
+  EXPECT_EQ(queue.actions()[1].cpc_key, static_cast<uint16_t>(CPC_CUR_DOWN));
+  EXPECT_EQ(queue.actions()[2].cpc_key, static_cast<uint16_t>(CPC_CUR_LEFT));
+  EXPECT_EQ(queue.actions()[3].cpc_key, static_cast<uint16_t>(CPC_CUR_RIGHT));
+}
+
+TEST_F(AutoTypeTest, DigitsAndSymbols) {
+  auto err = queue.enqueue("10 PRINT \"HELLO\"");
+  EXPECT_EQ(err, "");
+  // 1 0 ' ' P R I N T ' ' " H E L L O "
+  EXPECT_EQ(queue.remaining(), 16u);
+}
+
+TEST_F(AutoTypeTest, EnqueueAppendsToExisting) {
+  queue.enqueue("A");
+  queue.enqueue("B");
+  EXPECT_EQ(queue.remaining(), 2u);
+  EXPECT_EQ(queue.actions()[0].cpc_key, static_cast<uint16_t>(CPC_A));
+  EXPECT_EQ(queue.actions()[1].cpc_key, static_cast<uint16_t>(CPC_B));
+}
+
+TEST_F(AutoTypeTest, UnmappableCharsSkipped) {
+  // Tilde is not in the CPC char map; other unmappable chars should be skipped
+  auto err = queue.enqueue("a\x01" "b");  // 0x01 is not mappable
+  EXPECT_EQ(err, "");
+  EXPECT_EQ(queue.remaining(), 2u);  // only 'a' and 'b'
+}
+
+// --- Tick tests ---
+
+TEST_F(AutoTypeTest, TickCharPressRelease) {
+  queue.enqueue("A");
+  // Frame 1: press
+  EXPECT_TRUE(queue.tick(recorder()));
+  ASSERT_EQ(calls.size(), 1u);
+  EXPECT_EQ(calls[0].cpc_key, static_cast<uint16_t>(CPC_A));
+  EXPECT_TRUE(calls[0].pressed);
+  EXPECT_TRUE(queue.is_active());
+
+  // Frame 2: release
+  calls.clear();
+  EXPECT_FALSE(queue.tick(recorder()));  // no more actions after release
+  ASSERT_EQ(calls.size(), 1u);
+  EXPECT_EQ(calls[0].cpc_key, static_cast<uint16_t>(CPC_A));
+  EXPECT_FALSE(calls[0].pressed);
+  EXPECT_FALSE(queue.is_active());
+}
+
+TEST_F(AutoTypeTest, TickTwoChars) {
+  queue.enqueue("AB");
+  // Frame 1: press A
+  EXPECT_TRUE(queue.tick(recorder()));
+  EXPECT_EQ(calls.back().cpc_key, static_cast<uint16_t>(CPC_A));
+  EXPECT_TRUE(calls.back().pressed);
+
+  // Frame 2: release A
+  EXPECT_TRUE(queue.tick(recorder()));
+  EXPECT_EQ(calls.back().cpc_key, static_cast<uint16_t>(CPC_A));
+  EXPECT_FALSE(calls.back().pressed);
+
+  // Frame 3: press B
+  EXPECT_TRUE(queue.tick(recorder()));
+  EXPECT_EQ(calls.back().cpc_key, static_cast<uint16_t>(CPC_B));
+  EXPECT_TRUE(calls.back().pressed);
+
+  // Frame 4: release B
+  EXPECT_FALSE(queue.tick(recorder()));
+  EXPECT_EQ(calls.back().cpc_key, static_cast<uint16_t>(CPC_B));
+  EXPECT_FALSE(calls.back().pressed);
+
+  EXPECT_FALSE(queue.is_active());
+}
+
+TEST_F(AutoTypeTest, TickKeyPress) {
+  queue.enqueue("~+SHIFT~");
+  // Only press, no release
+  EXPECT_FALSE(queue.tick(recorder()));  // no more actions
+  ASSERT_EQ(calls.size(), 1u);
+  EXPECT_EQ(calls[0].cpc_key, static_cast<uint16_t>(CPC_LSHIFT));
+  EXPECT_TRUE(calls[0].pressed);
+}
+
+TEST_F(AutoTypeTest, TickKeyRelease) {
+  queue.enqueue("~-SHIFT~");
+  EXPECT_FALSE(queue.tick(recorder()));
+  ASSERT_EQ(calls.size(), 1u);
+  EXPECT_EQ(calls[0].cpc_key, static_cast<uint16_t>(CPC_LSHIFT));
+  EXPECT_FALSE(calls[0].pressed);
+}
+
+TEST_F(AutoTypeTest, TickPause) {
+  queue.enqueue("A~PAUSE 3~B");
+  // Frame 1: press A
+  EXPECT_TRUE(queue.tick(recorder()));
+  EXPECT_EQ(calls.size(), 1u);
+
+  // Frame 2: release A
+  EXPECT_TRUE(queue.tick(recorder()));
+  EXPECT_EQ(calls.size(), 2u);
+
+  // Frame 3: pause starts (frame 1 of 3)
+  EXPECT_TRUE(queue.tick(recorder()));
+  EXPECT_EQ(calls.size(), 2u);  // no key calls during pause
+
+  // Frame 4: pause (frame 2 of 3)
+  EXPECT_TRUE(queue.tick(recorder()));
+  EXPECT_EQ(calls.size(), 2u);
+
+  // Frame 5: pause (frame 3 of 3)
+  EXPECT_TRUE(queue.tick(recorder()));
+  EXPECT_EQ(calls.size(), 2u);
+
+  // Frame 6: press B
+  EXPECT_TRUE(queue.tick(recorder()));
+  EXPECT_EQ(calls.size(), 3u);
+  EXPECT_EQ(calls[2].cpc_key, static_cast<uint16_t>(CPC_B));
+  EXPECT_TRUE(calls[2].pressed);
+
+  // Frame 7: release B
+  EXPECT_FALSE(queue.tick(recorder()));
+  EXPECT_EQ(calls.size(), 4u);
+}
+
+TEST_F(AutoTypeTest, TickShiftedChar) {
+  // Hold shift, type a, release shift
+  queue.enqueue("~+SHIFT~a~-SHIFT~");
+  // Frame 1: press SHIFT (KEY_PRESS, no awaiting_release)
+  // KEY_PRESS returns !queue_.empty(), which is true (a and -SHIFT remaining)
+  EXPECT_TRUE(queue.tick(recorder()));
+  EXPECT_EQ(calls.size(), 1u);
+  EXPECT_TRUE(calls[0].pressed);
+
+  // Frame 2: press 'a' (CHAR_PRESS_RELEASE)
+  EXPECT_TRUE(queue.tick(recorder()));
+  EXPECT_EQ(calls.size(), 2u);
+  EXPECT_EQ(calls[1].cpc_key, static_cast<uint16_t>(CPC_a));
+  EXPECT_TRUE(calls[1].pressed);
+
+  // Frame 3: release 'a'
+  EXPECT_TRUE(queue.tick(recorder()));
+  EXPECT_EQ(calls.size(), 3u);
+  EXPECT_FALSE(calls[2].pressed);
+
+  // Frame 4: release SHIFT
+  EXPECT_FALSE(queue.tick(recorder()));
+  EXPECT_EQ(calls.size(), 4u);
+  EXPECT_EQ(calls[3].cpc_key, static_cast<uint16_t>(CPC_LSHIFT));
+  EXPECT_FALSE(calls[3].pressed);
+}
+
+TEST_F(AutoTypeTest, TickEmpty) {
+  EXPECT_FALSE(queue.tick(recorder()));
+  EXPECT_EQ(calls.size(), 0u);
+}
+
+TEST_F(AutoTypeTest, ClearWhileActive) {
+  queue.enqueue("ABCDEF");
+  queue.tick(recorder());  // press A
+  EXPECT_TRUE(queue.is_active());
+  queue.clear();
+  EXPECT_FALSE(queue.is_active());
+  EXPECT_EQ(queue.remaining(), 0u);
+  EXPECT_FALSE(queue.tick(recorder()));
+}
+
+TEST_F(AutoTypeTest, StatusIdle) {
+  EXPECT_FALSE(queue.is_active());
+  EXPECT_EQ(queue.remaining(), 0u);
+}
+
+TEST_F(AutoTypeTest, StatusActive) {
+  queue.enqueue("A");
+  EXPECT_TRUE(queue.is_active());
+  EXPECT_EQ(queue.remaining(), 1u);
+}
+
+TEST_F(AutoTypeTest, ControlKey) {
+  auto err = queue.enqueue("~CONTROL~");
+  EXPECT_EQ(err, "");
+  EXPECT_EQ(queue.actions()[0].cpc_key, static_cast<uint16_t>(CPC_CONTROL));
+}
+
+TEST_F(AutoTypeTest, EscKey) {
+  auto err = queue.enqueue("~ESC~");
+  EXPECT_EQ(err, "");
+  EXPECT_EQ(queue.actions()[0].cpc_key, static_cast<uint16_t>(CPC_ESC));
+}
+
+TEST_F(AutoTypeTest, CopyKey) {
+  auto err = queue.enqueue("~COPY~");
+  EXPECT_EQ(err, "");
+  EXPECT_EQ(queue.actions()[0].cpc_key, static_cast<uint16_t>(CPC_COPY));
+}
+
+TEST_F(AutoTypeTest, TabAndDel) {
+  auto err = queue.enqueue("~TAB~~DEL~");
+  EXPECT_EQ(err, "");
+  EXPECT_EQ(queue.remaining(), 2u);
+  EXPECT_EQ(queue.actions()[0].cpc_key, static_cast<uint16_t>(CPC_TAB));
+  EXPECT_EQ(queue.actions()[1].cpc_key, static_cast<uint16_t>(CPC_DEL));
+}
+
+TEST_F(AutoTypeTest, ClrKey) {
+  auto err = queue.enqueue("~CLR~");
+  EXPECT_EQ(err, "");
+  EXPECT_EQ(queue.actions()[0].cpc_key, static_cast<uint16_t>(CPC_CLR));
+}
+
+TEST_F(AutoTypeTest, PauseOneFrame) {
+  queue.enqueue("~PAUSE 1~");
+  // The pause counts this frame, so only 1 frame
+  EXPECT_TRUE(queue.tick(recorder()));  // pause frame (counter = 0 after -1)
+  EXPECT_FALSE(queue.tick(recorder())); // queue empty
+}


### PR DESCRIPTION
## Summary
- New `autotype` IPC command for automated keyboard input using WinAPE's `~KEY~` syntax
- Supports special keys (`~RETURN~`, `~SPACE~`, etc.), key hold/release (`~+A~`/`~-A~`), frame pauses (`~PAUSE N~`), and literal tilde (`~~`)
- Frame-based injection: each character gets press/release across two frames for reliable keyboard matrix scanning
- New files: `src/autotype.h`, `src/autotype.cpp`

## IPC Commands
- `autotype <text>` — queue text/key sequence for injection
- `autotype status` — returns `idle` or `active: N actions remaining`
- `autotype clear` — clear the auto-type queue

## Test plan
- [x] 37 new unit tests (parser + tick behavior)
- [x] All 277 tests pass (240 existing + 37 new)
- [x] `make clean && make` — clean build