### PR TITLE
feat(5a): add data areas for marking bytes/words/text in disassembly

### DIFF
--- a/src/data_areas.cpp
+++ b/src/data_areas.cpp
@@ -1,0 +1,121 @@
+#include "data_areas.h"
+#include <algorithm>
+#include <cstdio>
+#include <sstream>
+
+DataAreaManager g_data_areas;
+
+void DataAreaManager::mark(uint16_t start, uint16_t end, DataType type, const std::string& label) {
+    // Remove any existing areas that overlap with the new one
+    auto it = areas_.begin();
+    while (it != areas_.end()) {
+        if (it->second.start <= end && it->second.end >= start) {
+            it = areas_.erase(it);
+        } else {
+            ++it;
+        }
+    }
+    areas_[start] = DataArea{start, end, type, label};
+}
+
+void DataAreaManager::clear(uint16_t start) {
+    areas_.erase(start);
+}
+
+void DataAreaManager::clear_all() {
+    areas_.clear();
+}
+
+std::vector<DataArea> DataAreaManager::list() const {
+    std::vector<DataArea> result;
+    result.reserve(areas_.size());
+    for (const auto& kv : areas_) {
+        result.push_back(kv.second);
+    }
+    return result;
+}
+
+const DataArea* DataAreaManager::find(uint16_t addr) const {
+    // Check all areas to see if addr falls within any of them
+    for (const auto& kv : areas_) {
+        if (addr >= kv.second.start && addr <= kv.second.end) {
+            return &kv.second;
+        }
+    }
+    return nullptr;
+}
+
+std::string DataAreaManager::format_at(uint16_t addr, const uint8_t* mem, size_t mem_size) const {
+    const DataArea* area = find(addr);
+    if (!area) return {};
+
+    std::ostringstream oss;
+    char buf[8];
+
+    switch (area->type) {
+        case DataType::BYTES: {
+            // Up to 8 bytes per line
+            oss << "db ";
+            int remaining = static_cast<int>(area->end) - static_cast<int>(addr) + 1;
+            int count = std::min(remaining, 8);
+            for (int i = 0; i < count; i++) {
+                uint16_t a = static_cast<uint16_t>(addr + i);
+                if (a >= mem_size) break;
+                if (i > 0) oss << ",";
+                snprintf(buf, sizeof(buf), "$%02X", mem[a]);
+                oss << buf;
+            }
+            break;
+        }
+        case DataType::WORDS: {
+            // Up to 4 words per line
+            oss << "dw ";
+            int remaining_bytes = static_cast<int>(area->end) - static_cast<int>(addr) + 1;
+            int word_count = std::min(remaining_bytes / 2, 4);
+            if (word_count == 0 && remaining_bytes >= 2) word_count = 1;
+            for (int i = 0; i < word_count; i++) {
+                uint16_t a = static_cast<uint16_t>(addr + i * 2);
+                if (static_cast<size_t>(a + 1) >= mem_size) break;
+                if (i > 0) oss << ",";
+                uint16_t w = static_cast<uint16_t>(mem[a] | (mem[a + 1] << 8));
+                snprintf(buf, sizeof(buf), "$%04X", w);
+                oss << buf;
+            }
+            break;
+        }
+        case DataType::TEXT: {
+            // Emit printable chars as string, non-printable as hex
+            oss << "db ";
+            int remaining = static_cast<int>(area->end) - static_cast<int>(addr) + 1;
+            int count = std::min(remaining, 64);  // reasonable line limit
+            bool in_string = false;
+            bool first = true;
+            for (int i = 0; i < count; i++) {
+                uint16_t a = static_cast<uint16_t>(addr + i);
+                if (a >= mem_size) break;
+                uint8_t c = mem[a];
+                if (c >= 0x20 && c < 0x7F) {
+                    if (!in_string) {
+                        if (!first) oss << ",";
+                        oss << "\"";
+                        in_string = true;
+                    }
+                    oss << static_cast<char>(c);
+                } else {
+                    if (in_string) {
+                        oss << "\"";
+                        in_string = false;
+                    }
+                    if (!first) oss << ",";
+                    snprintf(buf, sizeof(buf), "$%02X", c);
+                    oss << buf;
+                }
+                first = false;
+            }
+            if (in_string) oss << "\"";
+            break;
+        }
+    }
+
+    return oss.str();
+}

--- a/src/data_areas.h
+++ b/src/data_areas.h
@@ -1,0 +1,34 @@
+#pragma once
+#include <cstdint>
+#include <map>
+#include <string>
+#include <vector>
+
+enum class DataType { BYTES, WORDS, TEXT };
+
+struct DataArea {
+    uint16_t start;
+    uint16_t end;      // inclusive
+    DataType type;
+    std::string label;  // optional
+};
+
+class DataAreaManager {
+public:
+    void mark(uint16_t start, uint16_t end, DataType type, const std::string& label = "");
+    void clear(uint16_t start);
+    void clear_all();
+    std::vector<DataArea> list() const;
+
+    // Query: is this address inside a data area?
+    const DataArea* find(uint16_t addr) const;
+
+    // Format a data area line for disassembly output
+    // Returns empty string if addr is not in a data area
+    std::string format_at(uint16_t addr, const uint8_t* mem, size_t mem_size) const;
+
+private:
+    std::map<uint16_t, DataArea> areas_;  // keyed by start address
+};
+
+extern DataAreaManager g_data_areas;

--- a/test/data_areas.cpp
+++ b/test/data_areas.cpp
@@ -1,0 +1,159 @@
+#include <gtest/gtest.h>
+#include "data_areas.h"
+
+namespace {
+
+class DataAreaManagerTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        mgr_.clear_all();
+    }
+    DataAreaManager mgr_;
+};
+
+// --- find() tests ---
+
+TEST_F(DataAreaManagerTest, FindReturnsAreaContainingAddress) {
+    mgr_.mark(0x1000, 0x100F, DataType::BYTES, "table1");
+    const DataArea* a = mgr_.find(0x1005);
+    ASSERT_NE(a, nullptr);
+    EXPECT_EQ(a->start, 0x1000);
+    EXPECT_EQ(a->end, 0x100F);
+    EXPECT_EQ(a->type, DataType::BYTES);
+    EXPECT_EQ(a->label, "table1");
+}
+
+TEST_F(DataAreaManagerTest, FindReturnsNullptrForAddressOutside) {
+    mgr_.mark(0x1000, 0x100F, DataType::BYTES);
+    EXPECT_EQ(mgr_.find(0x0FFF), nullptr);
+    EXPECT_EQ(mgr_.find(0x1010), nullptr);
+}
+
+TEST_F(DataAreaManagerTest, FindAtBoundaries) {
+    mgr_.mark(0x2000, 0x2003, DataType::WORDS);
+    EXPECT_NE(mgr_.find(0x2000), nullptr);
+    EXPECT_NE(mgr_.find(0x2003), nullptr);
+    EXPECT_EQ(mgr_.find(0x1FFF), nullptr);
+    EXPECT_EQ(mgr_.find(0x2004), nullptr);
+}
+
+// --- Overlapping regions ---
+
+TEST_F(DataAreaManagerTest, OverlappingRegionOverwritesFirst) {
+    mgr_.mark(0x1000, 0x100F, DataType::BYTES, "first");
+    mgr_.mark(0x1008, 0x101F, DataType::WORDS, "second");
+    // First area should have been removed due to overlap
+    const DataArea* a = mgr_.find(0x1000);
+    // Address 0x1000 is no longer covered (old area removed, new starts at 0x1008)
+    EXPECT_EQ(a, nullptr);
+    // Address 0x1010 should be in the new area
+    a = mgr_.find(0x1010);
+    ASSERT_NE(a, nullptr);
+    EXPECT_EQ(a->start, 0x1008);
+    EXPECT_EQ(a->type, DataType::WORDS);
+}
+
+// --- clear() ---
+
+TEST_F(DataAreaManagerTest, ClearRemovesSpecificArea) {
+    mgr_.mark(0x1000, 0x100F, DataType::BYTES);
+    mgr_.mark(0x2000, 0x200F, DataType::WORDS);
+    mgr_.clear(0x1000);
+    EXPECT_EQ(mgr_.find(0x1005), nullptr);
+    EXPECT_NE(mgr_.find(0x2005), nullptr);
+}
+
+// --- clear_all() ---
+
+TEST_F(DataAreaManagerTest, ClearAllRemovesEverything) {
+    mgr_.mark(0x1000, 0x100F, DataType::BYTES);
+    mgr_.mark(0x2000, 0x200F, DataType::WORDS);
+    mgr_.mark(0x3000, 0x300F, DataType::TEXT);
+    mgr_.clear_all();
+    EXPECT_EQ(mgr_.find(0x1005), nullptr);
+    EXPECT_EQ(mgr_.find(0x2005), nullptr);
+    EXPECT_EQ(mgr_.find(0x3005), nullptr);
+}
+
+// --- list() ---
+
+TEST_F(DataAreaManagerTest, ListReturnsSortedByStartAddress) {
+    mgr_.mark(0x3000, 0x300F, DataType::TEXT);
+    mgr_.mark(0x1000, 0x100F, DataType::BYTES);
+    mgr_.mark(0x2000, 0x200F, DataType::WORDS);
+    auto areas = mgr_.list();
+    ASSERT_EQ(areas.size(), 3u);
+    EXPECT_EQ(areas[0].start, 0x1000);
+    EXPECT_EQ(areas[1].start, 0x2000);
+    EXPECT_EQ(areas[2].start, 0x3000);
+}
+
+// --- format_at() BYTES ---
+
+TEST_F(DataAreaManagerTest, FormatAtBytesProducesDbOutput) {
+    mgr_.mark(0x0000, 0x0003, DataType::BYTES);
+    uint8_t mem[] = {0x41, 0x42, 0x00, 0xFF};
+    std::string result = mgr_.format_at(0x0000, mem, sizeof(mem));
+    EXPECT_EQ(result, "db $41,$42,$00,$FF");
+}
+
+TEST_F(DataAreaManagerTest, FormatAtBytesMaxEightPerLine) {
+    mgr_.mark(0x0000, 0x000F, DataType::BYTES);
+    uint8_t mem[16];
+    for (int i = 0; i < 16; i++) mem[i] = static_cast<uint8_t>(i);
+    // At addr 0, should emit 8 bytes
+    std::string result = mgr_.format_at(0x0000, mem, sizeof(mem));
+    EXPECT_EQ(result, "db $00,$01,$02,$03,$04,$05,$06,$07");
+    // At addr 8, should emit next 8
+    result = mgr_.format_at(0x0008, mem, sizeof(mem));
+    EXPECT_EQ(result, "db $08,$09,$0A,$0B,$0C,$0D,$0E,$0F");
+}
+
+// --- format_at() WORDS ---
+
+TEST_F(DataAreaManagerTest, FormatAtWordsProducesDwOutput) {
+    mgr_.mark(0x0000, 0x0003, DataType::WORDS);
+    uint8_t mem[] = {0x34, 0x12, 0x78, 0x56};  // little-endian: $1234, $5678
+    std::string result = mgr_.format_at(0x0000, mem, sizeof(mem));
+    EXPECT_EQ(result, "dw $1234,$5678");
+}
+
+TEST_F(DataAreaManagerTest, FormatAtWordsMaxFourPerLine) {
+    mgr_.mark(0x0000, 0x000F, DataType::WORDS);
+    uint8_t mem[16];
+    for (int i = 0; i < 16; i++) mem[i] = static_cast<uint8_t>(i);
+    // At addr 0: 4 words (8 bytes)
+    std::string result = mgr_.format_at(0x0000, mem, sizeof(mem));
+    // Bytes: 00 01 02 03 04 05 06 07 -> words $0100,$0302,$0504,$0706
+    EXPECT_EQ(result, "dw $0100,$0302,$0504,$0706");
+}
+
+// --- format_at() TEXT ---
+
+TEST_F(DataAreaManagerTest, FormatAtTextHandlesPrintableChars) {
+    mgr_.mark(0x0000, 0x0004, DataType::TEXT);
+    uint8_t mem[] = {'H', 'e', 'l', 'l', 'o'};
+    std::string result = mgr_.format_at(0x0000, mem, sizeof(mem));
+    EXPECT_EQ(result, "db \"Hello\"");
+}
+
+TEST_F(DataAreaManagerTest, FormatAtTextHandlesNonPrintable) {
+    mgr_.mark(0x0000, 0x0004, DataType::TEXT);
+    uint8_t mem[] = {'H', 'i', 0x00, 0x0D, '!'};
+    std::string result = mgr_.format_at(0x0000, mem, sizeof(mem));
+    EXPECT_EQ(result, "db \"Hi\",$00,$0D,\"!\"");
+}
+
+// --- Address not in any area ---
+
+TEST_F(DataAreaManagerTest, FormatAtReturnsEmptyForNonDataAddress) {
+    uint8_t mem[] = {0x00};
+    std::string result = mgr_.format_at(0x0000, mem, sizeof(mem));
+    EXPECT_TRUE(result.empty());
+}
+
+TEST_F(DataAreaManagerTest, FindReturnsNullptrWhenEmpty) {
+    EXPECT_EQ(mgr_.find(0x1234), nullptr);
+}
+
+}  // namespace


### PR DESCRIPTION
## Summary
- Adds DataAreaManager that tracks address ranges as BYTES, WORDS, or TEXT regions
- Integrates with disassembler: marked ranges show `db`/`dw` directives instead of decoded instructions
- IPC commands: `data mark <start> <end> <type> [label]`, `data clear <addr|all>`, `data list`
- Handles overlapping regions (new region replaces any overlapping old ones)

## Test plan
- [ ] 15 unit tests covering find, overlap, clear, list, and format_at for all three data types
- [ ] Verify `data mark 0x4000 0x400F bytes jump_table` via IPC
- [ ] Verify `disasm 0x4000 16` shows `db` directives for marked range
- [ ] CI passes (macOS, Ubuntu, MINGW32, MINGW64)