### PR TITLE
Add ASIC debug inspection via IPC (Feature 4a)

### DIFF
--- a/src/asic_debug.cpp
+++ b/src/asic_debug.cpp
@@ -1,0 +1,116 @@
+#include "asic_debug.h"
+#include "asic.h"
+#include "koncepcja.h"
+
+#include <cstdio>
+#include <sstream>
+
+extern t_CRTC CRTC;
+extern byte *pbRegisterPage;
+
+std::string asic_dump_dma() {
+  std::ostringstream out;
+  for (int c = 0; c < NB_DMA_CHANNELS; c++) {
+    const dma_channel &ch = asic.dma.ch[c];
+    char buf[128];
+    snprintf(buf, sizeof(buf),
+             "ch%d: addr=%04X prescaler=%02X enabled=%d pause=%d loop_count=%d",
+             c, ch.source_address, ch.prescaler,
+             ch.enabled ? 1 : 0,
+             (ch.pause_ticks > 0) ? 1 : 0,
+             ch.loops);
+    if (c > 0) out << "\n";
+    out << buf;
+  }
+  return out.str();
+}
+
+std::string asic_dump_sprites() {
+  std::ostringstream out;
+  for (int i = 0; i < 16; i++) {
+    char buf[64];
+    snprintf(buf, sizeof(buf), "spr%d: x=%d y=%d mag_x=%d mag_y=%d",
+             i,
+             static_cast<int>(asic.sprites_x[i]),
+             static_cast<int>(asic.sprites_y[i]),
+             static_cast<int>(asic.sprites_mag_x[i]),
+             static_cast<int>(asic.sprites_mag_y[i]));
+    if (i > 0) out << "\n";
+    out << buf;
+  }
+  return out.str();
+}
+
+std::string asic_dump_interrupts() {
+  std::ostringstream out;
+  char buf[128];
+
+  // Raster interrupt: the PRI scan line is stored in CRTC.interrupt_sl
+  // Line 0 means use normal GA interrupts (not enabled)
+  snprintf(buf, sizeof(buf), "raster_interrupt: line=%d enabled=%d",
+           static_cast<int>(CRTC.interrupt_sl),
+           (CRTC.interrupt_sl != 0) ? 1 : 0);
+  out << buf;
+
+  // DMA interrupts: per-channel interrupt flags
+  snprintf(buf, sizeof(buf), "\ndma_interrupt: ch0=%d ch1=%d ch2=%d",
+           asic.dma.ch[0].interrupt ? 1 : 0,
+           asic.dma.ch[1].interrupt ? 1 : 0,
+           asic.dma.ch[2].interrupt ? 1 : 0);
+  out << buf;
+
+  // Interrupt vector
+  snprintf(buf, sizeof(buf), "\ninterrupt_vector: %02X",
+           asic.interrupt_vector);
+  out << buf;
+
+  // DCSR: reconstruct from channel state (enabled bits 0-2, interrupt bits 6-4)
+  byte dcsr = 0;
+  for (int c = 0; c < NB_DMA_CHANNELS; c++) {
+    if (asic.dma.ch[c].enabled) dcsr |= (0x1 << c);
+    if (asic.dma.ch[c].interrupt) dcsr |= (0x40 >> c);
+  }
+  snprintf(buf, sizeof(buf), "\ndcsr: %02X", dcsr);
+  out << buf;
+
+  return out.str();
+}
+
+std::string asic_dump_palette() {
+  constexpr int kPaletteRegisterOffset = 0x2400;
+  std::ostringstream out;
+  // Palette at register page offset 0x2400 (addr 0x6400 - 0x4000)
+  // 32 entries, 2 bytes each: even byte = RB, odd byte = 0G
+  // Even byte: high nibble = R, low nibble = B
+  // Odd byte: low nibble = G
+  // Output as 0GRB (4 hex digits)
+  for (int i = 0; i < 32; i++) {
+    int offset = kPaletteRegisterOffset + (i * 2);
+    byte rb = pbRegisterPage ? pbRegisterPage[offset] : 0;
+    byte g  = pbRegisterPage ? pbRegisterPage[offset + 1] : 0;
+    int r_val = (rb >> 4) & 0x0F;
+    int g_val = g & 0x0F;
+    int b_val = rb & 0x0F;
+    char buf[16];
+    snprintf(buf, sizeof(buf), "%01X%01X%01X%01X", 0, g_val, r_val, b_val);
+    if (i > 0) out << " ";
+    if (i < 16) {
+      out << "pen" << i << "=" << buf;
+    } else {
+      out << "ink" << (i - 16) << "=" << buf;
+    }
+  }
+  return out.str();
+}
+
+std::string asic_dump_all() {
+  std::ostringstream out;
+  out << "locked=" << (asic.locked ? 1 : 0) << "\n";
+  out << "hscroll=" << asic.hscroll << " vscroll=" << asic.vscroll
+      << " extend_border=" << (asic.extend_border ? 1 : 0) << "\n";
+  out << "[sprites]\n" << asic_dump_sprites() << "\n";
+  out << "[dma]\n" << asic_dump_dma() << "\n";
+  out << "[interrupts]\n" << asic_dump_interrupts() << "\n";
+  out << "[palette]\n" << asic_dump_palette();
+  return out.str();
+}

--- a/src/asic_debug.h
+++ b/src/asic_debug.h
@@ -1,0 +1,12 @@
+#ifndef ASIC_DEBUG_H
+#define ASIC_DEBUG_H
+
+#include <string>
+
+std::string asic_dump_dma();
+std::string asic_dump_sprites();
+std::string asic_dump_interrupts();
+std::string asic_dump_palette();
+std::string asic_dump_all();
+
+#endif

--- a/src/koncepcja_ipc_server.cpp
+++ b/src/koncepcja_ipc_server.cpp
@@ -40,6 +40,7 @@
 #include "symfile.h"
 #include "pokes.h"
 #include "config_profile.h"
+#include "asic_debug.h"
 
 extern t_z80regs z80;
 extern t_CPC CPC;
@@ -180,7 +181,7 @@ std::string handle_command(const std::string& line) {
   const auto& cmd = parts[0];
   if (cmd == "ping") return "OK pong\n";
   if (cmd == "version") return "OK kaprys-0.1\n";
-  if (cmd == "help") return "OK commands: ping version help quit pause run reset load regs reg(set/get) mem(read/write/fill/compare/find) bp(list/add/del/clear) wp(add/del/clear/list) iobp(add/del/clear/list) step(N/over/out/to/frame) wait hash(vram/mem/regs) screenshot snapshot(save/load) disasm(follow/refs) devtools input(keydown/keyup/key/type/joy) trace(on/off/dump/on_crash/status) frames(dump) event(on/once/off/list) timer(list/clear) sym(load/add/del/list/lookup) stack autotype(text/status/clear) disk(formats/format/new/ls/cat/get/put/rm/info) record(wav) poke(load/list/apply/unapply/write) profile(list/current/load/save/delete)\n";
+  if (cmd == "help") return "OK commands: ping version help quit pause run reset load regs reg(set/get) regs(crtc/ga/psg/asic) regs_asic(dma/sprites/interrupts/palette) mem(read/write/fill/compare/find) bp(list/add/del/clear) wp(add/del/clear/list) iobp(add/del/clear/list) step(N/over/out/to/frame) wait hash(vram/mem/regs) screenshot snapshot(save/load) disasm(follow/refs) devtools input(keydown/keyup/key/type/joy) trace(on/off/dump/on_crash/status) frames(dump) event(on/once/off/list) timer(list/clear) sym(load/add/del/list/lookup) stack autotype(text/status/clear) disk(formats/format/new/ls/cat/get/put/rm/info) record(wav) poke(load/list/apply/unapply/write) profile(list/current/load/save/delete)\n";
   if (cmd == "quit") {
     int code = 0;
     if (parts.size() >= 2) code = std::stoi(parts[1]);
@@ -406,6 +407,22 @@ std::string handle_command(const std::string& line) {
     snprintf(buf, sizeof(buf), " SELECT=%02X CONTROL=%02X", PSG.reg_select, PSG.control);
     resp << buf << "\n";
     return resp.str();
+  }
+  if ((cmd == "reg" || cmd == "regs") && parts.size() >= 2 && parts[1] == "asic") {
+    if (parts.size() >= 3 && parts[2] == "dma") {
+      return "OK\n" + asic_dump_dma() + "\n";
+    }
+    if (parts.size() >= 3 && parts[2] == "sprites") {
+      return "OK\n" + asic_dump_sprites() + "\n";
+    }
+    if (parts.size() >= 3 && parts[2] == "interrupts") {
+      return "OK\n" + asic_dump_interrupts() + "\n";
+    }
+    if (parts.size() >= 3 && parts[2] == "palette") {
+      return "OK\n" + asic_dump_palette() + "\n";
+    }
+    // regs asic → full ASIC state dump
+    return "OK\n" + asic_dump_all() + "\n";
   }
   if (cmd == "regs") {
     char out[256];

--- a/test/asic_debug.cpp
+++ b/test/asic_debug.cpp
@@ -1,0 +1,172 @@
+#include <gtest/gtest.h>
+
+#include "asic.h"
+#include "asic_debug.h"
+#include "koncepcja.h"
+
+extern byte *pbRegisterPage;
+extern t_CRTC CRTC;
+
+namespace {
+
+class AsicDebugTest : public testing::Test {
+ protected:
+  void SetUp() override {
+    asic_reset();
+    memset(&CRTC, 0, sizeof(CRTC));
+    // Allocate a register page if needed
+    if (!reg_page_allocated_) {
+      reg_page_ = new byte[16 * 1024]();
+      reg_page_allocated_ = true;
+    }
+    pbRegisterPage = reg_page_;
+  }
+
+  static void TearDownTestSuite() {
+    if (reg_page_allocated_) {
+      delete[] reg_page_;
+      reg_page_ = nullptr;
+      reg_page_allocated_ = false;
+      pbRegisterPage = nullptr;
+    }
+  }
+
+  static byte *reg_page_;
+  static bool reg_page_allocated_;
+};
+
+byte *AsicDebugTest::reg_page_ = nullptr;
+bool AsicDebugTest::reg_page_allocated_ = false;
+
+TEST_F(AsicDebugTest, DmaDumpAfterReset) {
+  std::string result = asic_dump_dma();
+  EXPECT_NE(result.find("ch0: addr=0000 prescaler=00 enabled=0 pause=0 loop_count=0"), std::string::npos);
+  EXPECT_NE(result.find("ch1: addr=0000 prescaler=00 enabled=0 pause=0 loop_count=0"), std::string::npos);
+  EXPECT_NE(result.find("ch2: addr=0000 prescaler=00 enabled=0 pause=0 loop_count=0"), std::string::npos);
+}
+
+TEST_F(AsicDebugTest, DmaDumpWithState) {
+  asic.dma.ch[0].source_address = 0x1234;
+  asic.dma.ch[0].prescaler = 0x0A;
+  asic.dma.ch[0].enabled = true;
+  asic.dma.ch[0].pause_ticks = 5;
+  asic.dma.ch[0].loops = 3;
+
+  asic.dma.ch[2].source_address = 0xABCD;
+  asic.dma.ch[2].enabled = true;
+
+  std::string result = asic_dump_dma();
+  EXPECT_NE(result.find("ch0: addr=1234 prescaler=0A enabled=1 pause=1 loop_count=3"), std::string::npos);
+  EXPECT_NE(result.find("ch1: addr=0000 prescaler=00 enabled=0 pause=0 loop_count=0"), std::string::npos);
+  EXPECT_NE(result.find("ch2: addr=ABCD prescaler=00 enabled=1 pause=0 loop_count=0"), std::string::npos);
+}
+
+TEST_F(AsicDebugTest, SpritesDumpAfterReset) {
+  std::string result = asic_dump_sprites();
+  EXPECT_NE(result.find("spr0: x=0 y=0 mag_x=0 mag_y=0"), std::string::npos);
+  EXPECT_NE(result.find("spr15: x=0 y=0 mag_x=0 mag_y=0"), std::string::npos);
+}
+
+TEST_F(AsicDebugTest, SpritesDumpWithPositions) {
+  asic.sprites_x[0] = 100;
+  asic.sprites_y[0] = 200;
+  asic.sprites_mag_x[0] = 2;
+  asic.sprites_mag_y[0] = 4;
+
+  asic.sprites_x[15] = -32;
+  asic.sprites_y[15] = 512;
+
+  std::string result = asic_dump_sprites();
+  EXPECT_NE(result.find("spr0: x=100 y=200 mag_x=2 mag_y=4"), std::string::npos);
+  EXPECT_NE(result.find("spr15: x=-32 y=512 mag_x=0 mag_y=0"), std::string::npos);
+}
+
+TEST_F(AsicDebugTest, InterruptsDumpAfterReset) {
+  std::string result = asic_dump_interrupts();
+  EXPECT_NE(result.find("raster_interrupt: line=0 enabled=0"), std::string::npos);
+  EXPECT_NE(result.find("dma_interrupt: ch0=0 ch1=0 ch2=0"), std::string::npos);
+  // Interrupt vector after reset has D0=1
+  EXPECT_NE(result.find("interrupt_vector: 01"), std::string::npos);
+  EXPECT_NE(result.find("dcsr: 00"), std::string::npos);
+}
+
+TEST_F(AsicDebugTest, InterruptsDumpWithState) {
+  CRTC.interrupt_sl = 42;
+  asic.dma.ch[0].interrupt = true;
+  asic.dma.ch[1].enabled = true;
+  asic.dma.ch[2].interrupt = true;
+  asic.dma.ch[2].enabled = true;
+  asic.interrupt_vector = 0xF8;
+
+  std::string result = asic_dump_interrupts();
+  EXPECT_NE(result.find("raster_interrupt: line=42 enabled=1"), std::string::npos);
+  EXPECT_NE(result.find("dma_interrupt: ch0=1 ch1=0 ch2=1"), std::string::npos);
+  EXPECT_NE(result.find("interrupt_vector: F8"), std::string::npos);
+  // DCSR: ch1 enabled=bit1, ch2 enabled=bit2, ch0 int=bit6, ch2 int=bit4
+  // = 0x02 | 0x04 | 0x40 | 0x10 = 0x56
+  EXPECT_NE(result.find("dcsr: 56"), std::string::npos);
+}
+
+TEST_F(AsicDebugTest, PaletteDumpAllZeros) {
+  std::string result = asic_dump_palette();
+  EXPECT_NE(result.find("pen0=0000"), std::string::npos);
+  EXPECT_NE(result.find("pen15=0000"), std::string::npos);
+  EXPECT_NE(result.find("ink0=0000"), std::string::npos);
+  EXPECT_NE(result.find("ink15=0000"), std::string::npos);
+}
+
+TEST_F(AsicDebugTest, PaletteDumpWithColors) {
+  // Set pen0 to R=F, G=0, B=0 => even byte = 0xF0, odd byte = 0x00
+  int offset = 0x2400;
+  pbRegisterPage[offset] = 0xF0;     // R=F, B=0
+  pbRegisterPage[offset + 1] = 0x00; // G=0
+
+  // Set pen1 to R=0, G=F, B=0 => even byte = 0x00, odd byte = 0x0F
+  pbRegisterPage[offset + 2] = 0x00; // R=0, B=0
+  pbRegisterPage[offset + 3] = 0x0F; // G=F
+
+  // Set pen2 to R=0, G=0, B=F => even byte = 0x0F, odd byte = 0x00
+  pbRegisterPage[offset + 4] = 0x0F; // R=0, B=F
+  pbRegisterPage[offset + 5] = 0x00; // G=0
+
+  // Set ink0 (entry 16) to white R=F, G=F, B=F => even = 0xFF, odd = 0x0F
+  int ink0_offset = offset + (16 * 2);
+  pbRegisterPage[ink0_offset] = 0xFF;     // R=F, B=F
+  pbRegisterPage[ink0_offset + 1] = 0x0F; // G=F
+
+  std::string result = asic_dump_palette();
+  EXPECT_NE(result.find("pen0=00F0"), std::string::npos);  // 0GRB: 0=0, G=0, R=F, B=0
+  EXPECT_NE(result.find("pen1=0F00"), std::string::npos);  // 0GRB: 0=0, G=F, R=0, B=0
+  EXPECT_NE(result.find("pen2=000F"), std::string::npos);  // 0GRB: 0=0, G=0, R=0, B=F
+  EXPECT_NE(result.find("ink0=0FFF"), std::string::npos);  // 0GRB: 0=0, G=F, R=F, B=F
+}
+
+TEST_F(AsicDebugTest, PaletteDumpNullRegPage) {
+  pbRegisterPage = nullptr;
+  std::string result = asic_dump_palette();
+  EXPECT_NE(result.find("pen0=0000"), std::string::npos);
+  // Restore for other tests
+  pbRegisterPage = reg_page_;
+}
+
+TEST_F(AsicDebugTest, AllDumpContainsSections) {
+  std::string result = asic_dump_all();
+  EXPECT_NE(result.find("locked="), std::string::npos);
+  EXPECT_NE(result.find("hscroll="), std::string::npos);
+  EXPECT_NE(result.find("[sprites]"), std::string::npos);
+  EXPECT_NE(result.find("[dma]"), std::string::npos);
+  EXPECT_NE(result.find("[interrupts]"), std::string::npos);
+  EXPECT_NE(result.find("[palette]"), std::string::npos);
+}
+
+TEST_F(AsicDebugTest, AllDumpReflectsLockState) {
+  asic.locked = false;
+  std::string result = asic_dump_all();
+  EXPECT_NE(result.find("locked=0"), std::string::npos);
+
+  asic.locked = true;
+  result = asic_dump_all();
+  EXPECT_NE(result.find("locked=1"), std::string::npos);
+}
+
+}  // namespace

--- a/test/asic_debug.cpp
+++ b/test/asic_debug.cpp
@@ -19,6 +19,8 @@ class AsicDebugTest : public testing::Test {
       reg_page_ = new byte[16 * 1024]();
       reg_page_allocated_ = true;
     }
+    // Re-zero every test — tests run in shuffle order (--gtest_shuffle)
+    memset(reg_page_, 0, 16 * 1024);
     pbRegisterPage = reg_page_;
   }
 


### PR DESCRIPTION
## Summary
- Expose CPC Plus ASIC state via IPC for debugging
- New commands: `regs asic`, `regs asic dma/sprites/interrupts/palette`
- Read-only inspection of DMA channels, sprite attributes, interrupt state, Plus palette
- DCSR register reconstruction from individual flags
- Null register page safety for palette reads
- 11 new unit tests (338 total pass)

## New files
- `src/asic_debug.h` / `src/asic_debug.cpp` — 5 dump functions for ASIC subsystems
- `test/asic_debug.cpp` — 11 tests covering all dump functions with known state

## Test plan
- [x] Build passes on all platforms
- [x] 11 new unit tests pass
- [x] DMA dump shows per-channel state (addr, prescaler, enabled, pause, loop)
- [x] Sprite dump shows all 16 sprites (including negative coords)
- [x] Interrupt dump shows raster line, DMA flags, vector, DCSR
- [x] Palette dump reads 32 GRB entries from register page
- [x] Graceful handling of null register page