### PR TITLE
fix: address review comments from PRs #28-30

### DIFF
--- a/src/data_areas.h
+++ b/src/data_areas.h
@@ -23,9 +23,11 @@ public:
     // Query: is this address inside a data area?
     const DataArea* find(uint16_t addr) const;
 
-    // Format a data area line for disassembly output
-    // Returns empty string if addr is not in a data area
-    std::string format_at(uint16_t addr, const uint8_t* mem, size_t mem_size) const;
+    // Format a data area line for disassembly output.
+    // Returns empty string if addr is not in a data area.
+    // If bytes_consumed is non-null, stores the number of bytes this line covers.
+    std::string format_at(uint16_t addr, const uint8_t* mem, size_t mem_size,
+                          int* bytes_consumed = nullptr) const;
 
 private:
     std::map<uint16_t, DataArea> areas_;  // keyed by start address

--- a/src/imgui_ui_testable.h
+++ b/src/imgui_ui_testable.h
@@ -55,6 +55,14 @@ constexpr int RAM_SIZE_COUNT = sizeof(RAM_SIZES) / sizeof(RAM_SIZES[0]);
 constexpr unsigned int SAMPLE_RATES[] = { 11025, 22050, 44100, 48000, 96000 };
 constexpr int SAMPLE_RATE_COUNT = sizeof(SAMPLE_RATES) / sizeof(SAMPLE_RATES[0]);
 
+// Check if a RAM size is in the allowed set
+inline bool is_valid_ram_size(unsigned int ram) {
+  for (int i = 0; i < RAM_SIZE_COUNT; i++) {
+    if (RAM_SIZES[i] == ram) return true;
+  }
+  return false;
+}
+
 // Find index of RAM size in options array, returns 2 (192 KB default) if not found
 inline int find_ram_index(unsigned int ram) {
   for (int i = 0; i < RAM_SIZE_COUNT; i++) {

--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -69,6 +69,7 @@ namespace {
 #include "argparse.h"
 #include "slotshandler.h"
 #include "fileutils.h"
+#include "imgui_ui_testable.h"
 
 #include <errno.h>
 #include <cstring>
@@ -1910,9 +1911,7 @@ void loadConfiguration (t_CPC &CPC, const std::string& configFilename)
    }
    CPC.jumpers = conf.getIntValue("system", "jumpers", 0x1e) & 0x1e; // OEM is Amstrad, video refresh is 50Hz
    CPC.ram_size = conf.getIntValue("system", "ram_size", 128);
-   // Validate RAM size: allowed values are 64, 128, 256, 512, 576, 4160 (Yarek 4MB)
-   if (CPC.ram_size != 64 && CPC.ram_size != 128 && CPC.ram_size != 256 &&
-       CPC.ram_size != 512 && CPC.ram_size != 576 && CPC.ram_size != 4160) {
+   if (!is_valid_ram_size(CPC.ram_size)) {
       CPC.ram_size = 128; // default to 128KB
    }
    if ((CPC.model >= 2) && (CPC.ram_size < 128)) {


### PR DESCRIPTION
## Summary
Addresses all 8 Gemini review comments (3 high, 5 medium) from PRs #28-30:

**PR #28 (RAM expansion):**
- Centralize RAM size validation into shared `is_valid_ram_size()` in `imgui_ui_testable.h`
- Eliminates duplication between `kon_cpc_ja.cpp` and `koncepcja_ipc_server.cpp`

**PR #29 (data areas):**
- O(log N) binary search via `upper_bound` in `DataAreaManager::find()` (was linear scan)
- `format_at()` now returns bytes consumed, eliminating duplicated line-length logic in disasm handler
- Removed dead code (`word_count == 0` guard that could never trigger)
- Restructured `data clear` to if-else with proper error on missing argument
- Disasm handler reads only the bytes needed per line (was reading entire data area)

**PR #30 (gfx finder):**
- Portable little-endian BMP header writes (explicit byte shifts, no `memcpy` of host-endian ints)
- Check `fwrite` return values for write failure detection
- Removed dead `p0`/`p1` variables from mode 0 decode

## Test plan
- [ ] 589 tests pass, 2 skipped (same as before)
- [ ] CI passes (macOS, Ubuntu, MINGW32, MINGW64)