### PR TITLE
Add drive status IPC command (Feature 3d)

### DIFF
--- a/src/drive_status.cpp
+++ b/src/drive_status.cpp
@@ -1,0 +1,73 @@
+#include "drive_status.h"
+#include "koncepcja.h"
+#include "disk.h"
+
+#include <filesystem>
+#include <sstream>
+
+extern t_CPC CPC;
+extern t_FDC FDC;
+extern t_drive driveA;
+extern t_drive driveB;
+
+// Extract just the filename from the slot file path
+static std::string image_basename(const std::string& path) {
+  if (path.empty()) return "";
+  return std::filesystem::path(path).filename().string();
+}
+
+std::string emulator_status_summary() {
+  std::ostringstream oss;
+  oss << "paused=" << (CPC.paused ? 1 : 0)
+      << " model=" << CPC.model
+      << " speed=" << CPC.speed;
+  return oss.str();
+}
+
+std::string drive_status_summary() {
+  std::ostringstream oss;
+  std::string imgA = image_basename(CPC.driveA.file);
+  std::string imgB = image_basename(CPC.driveB.file);
+
+  oss << "driveA:"
+      << " motor=" << FDC.motor
+      << " track=" << driveA.current_track
+      << " side=" << driveA.current_side
+      << " image=" << imgA
+      << " wp=" << driveA.write_protected
+      << "\n";
+  oss << "driveB:"
+      << " motor=" << FDC.motor
+      << " track=" << driveB.current_track
+      << " side=" << driveB.current_side
+      << " image=" << imgB
+      << " wp=" << driveB.write_protected;
+  return oss.str();
+}
+
+std::string drive_status_detailed() {
+  std::ostringstream oss;
+  std::string imgA = image_basename(CPC.driveA.file);
+  std::string imgB = image_basename(CPC.driveB.file);
+
+  oss << "drive=A"
+      << " motor=" << FDC.motor
+      << " track=" << driveA.current_track
+      << " side=" << driveA.current_side
+      << " tracks=" << driveA.tracks
+      << " sides=" << driveA.sides
+      << " image=" << imgA
+      << " write_protected=" << driveA.write_protected
+      << " altered=" << (driveA.altered ? 1 : 0)
+      << "\n";
+  oss << "drive=B"
+      << " motor=" << FDC.motor
+      << " track=" << driveB.current_track
+      << " side=" << driveB.current_side
+      << " tracks=" << driveB.tracks
+      << " sides=" << driveB.sides
+      << " image=" << imgB
+      << " write_protected=" << driveB.write_protected
+      << " altered=" << (driveB.altered ? 1 : 0);
+  return oss.str();
+}

--- a/src/drive_status.h
+++ b/src/drive_status.h
@@ -1,0 +1,15 @@
+#ifndef DRIVE_STATUS_H
+#define DRIVE_STATUS_H
+
+#include <string>
+
+// Brief one-line-per-drive summary (for `status` command)
+std::string drive_status_summary();
+
+// Detailed multi-line per-drive output (for `status drives` command)
+std::string drive_status_detailed();
+
+// Overall emulator state line (paused, model, speed)
+std::string emulator_status_summary();
+
+#endif

--- a/src/koncepcja_ipc_server.cpp
+++ b/src/koncepcja_ipc_server.cpp
@@ -43,6 +43,7 @@
 #include "pokes.h"
 #include "config_profile.h"
 #include "asic_debug.h"
+#include "drive_status.h"
 
 extern t_z80regs z80;
 extern t_CPC CPC;
@@ -55,6 +56,7 @@ extern byte *membank_read[4], *membank_write[4];
 extern byte keyboard_matrix[16];
 extern t_drive driveA;
 extern t_drive driveB;
+extern t_FDC FDC;
 
 // Friendly key names → CPC_KEYS for IPC input commands
 static const std::map<std::string, CPC_KEYS> ipc_key_names = {
@@ -183,7 +185,7 @@ std::string handle_command(const std::string& line) {
   const auto& cmd = parts[0];
   if (cmd == "ping") return "OK pong\n";
   if (cmd == "version") return "OK kaprys-0.1\n";
-  if (cmd == "help") return "OK commands: ping version help quit pause run reset load regs reg(set/get) regs(crtc/ga/psg/asic) regs_asic(dma/sprites/interrupts/palette) mem(read/write/fill/compare/find) bp(list/add/del/clear) wp(add/del/clear/list) iobp(add/del/clear/list) step(N/over/out/to/frame) wait hash(vram/mem/regs) screenshot snapshot(save/load) disasm(follow/refs) devtools input(keydown/keyup/key/type/joy) trace(on/off/dump/on_crash/status) frames(dump) event(on/once/off/list) timer(list/clear) sym(load/add/del/list/lookup) stack autotype(text/status/clear) disk(formats/format/new/ls/cat/get/put/rm/info/sector) record(wav/ym) poke(load/list/apply/unapply/write) profile(list/current/load/save/delete)\n";
+  if (cmd == "help") return "OK commands: ping version help quit pause run reset load regs reg(set/get) regs(crtc/ga/psg/asic) regs_asic(dma/sprites/interrupts/palette) mem(read/write/fill/compare/find) bp(list/add/del/clear) wp(add/del/clear/list) iobp(add/del/clear/list) step(N/over/out/to/frame) wait hash(vram/mem/regs) screenshot snapshot(save/load) disasm(follow/refs) devtools input(keydown/keyup/key/type/joy) trace(on/off/dump/on_crash/status) frames(dump) event(on/once/off/list) timer(list/clear) sym(load/add/del/list/lookup) stack autotype(text/status/clear) disk(formats/format/new/ls/cat/get/put/rm/info/sector) record(wav/ym) poke(load/list/apply/unapply/write) profile(list/current/load/save/delete) status(drives)\n";
   if (cmd == "quit") {
     int code = 0;
     if (parts.size() >= 2) code = std::stoi(parts[1]);
@@ -2113,6 +2115,14 @@ std::string handle_command(const std::string& line) {
       return "OK\n";
     }
     return "ERR 400 unknown profile subcommand (list|current|load|save|delete)\n";
+  }
+
+  // --- Status command ---
+  if (cmd == "status") {
+    if (parts.size() >= 2 && parts[1] == "drives") {
+      return "OK " + drive_status_detailed() + "\n";
+    }
+    return "OK " + emulator_status_summary() + "\n" + drive_status_summary() + "\n";
   }
 
   return "ERR 501 not-implemented\n";

--- a/test/drive_status.cpp
+++ b/test/drive_status.cpp
@@ -1,0 +1,120 @@
+#include <gtest/gtest.h>
+
+#include "koncepcja.h"
+#include "disk.h"
+#include "drive_status.h"
+
+extern t_CPC CPC;
+extern t_FDC FDC;
+extern t_drive driveA;
+extern t_drive driveB;
+
+class DriveStatusTest : public testing::Test {
+ protected:
+  void SetUp() override {
+    // Reset emulator state
+    CPC.paused = false;
+    CPC.model = 2;
+    CPC.speed = 4;
+    CPC.driveA.file = "";
+    CPC.driveB.file = "";
+
+    // Reset FDC
+    memset(&FDC, 0, sizeof(FDC));
+
+    // Reset drives
+    memset(&driveA, 0, sizeof(driveA));
+    memset(&driveB, 0, sizeof(driveB));
+  }
+};
+
+TEST_F(DriveStatusTest, EmulatorStatusFormat) {
+  CPC.paused = false;
+  CPC.model = 2;
+  CPC.speed = 4;
+  auto s = emulator_status_summary();
+  EXPECT_EQ(s, "paused=0 model=2 speed=4");
+}
+
+TEST_F(DriveStatusTest, EmulatorStatusPaused) {
+  CPC.paused = true;
+  CPC.model = 0;
+  CPC.speed = 8;
+  auto s = emulator_status_summary();
+  EXPECT_EQ(s, "paused=1 model=0 speed=8");
+}
+
+TEST_F(DriveStatusTest, DriveStatusNoDisc) {
+  auto s = drive_status_summary();
+  EXPECT_NE(s.find("driveA: motor=0 track=0 side=0 image= wp=0"), std::string::npos);
+  EXPECT_NE(s.find("driveB: motor=0 track=0 side=0 image= wp=0"), std::string::npos);
+}
+
+TEST_F(DriveStatusTest, DriveStatusWithDisc) {
+  CPC.driveA.file = "/path/to/game.dsk";
+  driveA.tracks = 42;
+  driveA.sides = 1;
+  driveA.current_track = 12;
+  driveA.current_side = 0;
+  driveA.write_protected = 0;
+  FDC.motor = 1;
+
+  auto s = drive_status_summary();
+  EXPECT_NE(s.find("driveA: motor=1 track=12 side=0 image=game.dsk wp=0"), std::string::npos);
+}
+
+TEST_F(DriveStatusTest, MotorStateReporting) {
+  FDC.motor = 0;
+  auto s = drive_status_summary();
+  EXPECT_NE(s.find("motor=0"), std::string::npos);
+
+  FDC.motor = 1;
+  s = drive_status_summary();
+  EXPECT_NE(s.find("motor=1"), std::string::npos);
+}
+
+TEST_F(DriveStatusTest, WriteProtectedFlag) {
+  driveA.write_protected = 1;
+  auto s = drive_status_summary();
+  EXPECT_NE(s.find("driveA: motor=0 track=0 side=0 image= wp=1"), std::string::npos);
+}
+
+TEST_F(DriveStatusTest, DetailedDriveStatusNoDisc) {
+  auto s = drive_status_detailed();
+  EXPECT_NE(s.find("drive=A motor=0 track=0 side=0 tracks=0 sides=0 image= write_protected=0 altered=0"), std::string::npos);
+  EXPECT_NE(s.find("drive=B motor=0 track=0 side=0 tracks=0 sides=0 image= write_protected=0 altered=0"), std::string::npos);
+}
+
+TEST_F(DriveStatusTest, DetailedDriveStatusWithDisc) {
+  CPC.driveA.file = "/games/roland.dsk";
+  driveA.tracks = 40;
+  driveA.sides = 2;
+  driveA.current_track = 5;
+  driveA.current_side = 1;
+  driveA.write_protected = 1;
+  driveA.altered = true;
+  FDC.motor = 1;
+
+  auto s = drive_status_detailed();
+  EXPECT_NE(s.find("drive=A motor=1 track=5 side=1 tracks=40 sides=2 image=roland.dsk write_protected=1 altered=1"), std::string::npos);
+}
+
+TEST_F(DriveStatusTest, DetailedBothDrives) {
+  CPC.driveA.file = "/path/disc1.dsk";
+  CPC.driveB.file = "/path/disc2.dsk";
+  driveA.tracks = 42;
+  driveA.sides = 1;
+  driveB.tracks = 80;
+  driveB.sides = 2;
+  driveB.current_track = 7;
+  driveB.write_protected = 1;
+  driveB.altered = false;
+
+  auto s = drive_status_detailed();
+  EXPECT_NE(s.find("drive=A"), std::string::npos);
+  EXPECT_NE(s.find("image=disc1.dsk"), std::string::npos);
+  EXPECT_NE(s.find("drive=B"), std::string::npos);
+  EXPECT_NE(s.find("image=disc2.dsk"), std::string::npos);
+  EXPECT_NE(s.find("tracks=80 sides=2"), std::string::npos);
+  EXPECT_NE(s.find("write_protected=1"), std::string::npos);
+}


### PR DESCRIPTION
## Summary
- Add `status` IPC command returning emulator state (paused/model/speed) and per-drive summary
- Add `status drives` subcommand for detailed per-drive state (motor/track/side/image/altered)
- Drive LED & track display data accessible to automation and UI

## New files
- `src/drive_status.h/cpp` — status formatting from FDC/CPC/drive structs
- `test/drive_status.cpp` — 9 unit tests covering all output formats and edge cases

## IPC Commands
| Command | Description |
|---------|-------------|
| `status` | Emulator state + brief drive summary |
| `status drives` | Detailed per-drive state |

## Test plan
- [x] 9/9 DriveStatus tests pass locally
- [x] 385/385 total tests pass (--gtest_shuffle)
- [ ] CI passes (Coverage + MINGW32)