### PR TITLE
Add WAV audio recording from PSG (Feature 2d)

### DIFF
--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -48,6 +48,7 @@ static inline Uint32 MapRGBSurface(SDL_Surface* surface, Uint8 r, Uint8 g, Uint8
 #include "zip.h"
 #include "keyboard.h"
 #include "trace.h"
+#include "wav_recorder.h"
 #include "macos_menu.h"
 
 #include "imgui.h"
@@ -1367,6 +1368,9 @@ void audio_update([[maybe_unused]] void *userdata, SDL_AudioStream *stream, int 
     if (len > static_cast<int>(CPC.snd_buffersize)) len = static_cast<int>(CPC.snd_buffersize);
     if (len > 0) {
       SDL_PutAudioStreamData(stream, pbSndBuffer.get(), len);
+      if (g_wav_recorder.is_recording()) {
+        g_wav_recorder.write_samples(pbSndBuffer.get(), static_cast<uint32_t>(len));
+      }
     }
   } else {
     LOG_VERBOSE("Audio: audio_update: skipping audio: sound buffer not ready");

--- a/src/wav_recorder.cpp
+++ b/src/wav_recorder.cpp
@@ -1,0 +1,133 @@
+#include "wav_recorder.h"
+#include <cstring>
+
+namespace {
+void write_le_u16(uint16_t val, FILE* f) {
+    fputc(val & 0xff, f);
+    fputc((val >> 8) & 0xff, f);
+}
+void write_le_u32(uint32_t val, FILE* f) {
+    fputc(val & 0xff, f);
+    fputc((val >> 8) & 0xff, f);
+    fputc((val >> 16) & 0xff, f);
+    fputc((val >> 24) & 0xff, f);
+}
+} // namespace
+
+WavRecorder g_wav_recorder;
+
+WavRecorder::~WavRecorder() {
+    if (file_) {
+        stop();
+    }
+}
+
+std::string WavRecorder::start(const std::string& path, uint32_t sample_rate,
+                               uint16_t bits_per_sample, uint16_t channels) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (file_) {
+        return "already recording";
+    }
+
+    file_ = fopen(path.c_str(), "wb");
+    if (!file_) {
+        return std::string("cannot open file: ") + strerror(errno);
+    }
+
+    path_ = path;
+    data_bytes_ = 0;
+    sample_rate_ = sample_rate;
+    bits_per_sample_ = bits_per_sample;
+    channels_ = channels;
+    error_ = false;
+
+    write_header();
+    return "";
+}
+
+uint32_t WavRecorder::stop() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!file_) {
+        return 0;
+    }
+
+    finalize_header();
+    fclose(file_);
+    file_ = nullptr;
+
+    uint32_t result = data_bytes_;
+    data_bytes_ = 0;
+    path_.clear();
+    return result;
+}
+
+void WavRecorder::write_samples(const uint8_t* data, uint32_t len) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!file_ || len == 0) return;
+
+    size_t written = fwrite(data, 1, len, file_);
+    data_bytes_ += static_cast<uint32_t>(written);
+    if (written < len) {
+        error_ = true;
+    }
+}
+
+bool WavRecorder::is_recording() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return file_ != nullptr;
+}
+
+std::string WavRecorder::current_path() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return path_;
+}
+
+uint32_t WavRecorder::bytes_written() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return data_bytes_;
+}
+
+bool WavRecorder::has_error() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return error_;
+}
+
+// Write the initial 44-byte WAV header with placeholder sizes.
+// Sizes will be patched by finalize_header() when recording stops.
+void WavRecorder::write_header() {
+    uint32_t byte_rate = sample_rate_ * channels_ * (bits_per_sample_ / 8);
+    uint16_t block_align = static_cast<uint16_t>(channels_ * (bits_per_sample_ / 8));
+
+    // RIFF header
+    fwrite("RIFF", 1, 4, file_);
+    write_le_u32(0, file_);  // file size placeholder, will be patched
+    fwrite("WAVE", 1, 4, file_);
+
+    // fmt sub-chunk
+    fwrite("fmt ", 1, 4, file_);
+    write_le_u32(16, file_);           // fmt chunk size
+    write_le_u16(1, file_);            // audio format = PCM
+    write_le_u16(channels_, file_);
+    write_le_u32(sample_rate_, file_);
+    write_le_u32(byte_rate, file_);
+    write_le_u16(block_align, file_);
+    write_le_u16(bits_per_sample_, file_);
+
+    // data sub-chunk
+    fwrite("data", 1, 4, file_);
+    write_le_u32(0, file_);  // data size placeholder, will be patched
+}
+
+// Seek back to the header and patch the file size and data size fields.
+void WavRecorder::finalize_header() {
+    // Patch data sub-chunk size at offset 40
+    fseek(file_, 40, SEEK_SET);
+    write_le_u32(data_bytes_, file_);
+
+    // Patch RIFF chunk size at offset 4: total file size - 8
+    uint32_t riff_size = data_bytes_ + 36;  // 44 - 8 = 36 bytes of header after RIFF size
+    fseek(file_, 4, SEEK_SET);
+    write_le_u32(riff_size, file_);
+
+    fflush(file_);
+}

--- a/src/wav_recorder.h
+++ b/src/wav_recorder.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <string>
+#include <cstdint>
+#include <cstdio>
+#include <mutex>
+
+class WavRecorder {
+public:
+    ~WavRecorder();
+
+    // Start recording. Returns empty string on success, error message on failure.
+    std::string start(const std::string& path, uint32_t sample_rate,
+                      uint16_t bits_per_sample, uint16_t channels);
+
+    // Stop recording. Returns bytes of PCM data written.
+    uint32_t stop();
+
+    // Write PCM samples to WAV file. Thread-safe.
+    void write_samples(const uint8_t* data, uint32_t len);
+
+    bool is_recording() const;
+    std::string current_path() const;
+    uint32_t bytes_written() const;
+    bool has_error() const;
+
+private:
+    FILE* file_ = nullptr;
+    std::string path_;
+    uint32_t data_bytes_ = 0;
+    uint32_t sample_rate_ = 0;
+    uint16_t bits_per_sample_ = 0;
+    uint16_t channels_ = 0;
+    bool error_ = false;
+    mutable std::mutex mutex_;
+
+    void write_header();
+    void finalize_header();
+};
+
+// Global instance
+extern WavRecorder g_wav_recorder;

--- a/test/wav_recorder.cpp
+++ b/test/wav_recorder.cpp
@@ -1,0 +1,282 @@
+#include <gtest/gtest.h>
+#include <filesystem>
+#include <fstream>
+#include <cstring>
+
+#include "wav_recorder.h"
+
+namespace fs = std::filesystem;
+
+class WavRecorderTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        tmp_dir_ = fs::temp_directory_path() / "wav_recorder_test";
+        fs::create_directories(tmp_dir_);
+    }
+
+    void TearDown() override {
+        // Stop recorder if still running
+        recorder_.stop();
+        fs::remove_all(tmp_dir_);
+    }
+
+    std::string tmp_path(const std::string& name) {
+        return (tmp_dir_ / name).string();
+    }
+
+    // Read the full contents of a file into a vector
+    std::vector<uint8_t> read_file(const std::string& path) {
+        std::ifstream f(path, std::ios::binary);
+        return std::vector<uint8_t>(std::istreambuf_iterator<char>(f),
+                                    std::istreambuf_iterator<char>());
+    }
+
+    // Read a little-endian uint16 from a byte buffer at offset
+    uint16_t read_u16(const std::vector<uint8_t>& buf, size_t offset) {
+        return static_cast<uint16_t>(buf[offset]) |
+               (static_cast<uint16_t>(buf[offset + 1]) << 8);
+    }
+
+    // Read a little-endian uint32 from a byte buffer at offset
+    uint32_t read_u32(const std::vector<uint8_t>& buf, size_t offset) {
+        return static_cast<uint32_t>(buf[offset]) |
+               (static_cast<uint32_t>(buf[offset + 1]) << 8) |
+               (static_cast<uint32_t>(buf[offset + 2]) << 16) |
+               (static_cast<uint32_t>(buf[offset + 3]) << 24);
+    }
+
+    WavRecorder recorder_;
+    fs::path tmp_dir_;
+};
+
+TEST_F(WavRecorderTest, StartAndStopCreatesValidWavFile) {
+    std::string path = tmp_path("test.wav");
+    auto err = recorder_.start(path, 44100, 16, 2);
+    ASSERT_TRUE(err.empty()) << "start failed: " << err;
+    ASSERT_TRUE(recorder_.is_recording());
+
+    uint32_t bytes = recorder_.stop();
+    EXPECT_EQ(bytes, 0u);  // No samples written
+    EXPECT_FALSE(recorder_.is_recording());
+
+    // Verify the file exists and has a valid header (44 bytes minimum)
+    auto data = read_file(path);
+    ASSERT_GE(data.size(), 44u);
+
+    // Check RIFF header
+    EXPECT_EQ(data[0], 'R');
+    EXPECT_EQ(data[1], 'I');
+    EXPECT_EQ(data[2], 'F');
+    EXPECT_EQ(data[3], 'F');
+
+    // Check WAVE format
+    EXPECT_EQ(data[8], 'W');
+    EXPECT_EQ(data[9], 'A');
+    EXPECT_EQ(data[10], 'V');
+    EXPECT_EQ(data[11], 'E');
+
+    // Check fmt sub-chunk
+    EXPECT_EQ(data[12], 'f');
+    EXPECT_EQ(data[13], 'm');
+    EXPECT_EQ(data[14], 't');
+    EXPECT_EQ(data[15], ' ');
+}
+
+TEST_F(WavRecorderTest, HeaderFieldsAreCorrect) {
+    std::string path = tmp_path("header_test.wav");
+    auto err = recorder_.start(path, 48000, 16, 2);
+    ASSERT_TRUE(err.empty());
+    recorder_.stop();
+
+    auto data = read_file(path);
+    ASSERT_GE(data.size(), 44u);
+
+    // fmt chunk size = 16
+    EXPECT_EQ(read_u32(data, 16), 16u);
+    // Audio format = 1 (PCM)
+    EXPECT_EQ(read_u16(data, 20), 1u);
+    // Channels = 2
+    EXPECT_EQ(read_u16(data, 22), 2u);
+    // Sample rate = 48000
+    EXPECT_EQ(read_u32(data, 24), 48000u);
+    // Byte rate = 48000 * 2 * 2 = 192000
+    EXPECT_EQ(read_u32(data, 28), 192000u);
+    // Block align = 2 * 2 = 4
+    EXPECT_EQ(read_u16(data, 32), 4u);
+    // Bits per sample = 16
+    EXPECT_EQ(read_u16(data, 34), 16u);
+
+    // data sub-chunk marker
+    EXPECT_EQ(data[36], 'd');
+    EXPECT_EQ(data[37], 'a');
+    EXPECT_EQ(data[38], 't');
+    EXPECT_EQ(data[39], 'a');
+
+    // data size = 0 (no samples)
+    EXPECT_EQ(read_u32(data, 40), 0u);
+
+    // RIFF size = 36 (44 - 8 + 0 data bytes)
+    EXPECT_EQ(read_u32(data, 4), 36u);
+}
+
+TEST_F(WavRecorderTest, WriteSamplesUpdatesCount) {
+    std::string path = tmp_path("samples.wav");
+    auto err = recorder_.start(path, 44100, 16, 1);
+    ASSERT_TRUE(err.empty());
+
+    // Write 100 bytes of sample data
+    std::vector<uint8_t> samples(100, 0x42);
+    recorder_.write_samples(samples.data(), static_cast<uint32_t>(samples.size()));
+
+    EXPECT_EQ(recorder_.bytes_written(), 100u);
+
+    // Write more
+    recorder_.write_samples(samples.data(), 50);
+    EXPECT_EQ(recorder_.bytes_written(), 150u);
+
+    uint32_t total = recorder_.stop();
+    EXPECT_EQ(total, 150u);
+}
+
+TEST_F(WavRecorderTest, WriteSamplesProducesCorrectFile) {
+    std::string path = tmp_path("pcm_data.wav");
+    auto err = recorder_.start(path, 22050, 8, 1);
+    ASSERT_TRUE(err.empty());
+
+    // Write known data pattern
+    uint8_t pattern[] = {0x80, 0x90, 0xA0, 0xB0, 0xC0};
+    recorder_.write_samples(pattern, 5);
+    recorder_.stop();
+
+    auto data = read_file(path);
+    ASSERT_EQ(data.size(), 44u + 5u);
+
+    // Verify PCM data after header
+    EXPECT_EQ(data[44], 0x80);
+    EXPECT_EQ(data[45], 0x90);
+    EXPECT_EQ(data[46], 0xA0);
+    EXPECT_EQ(data[47], 0xB0);
+    EXPECT_EQ(data[48], 0xC0);
+
+    // Verify header sizes are patched correctly
+    EXPECT_EQ(read_u32(data, 40), 5u);        // data chunk size
+    EXPECT_EQ(read_u32(data, 4), 36u + 5u);   // RIFF size
+
+    // Verify audio format fields
+    EXPECT_EQ(read_u32(data, 24), 22050u);     // sample rate
+    EXPECT_EQ(read_u32(data, 28), 22050u);     // byte rate (22050 * 1 * 1)
+    EXPECT_EQ(read_u16(data, 32), 1u);         // block align
+    EXPECT_EQ(read_u16(data, 34), 8u);         // bits per sample
+    EXPECT_EQ(read_u16(data, 22), 1u);         // channels
+}
+
+TEST_F(WavRecorderTest, DoubleStartReturnsError) {
+    std::string path1 = tmp_path("double1.wav");
+    std::string path2 = tmp_path("double2.wav");
+
+    auto err1 = recorder_.start(path1, 44100, 16, 2);
+    ASSERT_TRUE(err1.empty());
+
+    auto err2 = recorder_.start(path2, 44100, 16, 2);
+    EXPECT_FALSE(err2.empty());
+    EXPECT_NE(err2.find("already recording"), std::string::npos);
+
+    recorder_.stop();
+}
+
+TEST_F(WavRecorderTest, StopWhenNotRecordingReturnsZero) {
+    EXPECT_FALSE(recorder_.is_recording());
+    uint32_t bytes = recorder_.stop();
+    EXPECT_EQ(bytes, 0u);
+}
+
+TEST_F(WavRecorderTest, StatusReporting) {
+    EXPECT_FALSE(recorder_.is_recording());
+    EXPECT_TRUE(recorder_.current_path().empty());
+    EXPECT_EQ(recorder_.bytes_written(), 0u);
+
+    std::string path = tmp_path("status.wav");
+    recorder_.start(path, 44100, 16, 2);
+
+    EXPECT_TRUE(recorder_.is_recording());
+    EXPECT_EQ(recorder_.current_path(), path);
+
+    uint8_t data[10] = {};
+    recorder_.write_samples(data, 10);
+    EXPECT_EQ(recorder_.bytes_written(), 10u);
+
+    recorder_.stop();
+
+    EXPECT_FALSE(recorder_.is_recording());
+    EXPECT_TRUE(recorder_.current_path().empty());
+}
+
+TEST_F(WavRecorderTest, StartWithInvalidPathReturnsError) {
+    std::string bad_path = "/nonexistent_dir_xyz/test.wav";
+    auto err = recorder_.start(bad_path, 44100, 16, 2);
+    EXPECT_FALSE(err.empty());
+    EXPECT_FALSE(recorder_.is_recording());
+}
+
+TEST_F(WavRecorderTest, MonoStereoConfigurations) {
+    // Test mono 8-bit
+    {
+        std::string path = tmp_path("mono8.wav");
+        auto err = recorder_.start(path, 11025, 8, 1);
+        ASSERT_TRUE(err.empty());
+        recorder_.stop();
+        auto data = read_file(path);
+        ASSERT_GE(data.size(), 44u);
+        EXPECT_EQ(read_u16(data, 22), 1u);          // channels
+        EXPECT_EQ(read_u16(data, 34), 8u);           // bits
+        EXPECT_EQ(read_u32(data, 24), 11025u);       // sample rate
+        EXPECT_EQ(read_u32(data, 28), 11025u);       // byte rate
+        EXPECT_EQ(read_u16(data, 32), 1u);            // block align
+    }
+
+    // Test stereo 16-bit
+    {
+        std::string path = tmp_path("stereo16.wav");
+        auto err = recorder_.start(path, 96000, 16, 2);
+        ASSERT_TRUE(err.empty());
+        recorder_.stop();
+        auto data = read_file(path);
+        ASSERT_GE(data.size(), 44u);
+        EXPECT_EQ(read_u16(data, 22), 2u);            // channels
+        EXPECT_EQ(read_u16(data, 34), 16u);            // bits
+        EXPECT_EQ(read_u32(data, 24), 96000u);         // sample rate
+        EXPECT_EQ(read_u32(data, 28), 96000u * 2 * 2); // byte rate
+        EXPECT_EQ(read_u16(data, 32), 4u);              // block align
+    }
+}
+
+TEST_F(WavRecorderTest, WriteZeroLengthIsNoop) {
+    std::string path = tmp_path("zero.wav");
+    recorder_.start(path, 44100, 16, 2);
+
+    uint8_t dummy = 0;
+    recorder_.write_samples(&dummy, 0);
+    EXPECT_EQ(recorder_.bytes_written(), 0u);
+
+    recorder_.write_samples(nullptr, 0);
+    EXPECT_EQ(recorder_.bytes_written(), 0u);
+
+    recorder_.stop();
+}
+
+TEST_F(WavRecorderTest, DestructorStopsRecording) {
+    std::string path = tmp_path("destructor.wav");
+    {
+        WavRecorder local_rec;
+        auto err = local_rec.start(path, 44100, 16, 1);
+        ASSERT_TRUE(err.empty());
+        uint8_t data[20] = {};
+        local_rec.write_samples(data, 20);
+        // Destructor should call stop() and finalize the file
+    }
+
+    // Verify file is valid after destructor
+    auto data = read_file(path);
+    ASSERT_GE(data.size(), 44u + 20u);
+    EXPECT_EQ(read_u32(data, 40), 20u);  // data size
+}


### PR DESCRIPTION
## Summary
- New `record wav` IPC commands for recording CPC PSG audio to WAV files
- Hooks into SDL3 audio callback to capture mixed audio output
- Thread-safe recording with mutex-protected write path
- Standard RIFF WAV format with proper header finalization on stop
- New files: `src/wav_recorder.h`, `src/wav_recorder.cpp`

## IPC Commands
- `record wav start <path>` — start recording to WAV file
- `record wav stop` — stop recording, finalize WAV header
- `record wav status` — returns `idle` or `recording <path> <bytes>`

## Test plan
- [x] 11 new unit tests (WAV header, start/stop, thread safety)
- [x] All 251 tests pass (240 existing + 11 new)
- [x] `make clean && make` — clean build