### PR TITLE
feat(4e): Silicon Disc 256K battery-backed RAM

### DIFF
--- a/src/silicon_disc.cpp
+++ b/src/silicon_disc.cpp
@@ -6,8 +6,7 @@ SiliconDisc g_silicon_disc;
 
 void silicon_disc_init(SiliconDisc& sd) {
     if (sd.data) return; // already allocated
-    sd.data = new uint8_t[SILICON_DISC_SIZE];
-    memset(sd.data, 0, SILICON_DISC_SIZE);
+    sd.data = new uint8_t[SILICON_DISC_SIZE]();  // value-initialized (zero)
 }
 
 void silicon_disc_free(SiliconDisc& sd) {

--- a/src/silicon_disc.cpp
+++ b/src/silicon_disc.cpp
@@ -1,0 +1,56 @@
+#include "silicon_disc.h"
+#include <cstring>
+#include <cstdio>
+
+SiliconDisc g_silicon_disc;
+
+void silicon_disc_init(SiliconDisc& sd) {
+    if (sd.data) return; // already allocated
+    sd.data = new uint8_t[SILICON_DISC_SIZE];
+    memset(sd.data, 0, SILICON_DISC_SIZE);
+}
+
+void silicon_disc_free(SiliconDisc& sd) {
+    delete[] sd.data;
+    sd.data = nullptr;
+    sd.enabled = false;
+}
+
+void silicon_disc_clear(SiliconDisc& sd) {
+    if (sd.data) {
+        memset(sd.data, 0, SILICON_DISC_SIZE);
+    }
+}
+
+bool silicon_disc_save(const SiliconDisc& sd, const std::string& path) {
+    if (!sd.data) return false;
+    FILE* f = fopen(path.c_str(), "wb");
+    if (!f) return false;
+    // Header: "KSDX" + version byte + 3 reserved bytes
+    const char header[8] = {'K', 'S', 'D', 'X', 1, 0, 0, 0};
+    if (fwrite(header, 1, 8, f) != 8) { fclose(f); return false; }
+    if (fwrite(sd.data, 1, SILICON_DISC_SIZE, f) != SILICON_DISC_SIZE) {
+        fclose(f);
+        return false;
+    }
+    fclose(f);
+    return true;
+}
+
+bool silicon_disc_load(SiliconDisc& sd, const std::string& path) {
+    if (!sd.data) silicon_disc_init(sd);
+    FILE* f = fopen(path.c_str(), "rb");
+    if (!f) return false;
+    char header[8];
+    if (fread(header, 1, 8, f) != 8 ||
+        header[0] != 'K' || header[1] != 'S' || header[2] != 'D' || header[3] != 'X') {
+        fclose(f);
+        return false;
+    }
+    if (fread(sd.data, 1, SILICON_DISC_SIZE, f) != SILICON_DISC_SIZE) {
+        fclose(f);
+        return false;
+    }
+    fclose(f);
+    return true;
+}

--- a/src/silicon_disc.h
+++ b/src/silicon_disc.h
@@ -1,0 +1,45 @@
+#pragma once
+#include <cstdint>
+#include <cstddef>
+#include <string>
+
+// DK'Tronics Silicon Disc: 256K battery-backed RAM
+// Occupies expansion banks 4-7 (4 banks x 64K each)
+// Memory persists across emulator resets (simulating battery backup)
+
+constexpr int SILICON_DISC_BANKS = 4;        // banks 4-7
+constexpr int SILICON_DISC_FIRST_BANK = 4;   // first bank index
+constexpr size_t SILICON_DISC_BANK_SIZE = 65536;
+constexpr size_t SILICON_DISC_SIZE = SILICON_DISC_BANKS * SILICON_DISC_BANK_SIZE; // 256K
+
+struct SiliconDisc {
+    bool enabled;
+    uint8_t* data;       // 256K buffer, NOT cleared on reset
+
+    SiliconDisc() : enabled(false), data(nullptr) {}
+
+    // Get pointer to a specific bank's 64K region (bank_index 0-3, mapped from expansion banks 4-7)
+    uint8_t* bank_ptr(int bank_index) const {
+        if (!data || bank_index < 0 || bank_index >= SILICON_DISC_BANKS) return nullptr;
+        return data + (bank_index * SILICON_DISC_BANK_SIZE);
+    }
+
+    // Check if an expansion bank number falls in the Silicon Disc range
+    bool owns_bank(int expansion_bank) const {
+        return enabled && expansion_bank >= SILICON_DISC_FIRST_BANK &&
+               expansion_bank < SILICON_DISC_FIRST_BANK + SILICON_DISC_BANKS;
+    }
+};
+
+// Allocate/free Silicon Disc buffer
+void silicon_disc_init(SiliconDisc& sd);
+void silicon_disc_free(SiliconDisc& sd);
+
+// Clear Silicon Disc contents (like removing the battery)
+void silicon_disc_clear(SiliconDisc& sd);
+
+// Save/load Silicon Disc contents to/from file
+bool silicon_disc_save(const SiliconDisc& sd, const std::string& path);
+bool silicon_disc_load(SiliconDisc& sd, const std::string& path);
+
+extern SiliconDisc g_silicon_disc;

--- a/test/silicon_disc.cpp
+++ b/test/silicon_disc.cpp
@@ -1,0 +1,129 @@
+#include <gtest/gtest.h>
+#include "silicon_disc.h"
+#include <cstring>
+#include <filesystem>
+
+namespace {
+
+class SiliconDiscTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        sd_ = SiliconDisc();
+    }
+    void TearDown() override {
+        silicon_disc_free(sd_);
+    }
+    SiliconDisc sd_;
+};
+
+TEST_F(SiliconDiscTest, InitAllocatesMemory) {
+    EXPECT_EQ(sd_.data, nullptr);
+    silicon_disc_init(sd_);
+    EXPECT_NE(sd_.data, nullptr);
+}
+
+TEST_F(SiliconDiscTest, InitIdempotent) {
+    silicon_disc_init(sd_);
+    uint8_t* first = sd_.data;
+    silicon_disc_init(sd_);
+    EXPECT_EQ(sd_.data, first);  // same pointer, not reallocated
+}
+
+TEST_F(SiliconDiscTest, FreeReleasesMemory) {
+    silicon_disc_init(sd_);
+    silicon_disc_free(sd_);
+    EXPECT_EQ(sd_.data, nullptr);
+    EXPECT_FALSE(sd_.enabled);
+}
+
+TEST_F(SiliconDiscTest, ClearZerosContents) {
+    silicon_disc_init(sd_);
+    memset(sd_.data, 0xAA, SILICON_DISC_SIZE);
+    silicon_disc_clear(sd_);
+    for (size_t i = 0; i < SILICON_DISC_SIZE; i++) {
+        EXPECT_EQ(sd_.data[i], 0) << "byte " << i << " not cleared";
+        if (sd_.data[i] != 0) break;  // fail fast
+    }
+}
+
+TEST_F(SiliconDiscTest, BankPtrReturnsCorrectOffsets) {
+    silicon_disc_init(sd_);
+    EXPECT_EQ(sd_.bank_ptr(0), sd_.data);
+    EXPECT_EQ(sd_.bank_ptr(1), sd_.data + SILICON_DISC_BANK_SIZE);
+    EXPECT_EQ(sd_.bank_ptr(2), sd_.data + 2 * SILICON_DISC_BANK_SIZE);
+    EXPECT_EQ(sd_.bank_ptr(3), sd_.data + 3 * SILICON_DISC_BANK_SIZE);
+}
+
+TEST_F(SiliconDiscTest, BankPtrOutOfRange) {
+    silicon_disc_init(sd_);
+    EXPECT_EQ(sd_.bank_ptr(-1), nullptr);
+    EXPECT_EQ(sd_.bank_ptr(4), nullptr);
+}
+
+TEST_F(SiliconDiscTest, BankPtrNullWhenNotAllocated) {
+    EXPECT_EQ(sd_.bank_ptr(0), nullptr);
+}
+
+TEST_F(SiliconDiscTest, OwnsBankWhenEnabled) {
+    sd_.enabled = true;
+    EXPECT_FALSE(sd_.owns_bank(0));
+    EXPECT_FALSE(sd_.owns_bank(3));
+    EXPECT_TRUE(sd_.owns_bank(4));
+    EXPECT_TRUE(sd_.owns_bank(5));
+    EXPECT_TRUE(sd_.owns_bank(6));
+    EXPECT_TRUE(sd_.owns_bank(7));
+    EXPECT_FALSE(sd_.owns_bank(8));
+}
+
+TEST_F(SiliconDiscTest, OwnsBankFalseWhenDisabled) {
+    sd_.enabled = false;
+    EXPECT_FALSE(sd_.owns_bank(4));
+    EXPECT_FALSE(sd_.owns_bank(7));
+}
+
+TEST_F(SiliconDiscTest, SaveAndLoadRoundTrip) {
+    silicon_disc_init(sd_);
+    // Write a known pattern
+    for (size_t i = 0; i < SILICON_DISC_SIZE; i++) {
+        sd_.data[i] = static_cast<uint8_t>(i & 0xFF);
+    }
+    std::string path = (std::filesystem::temp_directory_path() / "test_sdisc.ksdx").string();
+    ASSERT_TRUE(silicon_disc_save(sd_, path));
+
+    // Load into a fresh disc
+    SiliconDisc sd2;
+    silicon_disc_init(sd2);
+    memset(sd2.data, 0, SILICON_DISC_SIZE);
+    ASSERT_TRUE(silicon_disc_load(sd2, path));
+
+    EXPECT_EQ(memcmp(sd_.data, sd2.data, SILICON_DISC_SIZE), 0);
+    silicon_disc_free(sd2);
+    std::filesystem::remove(path);
+}
+
+TEST_F(SiliconDiscTest, LoadRejectsBadHeader) {
+    std::string path = (std::filesystem::temp_directory_path() / "test_sdisc_bad.ksdx").string();
+    // Write a file with invalid header
+    FILE* f = fopen(path.c_str(), "wb");
+    ASSERT_NE(f, nullptr);
+    fwrite("BADHDR00", 1, 8, f);
+    fclose(f);
+
+    silicon_disc_init(sd_);
+    EXPECT_FALSE(silicon_disc_load(sd_, path));
+    std::filesystem::remove(path);
+}
+
+TEST_F(SiliconDiscTest, SaveFailsWhenNotAllocated) {
+    std::string path = (std::filesystem::temp_directory_path() / "test_sdisc_null.ksdx").string();
+    EXPECT_FALSE(silicon_disc_save(sd_, path));
+}
+
+TEST_F(SiliconDiscTest, SizeConstants) {
+    EXPECT_EQ(SILICON_DISC_BANKS, 4);
+    EXPECT_EQ(SILICON_DISC_FIRST_BANK, 4);
+    EXPECT_EQ(SILICON_DISC_BANK_SIZE, 65536u);
+    EXPECT_EQ(SILICON_DISC_SIZE, 256u * 1024);
+}
+
+} // namespace


### PR DESCRIPTION
## Summary
- Implements DK'Tronics-compatible Silicon Disc as 256K battery-backed RAM in expansion banks 4-7
- Separate buffer from main RAM, survives `emulator_reset()`
- `.ksdx` file format for save/load with header validation
- IPC commands: `sdisc status/clear/save/load`, `config get/set silicon_disc`
- Banking integration in `ga_init_banking()` and `ga_memory_manager()`
- 13 new unit tests

## Test plan
- [x] `./test_runner --gtest_filter='SiliconDisc*'` — 13 tests pass
- [x] Full test suite: 604 pass, 2 skipped (same baseline + new)
- [ ] Manual: enable via config `silicon_disc=1`, verify banks 4-7 are separate RAM
- [ ] Manual: `echo "sdisc status" | nc localhost 6543`
- [ ] Manual: save/load persistence across resets