### PR TITLE
feat(2f): AVI video recording with MJPEG compression

### DIFF
--- a/makefile
+++ b/makefile
@@ -104,6 +104,26 @@ endif
 CXX ?= g++
 COMMON_CFLAGS += -fPIC
 
+# Optional libjpeg support for AVI recording
+# jpeg-turbo on macOS is keg-only, so check both default and homebrew paths
+JPEG_PREFIX := $(shell brew --prefix jpeg-turbo 2>/dev/null)
+ifeq ($(JPEG_PREFIX),)
+JPEG_PREFIX := $(shell brew --prefix libjpeg-turbo 2>/dev/null)
+endif
+ifneq ($(JPEG_PREFIX),)
+HAS_LIBJPEG := $(shell test -f $(JPEG_PREFIX)/include/jpeglib.h && echo 1)
+ifeq ($(HAS_LIBJPEG),1)
+COMMON_CFLAGS += -DHAS_LIBJPEG -I$(JPEG_PREFIX)/include
+LIBS += -L$(JPEG_PREFIX)/lib -ljpeg
+endif
+else
+HAS_LIBJPEG := $(shell echo '\#include <jpeglib.h>' | $(CXX) -x c++ -E - >/dev/null 2>&1 && echo 1)
+ifeq ($(HAS_LIBJPEG),1)
+COMMON_CFLAGS += -DHAS_LIBJPEG
+LIBS += -ljpeg
+endif
+endif
+
 ifneq (,$(findstring g++,$(CXX)))
 LIBS += -lstdc++fs
 endif

--- a/src/avi_recorder.cpp
+++ b/src/avi_recorder.cpp
@@ -1,0 +1,468 @@
+#include "avi_recorder.h"
+#include <cstring>
+#include <algorithm>
+
+#ifdef HAS_LIBJPEG
+extern "C" {
+#include <jpeglib.h>
+}
+#endif
+
+AviRecorder g_avi_recorder;
+
+namespace {
+
+// AVI chunk IDs used for index entries (little-endian)
+constexpr uint32_t FOURCC_01wb = 0x62773130;  // "01wb" - audio data chunk
+
+constexpr uint32_t AVIF_HASINDEX = 0x00000010;
+constexpr uint32_t CPC_FPS = 50;
+
+#ifdef HAS_LIBJPEG
+constexpr uint32_t FOURCC_00dc = 0x63643030;  // "00dc" - video data chunk
+constexpr uint32_t AVIIF_KEYFRAME = 0x00000010;
+#endif
+
+} // namespace
+
+void AviRecorder::write_le_u16(uint16_t val, FILE* f) {
+    fputc(val & 0xff, f);
+    fputc((val >> 8) & 0xff, f);
+}
+
+void AviRecorder::write_le_u32(uint32_t val, FILE* f) {
+    fputc(val & 0xff, f);
+    fputc((val >> 8) & 0xff, f);
+    fputc((val >> 16) & 0xff, f);
+    fputc((val >> 24) & 0xff, f);
+}
+
+void AviRecorder::write_fourcc(const char* cc, FILE* f) {
+    fwrite(cc, 1, 4, f);
+}
+
+AviRecorder::~AviRecorder() {
+    if (file_) {
+        stop();
+    }
+}
+
+std::string AviRecorder::start(const std::string& path, int quality,
+                               uint32_t sample_rate, uint16_t channels,
+                               uint16_t bits_per_sample) {
+#ifndef HAS_LIBJPEG
+    (void)path; (void)quality; (void)sample_rate; (void)channels; (void)bits_per_sample;
+    return "AVI recording requires libjpeg (not found at build time)";
+#else
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (file_) {
+        return "already recording";
+    }
+
+    file_ = fopen(path.c_str(), "wb");
+    if (!file_) {
+        return std::string("cannot open file: ") + strerror(errno);
+    }
+
+    path_ = path;
+    quality_ = std::clamp(quality, 1, 100);
+    sample_rate_ = sample_rate;
+    channels_ = channels;
+    bits_per_sample_ = bits_per_sample;
+    video_frames_ = 0;
+    audio_bytes_ = 0;
+    total_bytes_ = 0;
+    width_ = 0;
+    height_ = 0;
+    index_entries_.clear();
+    movi_start_ = 0;
+
+    // We defer writing the full headers until the first video frame,
+    // because we need to know the frame dimensions. Write a placeholder.
+    // Actually, we write headers with placeholder dimensions now and patch later.
+    // But for simplicity, we write headers assuming 384x270 (CPC default)
+    // and update on first frame if different.
+    width_ = 384;
+    height_ = 270;
+    write_headers();
+
+    return "";
+#endif
+}
+
+uint32_t AviRecorder::stop() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!file_) {
+        return 0;
+    }
+
+    finalize();
+    fclose(file_);
+    file_ = nullptr;
+
+    uint32_t result = video_frames_;
+    video_frames_ = 0;
+    audio_bytes_ = 0;
+    total_bytes_ = 0;
+    path_.clear();
+    index_entries_.clear();
+    return result;
+}
+
+void AviRecorder::capture_video_frame(const uint8_t* pixels, int width, int height, int stride) {
+#ifndef HAS_LIBJPEG
+    (void)pixels; (void)width; (void)height; (void)stride;
+#else
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!file_ || !pixels) return;
+
+    // Update dimensions if this is first frame with actual data
+    if (video_frames_ == 0 && (width != width_ || height != height_)) {
+        width_ = width;
+        height_ = height;
+        // Rewrite headers with correct dimensions
+        fseek(file_, 0, SEEK_SET);
+        movi_start_ = 0;
+        write_headers();
+    }
+
+    auto jpeg_data = compress_jpeg(pixels, width, height, stride);
+    if (jpeg_data.empty()) return;
+
+    uint32_t chunk_offset = static_cast<uint32_t>(ftell(file_) - movi_start_ - 4);
+
+    // Write video chunk: "00dc" + size + data (+ pad byte if odd size)
+    write_le_u32(FOURCC_00dc, file_);
+    uint32_t data_size = static_cast<uint32_t>(jpeg_data.size());
+    write_le_u32(data_size, file_);
+    fwrite(jpeg_data.data(), 1, jpeg_data.size(), file_);
+    // AVI chunks must be word-aligned
+    if (data_size & 1) {
+        fputc(0, file_);
+    }
+
+    index_entries_.push_back({FOURCC_00dc, AVIIF_KEYFRAME, chunk_offset, data_size});
+    video_frames_++;
+    total_bytes_ = static_cast<uint64_t>(ftell(file_));
+#endif
+}
+
+void AviRecorder::capture_audio_samples(const int16_t* samples, size_t count) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!file_ || !samples || count == 0) return;
+
+    uint32_t byte_count = static_cast<uint32_t>(count * sizeof(int16_t));
+    uint32_t chunk_offset = static_cast<uint32_t>(ftell(file_) - movi_start_ - 4);
+
+    // Write audio chunk: "01wb" + size + data (+ pad byte if odd)
+    write_le_u32(FOURCC_01wb, file_);
+    write_le_u32(byte_count, file_);
+    fwrite(samples, 1, byte_count, file_);
+    if (byte_count & 1) {
+        fputc(0, file_);
+    }
+
+    index_entries_.push_back({FOURCC_01wb, 0, chunk_offset, byte_count});
+    audio_bytes_ += byte_count;
+    total_bytes_ = static_cast<uint64_t>(ftell(file_));
+}
+
+bool AviRecorder::is_recording() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return file_ != nullptr;
+}
+
+uint32_t AviRecorder::frame_count() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return video_frames_;
+}
+
+uint64_t AviRecorder::bytes_written() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return total_bytes_;
+}
+
+std::string AviRecorder::current_path() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return path_;
+}
+
+// Write the full AVI header structure.
+// Layout:
+//   RIFF 'AVI '
+//     LIST 'hdrl'
+//       avih (main AVI header)
+//       LIST 'strl' (video stream)
+//         strh (stream header - vids)
+//         strf (stream format - BITMAPINFOHEADER)
+//       LIST 'strl' (audio stream)
+//         strh (stream header - auds)
+//         strf (stream format - WAVEFORMATEX)
+//     LIST 'movi'
+//       ... chunks ...
+//     idx1
+//       ... index ...
+void AviRecorder::write_headers() {
+    // RIFF header
+    write_fourcc("RIFF", file_);
+    write_le_u32(0, file_);  // placeholder for file size
+    write_fourcc("AVI ", file_);
+
+    // LIST 'hdrl'
+    write_fourcc("LIST", file_);
+    write_le_u32(0, file_);  // placeholder for hdrl size
+    uint32_t hdrl_start = static_cast<uint32_t>(ftell(file_));
+    write_fourcc("hdrl", file_);
+
+    // Main AVI header (avih) - 56 bytes
+    write_fourcc("avih", file_);
+    write_le_u32(56, file_);  // avih chunk size
+    write_le_u32(1000000 / CPC_FPS, file_);  // dwMicroSecPerFrame (20000 for 50fps)
+    write_le_u32(0, file_);   // dwMaxBytesPerSec (placeholder)
+    write_le_u32(0, file_);   // dwPaddingGranularity
+    write_le_u32(AVIF_HASINDEX, file_);  // dwFlags
+    write_le_u32(0, file_);   // dwTotalFrames (placeholder)
+    write_le_u32(0, file_);   // dwInitialFrames
+    write_le_u32(2, file_);   // dwStreams (video + audio)
+    write_le_u32(0, file_);   // dwSuggestedBufferSize
+    write_le_u32(static_cast<uint32_t>(width_), file_);   // dwWidth
+    write_le_u32(static_cast<uint32_t>(height_), file_);  // dwHeight
+    write_le_u32(0, file_);   // dwReserved[0]
+    write_le_u32(0, file_);   // dwReserved[1]
+    write_le_u32(0, file_);   // dwReserved[2]
+    write_le_u32(0, file_);   // dwReserved[3]
+
+    // --- Video stream ---
+    // LIST 'strl'
+    write_fourcc("LIST", file_);
+    write_le_u32(0, file_);  // placeholder for strl size
+    uint32_t vstrl_start = static_cast<uint32_t>(ftell(file_));
+    write_fourcc("strl", file_);
+
+    // strh (stream header) - 56 bytes
+    write_fourcc("strh", file_);
+    write_le_u32(56, file_);  // strh chunk size
+    write_fourcc("vids", file_);  // fccType
+    write_fourcc("MJPG", file_);  // fccHandler
+    write_le_u32(0, file_);   // dwFlags
+    write_le_u16(0, file_);   // wPriority
+    write_le_u16(0, file_);   // wLanguage
+    write_le_u32(0, file_);   // dwInitialFrames
+    write_le_u32(1, file_);   // dwScale
+    write_le_u32(CPC_FPS, file_);  // dwRate (fps)
+    write_le_u32(0, file_);   // dwStart
+    write_le_u32(0, file_);   // dwLength (placeholder - total frames)
+    write_le_u32(0, file_);   // dwSuggestedBufferSize
+    write_le_u32(0xFFFFFFFF, file_);  // dwQuality (-1 = default)
+    write_le_u32(0, file_);   // dwSampleSize
+    write_le_u16(0, file_);   // rcFrame.left
+    write_le_u16(0, file_);   // rcFrame.top
+    write_le_u16(static_cast<uint16_t>(width_), file_);   // rcFrame.right
+    write_le_u16(static_cast<uint16_t>(height_), file_);  // rcFrame.bottom
+
+    // strf (stream format) - BITMAPINFOHEADER - 40 bytes
+    write_fourcc("strf", file_);
+    write_le_u32(40, file_);  // strf chunk size
+    write_le_u32(40, file_);  // biSize
+    write_le_u32(static_cast<uint32_t>(width_), file_);   // biWidth
+    write_le_u32(static_cast<uint32_t>(height_), file_);  // biHeight
+    write_le_u16(1, file_);   // biPlanes
+    write_le_u16(24, file_);  // biBitCount (MJPEG outputs 24bpp)
+    write_fourcc("MJPG", file_);  // biCompression
+    write_le_u32(static_cast<uint32_t>(width_ * height_ * 3), file_);  // biSizeImage
+    write_le_u32(0, file_);   // biXPelsPerMeter
+    write_le_u32(0, file_);   // biYPelsPerMeter
+    write_le_u32(0, file_);   // biClrUsed
+    write_le_u32(0, file_);   // biClrImportant
+
+    // Patch video strl LIST size
+    uint32_t vstrl_end = static_cast<uint32_t>(ftell(file_));
+    fseek(file_, static_cast<long>(vstrl_start - 4), SEEK_SET);
+    write_le_u32(vstrl_end - vstrl_start, file_);
+    fseek(file_, 0, SEEK_END);
+
+    // --- Audio stream ---
+    // LIST 'strl'
+    write_fourcc("LIST", file_);
+    write_le_u32(0, file_);  // placeholder for strl size
+    uint32_t astrl_start = static_cast<uint32_t>(ftell(file_));
+    write_fourcc("strl", file_);
+
+    // strh (stream header) - 56 bytes
+    uint16_t block_align = static_cast<uint16_t>(channels_ * (bits_per_sample_ / 8));
+    uint32_t byte_rate = sample_rate_ * block_align;
+
+    write_fourcc("strh", file_);
+    write_le_u32(56, file_);  // strh chunk size
+    write_fourcc("auds", file_);  // fccType
+    write_le_u32(0, file_);   // fccHandler (not used for PCM)
+    write_le_u32(0, file_);   // dwFlags
+    write_le_u16(0, file_);   // wPriority
+    write_le_u16(0, file_);   // wLanguage
+    write_le_u32(0, file_);   // dwInitialFrames
+    write_le_u32(block_align, file_);  // dwScale
+    write_le_u32(byte_rate, file_);    // dwRate
+    write_le_u32(0, file_);   // dwStart
+    write_le_u32(0, file_);   // dwLength (placeholder - total audio samples)
+    write_le_u32(0, file_);   // dwSuggestedBufferSize
+    write_le_u32(0xFFFFFFFF, file_);  // dwQuality
+    write_le_u32(block_align, file_);  // dwSampleSize
+    write_le_u16(0, file_);   // rcFrame.left
+    write_le_u16(0, file_);   // rcFrame.top
+    write_le_u16(0, file_);   // rcFrame.right
+    write_le_u16(0, file_);   // rcFrame.bottom
+
+    // strf (stream format) - WAVEFORMATEX - 18 bytes
+    write_fourcc("strf", file_);
+    write_le_u32(18, file_);   // strf chunk size
+    write_le_u16(1, file_);    // wFormatTag = PCM
+    write_le_u16(channels_, file_);
+    write_le_u32(sample_rate_, file_);
+    write_le_u32(byte_rate, file_);
+    write_le_u16(block_align, file_);
+    write_le_u16(bits_per_sample_, file_);
+    write_le_u16(0, file_);    // cbSize (extra format bytes)
+
+    // Patch audio strl LIST size
+    uint32_t astrl_end = static_cast<uint32_t>(ftell(file_));
+    fseek(file_, static_cast<long>(astrl_start - 4), SEEK_SET);
+    write_le_u32(astrl_end - astrl_start, file_);
+    fseek(file_, 0, SEEK_END);
+
+    // Patch hdrl LIST size
+    uint32_t hdrl_end = static_cast<uint32_t>(ftell(file_));
+    fseek(file_, static_cast<long>(hdrl_start - 4), SEEK_SET);
+    write_le_u32(hdrl_end - hdrl_start, file_);
+    fseek(file_, 0, SEEK_END);
+
+    // LIST 'movi'
+    write_fourcc("LIST", file_);
+    write_le_u32(0, file_);  // placeholder for movi size
+    movi_start_ = static_cast<uint32_t>(ftell(file_));
+    write_fourcc("movi", file_);
+
+    total_bytes_ = static_cast<uint64_t>(ftell(file_));
+}
+
+void AviRecorder::finalize() {
+    // Pad movi list to word boundary
+    long movi_end = ftell(file_);
+
+    // Patch movi LIST size
+    uint32_t movi_size = static_cast<uint32_t>(movi_end) - movi_start_;
+    fseek(file_, static_cast<long>(movi_start_ - 4), SEEK_SET);
+    write_le_u32(movi_size, file_);
+    fseek(file_, movi_end, SEEK_SET);
+
+    // Write idx1 index
+    write_idx1();
+
+    // Patch sizes in headers
+    patch_sizes();
+
+    fflush(file_);
+}
+
+void AviRecorder::write_idx1() {
+    write_fourcc("idx1", file_);
+    uint32_t idx_size = static_cast<uint32_t>(index_entries_.size() * 16);
+    write_le_u32(idx_size, file_);
+
+    for (const auto& entry : index_entries_) {
+        write_le_u32(entry.chunk_id, file_);
+        write_le_u32(entry.flags, file_);
+        write_le_u32(entry.offset, file_);
+        write_le_u32(entry.size, file_);
+    }
+}
+
+void AviRecorder::patch_sizes() {
+    long file_end = ftell(file_);
+
+    // Patch RIFF size at offset 4
+    uint32_t riff_size = static_cast<uint32_t>(file_end - 8);
+    fseek(file_, 4, SEEK_SET);
+    write_le_u32(riff_size, file_);
+
+    // Patch avih dwTotalFrames at offset 48
+    // avih starts at: RIFF(12) + LIST(8) + "hdrl"(4) + "avih"(4) + size(4) = 32
+    // dwTotalFrames is at offset 16 within avih data => file offset 48
+    fseek(file_, 48, SEEK_SET);
+    write_le_u32(video_frames_, file_);
+
+    // Patch video strh dwLength
+    // video strh starts at: 32(avih header offset) + 56(avih data) + 8(avih chunk overhead)
+    //   = actually let me compute it properly.
+    // RIFF header: 12 bytes (RIFF + size + AVI)
+    // LIST hdrl: 8 bytes (LIST + size) + 4 bytes (hdrl) = 12
+    // avih chunk: 8 bytes (avih + size) + 56 bytes data = 64
+    // LIST strl(video): 8 bytes (LIST + size) + 4 bytes (strl) = 12
+    // strh chunk: 8 bytes (strh + size) + data...
+    // strh.dwLength is at offset 20 within strh data
+    // So file offset = 12 + 12 + 64 + 12 + 8 + 20 = 128
+    fseek(file_, 128, SEEK_SET);
+    write_le_u32(video_frames_, file_);
+
+    // Patch audio strh dwLength
+    // After video strl: 12 + 12 + 64 + 12 + 64(strh) + 48(strf) = 212
+    // LIST strl(audio): 12
+    // strh chunk: 8 + data...
+    // strh.dwLength at offset 20 in strh data
+    // file offset = 212 + 12 + 8 + 20 = 252
+    uint16_t block_align = static_cast<uint16_t>(channels_ * (bits_per_sample_ / 8));
+    uint32_t audio_samples = (block_align > 0) ? (audio_bytes_ / block_align) : 0;
+    fseek(file_, 252, SEEK_SET);
+    write_le_u32(audio_samples, file_);
+
+    fseek(file_, file_end, SEEK_SET);
+}
+
+#ifdef HAS_LIBJPEG
+// Suppress old-style-cast warnings from libjpeg macros (jpeg_create_compress, etc.)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+
+std::vector<uint8_t> AviRecorder::compress_jpeg(const uint8_t* rgba, int w, int h, int stride) {
+    struct jpeg_compress_struct cinfo;
+    struct jpeg_error_mgr jerr;
+
+    cinfo.err = jpeg_std_error(&jerr);
+    jpeg_create_compress(&cinfo);
+
+    unsigned char* out_buf = nullptr;
+    unsigned long out_size = 0;
+    jpeg_mem_dest(&cinfo, &out_buf, &out_size);
+
+    cinfo.image_width = static_cast<JDIMENSION>(w);
+    cinfo.image_height = static_cast<JDIMENSION>(h);
+    cinfo.input_components = 3;
+    cinfo.in_color_space = JCS_RGB;
+
+    jpeg_set_defaults(&cinfo);
+    jpeg_set_quality(&cinfo, quality_, TRUE);
+    jpeg_start_compress(&cinfo, TRUE);
+
+    // Convert RGBA rows to RGB for JPEG compression
+    std::vector<uint8_t> rgb_row(static_cast<size_t>(w * 3));
+
+    while (cinfo.next_scanline < cinfo.image_height) {
+        const uint8_t* src = rgba + cinfo.next_scanline * stride;
+        for (int x = 0; x < w; x++) {
+            rgb_row[static_cast<size_t>(x * 3 + 0)] = src[x * 4 + 0];  // R
+            rgb_row[static_cast<size_t>(x * 3 + 1)] = src[x * 4 + 1];  // G
+            rgb_row[static_cast<size_t>(x * 3 + 2)] = src[x * 4 + 2];  // B
+        }
+        JSAMPROW row_ptr = rgb_row.data();
+        jpeg_write_scanlines(&cinfo, &row_ptr, 1);
+    }
+
+    jpeg_finish_compress(&cinfo);
+    jpeg_destroy_compress(&cinfo);
+
+    std::vector<uint8_t> result(out_buf, out_buf + out_size);
+    free(out_buf);  // NOLINT - libjpeg allocates with malloc
+    return result;
+}
+
+#pragma GCC diagnostic pop
+#endif

--- a/src/avi_recorder.h
+++ b/src/avi_recorder.h
@@ -1,0 +1,74 @@
+#pragma once
+
+#include <string>
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+#include <mutex>
+
+class AviRecorder {
+public:
+    ~AviRecorder();
+
+    // Start recording. Returns empty string on success, error message on failure.
+    std::string start(const std::string& path, int quality = 85,
+                      uint32_t sample_rate = 44100,
+                      uint16_t channels = 2,
+                      uint16_t bits_per_sample = 16);
+
+    // Stop recording and finalize AVI file. Returns frame count.
+    uint32_t stop();
+
+    // Capture a video frame (RGBA pixel data).
+    void capture_video_frame(const uint8_t* pixels, int width, int height, int stride);
+
+    // Capture audio samples (interleaved PCM). Thread-safe.
+    void capture_audio_samples(const int16_t* samples, size_t count);
+
+    bool is_recording() const;
+    uint32_t frame_count() const;
+    uint64_t bytes_written() const;
+    std::string current_path() const;
+
+private:
+    FILE* file_ = nullptr;
+    std::string path_;
+    int quality_ = 85;
+
+    int width_ = 0;
+    int height_ = 0;
+    uint32_t video_frames_ = 0;
+
+    uint32_t sample_rate_ = 44100;
+    uint16_t channels_ = 2;
+    uint16_t bits_per_sample_ = 16;
+    uint32_t audio_bytes_ = 0;
+
+    uint32_t movi_start_ = 0;
+    uint64_t total_bytes_ = 0;
+
+    struct IndexEntry {
+        uint32_t chunk_id;
+        uint32_t flags;
+        uint32_t offset;
+        uint32_t size;
+    };
+    std::vector<IndexEntry> index_entries_;
+
+    mutable std::mutex mutex_;
+
+    void write_headers();
+    void finalize();
+    void write_idx1();
+    void patch_sizes();
+
+#ifdef HAS_LIBJPEG
+    std::vector<uint8_t> compress_jpeg(const uint8_t* rgba, int w, int h, int stride);
+#endif
+
+    static void write_le_u16(uint16_t val, FILE* f);
+    static void write_le_u32(uint32_t val, FILE* f);
+    static void write_fourcc(const char* cc, FILE* f);
+};
+
+extern AviRecorder g_avi_recorder;

--- a/test/avi_recorder.cpp
+++ b/test/avi_recorder.cpp
@@ -1,0 +1,334 @@
+#include <gtest/gtest.h>
+#include <filesystem>
+#include <fstream>
+#include <cstring>
+
+#include "avi_recorder.h"
+
+namespace fs = std::filesystem;
+
+class AviRecorderTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        tmp_dir_ = fs::temp_directory_path() / "avi_recorder_test";
+        fs::create_directories(tmp_dir_);
+    }
+
+    void TearDown() override {
+        recorder_.stop();
+        fs::remove_all(tmp_dir_);
+    }
+
+    std::string tmp_path(const std::string& name) {
+        return (tmp_dir_ / name).string();
+    }
+
+    std::vector<uint8_t> read_file(const std::string& path) {
+        std::ifstream f(path, std::ios::binary);
+        return std::vector<uint8_t>(std::istreambuf_iterator<char>(f),
+                                    std::istreambuf_iterator<char>());
+    }
+
+    uint16_t read_u16(const std::vector<uint8_t>& buf, size_t offset) {
+        return static_cast<uint16_t>(buf[offset]) |
+               (static_cast<uint16_t>(buf[offset + 1]) << 8);
+    }
+
+    uint32_t read_u32(const std::vector<uint8_t>& buf, size_t offset) {
+        return static_cast<uint32_t>(buf[offset]) |
+               (static_cast<uint32_t>(buf[offset + 1]) << 8) |
+               (static_cast<uint32_t>(buf[offset + 2]) << 16) |
+               (static_cast<uint32_t>(buf[offset + 3]) << 24);
+    }
+
+    bool bytes_match(const std::vector<uint8_t>& buf, size_t offset,
+                     const char* str, size_t len) {
+        if (offset + len > buf.size()) return false;
+        return memcmp(buf.data() + offset, str, len) == 0;
+    }
+
+    // Create a simple RGBA test frame (solid color)
+    std::vector<uint8_t> make_test_frame(int width, int height,
+                                          uint8_t r, uint8_t g, uint8_t b) {
+        std::vector<uint8_t> frame(static_cast<size_t>(width * height * 4));
+        for (int i = 0; i < width * height; i++) {
+            frame[static_cast<size_t>(i * 4 + 0)] = r;
+            frame[static_cast<size_t>(i * 4 + 1)] = g;
+            frame[static_cast<size_t>(i * 4 + 2)] = b;
+            frame[static_cast<size_t>(i * 4 + 3)] = 255;
+        }
+        return frame;
+    }
+
+    AviRecorder recorder_;
+    fs::path tmp_dir_;
+};
+
+// === Tests that work regardless of HAS_LIBJPEG ===
+
+#ifndef HAS_LIBJPEG
+
+TEST_F(AviRecorderTest, StartReturnsErrorWithoutLibjpeg) {
+    std::string path = tmp_path("test.avi");
+    auto err = recorder_.start(path);
+    EXPECT_FALSE(err.empty());
+    EXPECT_NE(err.find("libjpeg"), std::string::npos);
+    EXPECT_FALSE(recorder_.is_recording());
+}
+
+#else  // HAS_LIBJPEG
+
+TEST_F(AviRecorderTest, StartAndStopLifecycle) {
+    EXPECT_FALSE(recorder_.is_recording());
+    EXPECT_EQ(recorder_.frame_count(), 0u);
+    EXPECT_TRUE(recorder_.current_path().empty());
+
+    std::string path = tmp_path("lifecycle.avi");
+    auto err = recorder_.start(path);
+    ASSERT_TRUE(err.empty()) << "start failed: " << err;
+    EXPECT_TRUE(recorder_.is_recording());
+    EXPECT_EQ(recorder_.current_path(), path);
+    EXPECT_EQ(recorder_.frame_count(), 0u);
+
+    uint32_t frames = recorder_.stop();
+    EXPECT_EQ(frames, 0u);
+    EXPECT_FALSE(recorder_.is_recording());
+    EXPECT_TRUE(recorder_.current_path().empty());
+}
+
+TEST_F(AviRecorderTest, DoubleStartReturnsError) {
+    std::string path1 = tmp_path("double1.avi");
+    std::string path2 = tmp_path("double2.avi");
+
+    auto err1 = recorder_.start(path1);
+    ASSERT_TRUE(err1.empty());
+
+    auto err2 = recorder_.start(path2);
+    EXPECT_FALSE(err2.empty());
+    EXPECT_NE(err2.find("already recording"), std::string::npos);
+
+    recorder_.stop();
+}
+
+TEST_F(AviRecorderTest, StopWithoutStartReturnsZero) {
+    EXPECT_FALSE(recorder_.is_recording());
+    uint32_t frames = recorder_.stop();
+    EXPECT_EQ(frames, 0u);
+}
+
+TEST_F(AviRecorderTest, StartWithInvalidPathReturnsError) {
+    std::string bad_path = "/nonexistent_dir_xyz/test.avi";
+    auto err = recorder_.start(bad_path);
+    EXPECT_FALSE(err.empty());
+    EXPECT_FALSE(recorder_.is_recording());
+}
+
+TEST_F(AviRecorderTest, RiffHeaderMagic) {
+    std::string path = tmp_path("magic.avi");
+    auto err = recorder_.start(path);
+    ASSERT_TRUE(err.empty());
+    recorder_.stop();
+
+    auto data = read_file(path);
+    ASSERT_GE(data.size(), 12u);
+
+    // "RIFF" at offset 0
+    EXPECT_TRUE(bytes_match(data, 0, "RIFF", 4));
+    // "AVI " at offset 8
+    EXPECT_TRUE(bytes_match(data, 8, "AVI ", 4));
+}
+
+TEST_F(AviRecorderTest, HasValidStreamHeaders) {
+    std::string path = tmp_path("streams.avi");
+    auto err = recorder_.start(path);
+    ASSERT_TRUE(err.empty());
+    recorder_.stop();
+
+    auto data = read_file(path);
+
+    // Search for "vids" and "MJPG" in the file
+    bool found_vids = false;
+    bool found_mjpg = false;
+    bool found_auds = false;
+    for (size_t i = 0; i + 4 <= data.size(); i++) {
+        if (memcmp(data.data() + i, "vids", 4) == 0) found_vids = true;
+        if (memcmp(data.data() + i, "MJPG", 4) == 0) found_mjpg = true;
+        if (memcmp(data.data() + i, "auds", 4) == 0) found_auds = true;
+    }
+    EXPECT_TRUE(found_vids) << "Video stream header 'vids' not found";
+    EXPECT_TRUE(found_mjpg) << "MJPG codec identifier not found";
+    EXPECT_TRUE(found_auds) << "Audio stream header 'auds' not found";
+}
+
+TEST_F(AviRecorderTest, AudioStreamFormatIsPCM) {
+    std::string path = tmp_path("pcm.avi");
+    auto err = recorder_.start(path, 85, 44100, 2, 16);
+    ASSERT_TRUE(err.empty());
+    recorder_.stop();
+
+    auto data = read_file(path);
+
+    // Find the audio strf chunk - look for the second "strf" occurrence
+    int strf_count = 0;
+    size_t audio_strf_offset = 0;
+    for (size_t i = 0; i + 4 <= data.size(); i++) {
+        if (memcmp(data.data() + i, "strf", 4) == 0) {
+            strf_count++;
+            if (strf_count == 2) {
+                audio_strf_offset = i + 8;  // skip "strf" + size field
+                break;
+            }
+        }
+    }
+    ASSERT_GT(strf_count, 1) << "Could not find audio strf chunk";
+    ASSERT_LT(audio_strf_offset + 18, data.size());
+
+    // wFormatTag = 1 (PCM)
+    EXPECT_EQ(read_u16(data, audio_strf_offset), 1u);
+    // nChannels = 2
+    EXPECT_EQ(read_u16(data, audio_strf_offset + 2), 2u);
+    // nSamplesPerSec = 44100
+    EXPECT_EQ(read_u32(data, audio_strf_offset + 4), 44100u);
+    // nAvgBytesPerSec = 44100 * 2 * 2 = 176400
+    EXPECT_EQ(read_u32(data, audio_strf_offset + 8), 176400u);
+    // nBlockAlign = 4
+    EXPECT_EQ(read_u16(data, audio_strf_offset + 12), 4u);
+    // wBitsPerSample = 16
+    EXPECT_EQ(read_u16(data, audio_strf_offset + 14), 16u);
+}
+
+TEST_F(AviRecorderTest, VideoFrameCaptureIncrementsCount) {
+    std::string path = tmp_path("frames.avi");
+    auto err = recorder_.start(path);
+    ASSERT_TRUE(err.empty());
+
+    auto frame = make_test_frame(64, 48, 255, 0, 0);
+    recorder_.capture_video_frame(frame.data(), 64, 48, 64 * 4);
+    EXPECT_EQ(recorder_.frame_count(), 1u);
+
+    recorder_.capture_video_frame(frame.data(), 64, 48, 64 * 4);
+    EXPECT_EQ(recorder_.frame_count(), 2u);
+
+    recorder_.capture_video_frame(frame.data(), 64, 48, 64 * 4);
+    EXPECT_EQ(recorder_.frame_count(), 3u);
+
+    uint32_t total = recorder_.stop();
+    EXPECT_EQ(total, 3u);
+}
+
+TEST_F(AviRecorderTest, BytesWrittenIncreases) {
+    std::string path = tmp_path("bytes.avi");
+    auto err = recorder_.start(path);
+    ASSERT_TRUE(err.empty());
+
+    uint64_t initial = recorder_.bytes_written();
+    EXPECT_GT(initial, 0u);  // headers written
+
+    auto frame = make_test_frame(64, 48, 0, 255, 0);
+    recorder_.capture_video_frame(frame.data(), 64, 48, 64 * 4);
+
+    EXPECT_GT(recorder_.bytes_written(), initial);
+
+    recorder_.stop();
+}
+
+TEST_F(AviRecorderTest, DestructorFinalizesFile) {
+    std::string path = tmp_path("destructor.avi");
+    {
+        AviRecorder local_rec;
+        auto err = local_rec.start(path);
+        ASSERT_TRUE(err.empty());
+        auto frame = make_test_frame(64, 48, 0, 0, 255);
+        local_rec.capture_video_frame(frame.data(), 64, 48, 64 * 4);
+        // Destructor should call stop() and finalize the file
+    }
+
+    auto data = read_file(path);
+    ASSERT_GE(data.size(), 12u);
+    EXPECT_TRUE(bytes_match(data, 0, "RIFF", 4));
+    EXPECT_TRUE(bytes_match(data, 8, "AVI ", 4));
+
+    // Verify RIFF size is patched (non-zero)
+    uint32_t riff_size = read_u32(data, 4);
+    EXPECT_GT(riff_size, 0u);
+    EXPECT_EQ(riff_size, static_cast<uint32_t>(data.size() - 8));
+}
+
+TEST_F(AviRecorderTest, HasIdx1Index) {
+    std::string path = tmp_path("index.avi");
+    auto err = recorder_.start(path);
+    ASSERT_TRUE(err.empty());
+
+    auto frame = make_test_frame(64, 48, 128, 128, 128);
+    recorder_.capture_video_frame(frame.data(), 64, 48, 64 * 4);
+    recorder_.stop();
+
+    auto data = read_file(path);
+
+    // Search for "idx1" chunk
+    bool found_idx1 = false;
+    for (size_t i = 0; i + 4 <= data.size(); i++) {
+        if (memcmp(data.data() + i, "idx1", 4) == 0) {
+            found_idx1 = true;
+            // Verify it has at least one 16-byte index entry
+            uint32_t idx_size = read_u32(data, i + 4);
+            EXPECT_GE(idx_size, 16u);
+            break;
+        }
+    }
+    EXPECT_TRUE(found_idx1) << "idx1 index chunk not found";
+}
+
+TEST_F(AviRecorderTest, AudioCaptureWritesData) {
+    std::string path = tmp_path("audio.avi");
+    auto err = recorder_.start(path, 85, 44100, 2, 16);
+    ASSERT_TRUE(err.empty());
+
+    // Write some audio samples
+    std::vector<int16_t> samples(1024, 0x1234);
+    recorder_.capture_audio_samples(samples.data(), samples.size());
+
+    uint64_t bytes_after_audio = recorder_.bytes_written();
+
+    auto frame = make_test_frame(64, 48, 255, 255, 0);
+    recorder_.capture_video_frame(frame.data(), 64, 48, 64 * 4);
+
+    uint64_t bytes_after_video = recorder_.bytes_written();
+    EXPECT_GT(bytes_after_video, bytes_after_audio);
+
+    recorder_.stop();
+
+    // Verify file has both "00dc" and "01wb" chunks
+    auto data = read_file(path);
+    bool found_00dc = false;
+    bool found_01wb = false;
+    for (size_t i = 0; i + 4 <= data.size(); i++) {
+        if (memcmp(data.data() + i, "00dc", 4) == 0) found_00dc = true;
+        if (memcmp(data.data() + i, "01wb", 4) == 0) found_01wb = true;
+    }
+    EXPECT_TRUE(found_00dc) << "Video data chunk '00dc' not found";
+    EXPECT_TRUE(found_01wb) << "Audio data chunk '01wb' not found";
+}
+
+TEST_F(AviRecorderTest, StatusReportsCorrectValues) {
+    EXPECT_FALSE(recorder_.is_recording());
+    EXPECT_TRUE(recorder_.current_path().empty());
+    EXPECT_EQ(recorder_.frame_count(), 0u);
+    EXPECT_EQ(recorder_.bytes_written(), 0u);
+
+    std::string path = tmp_path("status.avi");
+    recorder_.start(path);
+    EXPECT_TRUE(recorder_.is_recording());
+    EXPECT_EQ(recorder_.current_path(), path);
+
+    auto frame = make_test_frame(64, 48, 100, 100, 100);
+    recorder_.capture_video_frame(frame.data(), 64, 48, 64 * 4);
+    EXPECT_EQ(recorder_.frame_count(), 1u);
+    EXPECT_GT(recorder_.bytes_written(), 0u);
+
+    recorder_.stop();
+    EXPECT_FALSE(recorder_.is_recording());
+    EXPECT_TRUE(recorder_.current_path().empty());
+}
+
+#endif  // HAS_LIBJPEG


### PR DESCRIPTION
## Summary
- Add AVI recorder with MJPEG-compressed video + PCM audio in RIFF AVI container
- Optional libjpeg dependency with compile-time guard (`#ifdef HAS_LIBJPEG`)
- Makefile auto-detects Homebrew jpeg-turbo; graceful stub when unavailable
- `record avi start/stop/status` IPC commands (quality 1-100, default 85)
- Video capture hooked into VBL loop, audio capture in audio callback
- Proper AVI finalization: idx1 index, size patching, stream headers
- 13 new unit tests (conditional on HAS_LIBJPEG)

## Test plan
- [x] 434/434 tests pass with --gtest_shuffle
- [ ] Record short AVI and verify playback in VLC/ffplay
- [ ] Verify AVI file has correct RIFF/AVI headers
- [ ] Test without libjpeg: start returns graceful error
- [ ] Verify audio/video sync in recorded output