### PR TITLE
feat(5d): session recording and playback (.ksr format)

### DIFF
--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -70,6 +70,7 @@ namespace {
 #include "slotshandler.h"
 #include "fileutils.h"
 #include "imgui_ui_testable.h"
+#include "session_recording.h"
 
 #include <errno.h>
 #include <cstring>
@@ -3529,6 +3530,36 @@ int koncpc_main (int argc, char **argv)
                g_avi_recorder.capture_video_frame(
                   static_cast<const uint8_t*>(back_surface->pixels),
                   back_surface->w, back_surface->h, back_surface->pitch);
+            }
+
+            // Session recording: capture keyboard state per frame
+            if (g_session.state() == SessionState::RECORDING) {
+               // Record changed keyboard matrix bytes as key events
+               static uint8_t prev_matrix[16] = {0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,
+                                                   0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF};
+               for (int row = 0; row < 16; row++) {
+                  if (keyboard_matrix[row] != prev_matrix[row]) {
+                     // Encode as row in high byte, value in low byte
+                     uint16_t data = static_cast<uint16_t>((row << 8) | keyboard_matrix[row]);
+                     g_session.record_event(SessionEventType::KEY_DOWN, data);
+                     prev_matrix[row] = keyboard_matrix[row];
+                  }
+               }
+               g_session.record_frame_sync();
+            }
+
+            // Session playback: replay events for this frame
+            if (g_session.state() == SessionState::PLAYING) {
+               SessionEvent evt;
+               while (g_session.next_event(evt)) {
+                  if (evt.type == SessionEventType::KEY_DOWN) {
+                     int row = (evt.data >> 8) & 0x0F;
+                     keyboard_matrix[row] = static_cast<byte>(evt.data & 0xFF);
+                  }
+               }
+               if (!g_session.advance_frame()) {
+                  // Recording finished, session goes back to IDLE
+               }
             }
 
             // Auto-type: drain queue one action per frame

--- a/src/session_recording.cpp
+++ b/src/session_recording.cpp
@@ -1,0 +1,237 @@
+#include "session_recording.h"
+#include <cstdio>
+#include <cstring>
+#include <algorithm>
+
+SessionRecorder g_session;
+
+// Portable little-endian helpers
+static void write_le32(FILE* f, uint32_t val) {
+    uint8_t b[4] = {
+        static_cast<uint8_t>(val),
+        static_cast<uint8_t>(val >> 8),
+        static_cast<uint8_t>(val >> 16),
+        static_cast<uint8_t>(val >> 24)
+    };
+    fwrite(b, 1, 4, f);
+}
+
+static void write_le16(FILE* f, uint16_t val) {
+    uint8_t b[2] = {
+        static_cast<uint8_t>(val),
+        static_cast<uint8_t>(val >> 8)
+    };
+    fwrite(b, 1, 2, f);
+}
+
+static uint32_t read_le32(const uint8_t* p) {
+    return static_cast<uint32_t>(p[0]) |
+           (static_cast<uint32_t>(p[1]) << 8) |
+           (static_cast<uint32_t>(p[2]) << 16) |
+           (static_cast<uint32_t>(p[3]) << 24);
+}
+
+static uint16_t read_le16(const uint8_t* p) {
+    return static_cast<uint16_t>(p[0]) |
+           (static_cast<uint16_t>(p[1]) << 8);
+}
+
+SessionRecorder::~SessionRecorder() {
+    if (state_ == SessionState::RECORDING) stop_recording();
+    if (state_ == SessionState::PLAYING) stop_playback();
+}
+
+bool SessionRecorder::start_recording(const std::string& path, const std::string& snap_path) {
+    if (state_ != SessionState::IDLE) return false;
+
+    // Read the SNA file that was saved before calling us
+    FILE* snap_f = fopen(snap_path.c_str(), "rb");
+    if (!snap_f) return false;
+    fseek(snap_f, 0, SEEK_END);
+    long snap_size = ftell(snap_f);
+    fseek(snap_f, 0, SEEK_SET);
+    if (snap_size <= 0) { fclose(snap_f); return false; }
+
+    std::vector<uint8_t> snap_data(static_cast<size_t>(snap_size));
+    if (fread(snap_data.data(), 1, snap_data.size(), snap_f) != snap_data.size()) {
+        fclose(snap_f);
+        return false;
+    }
+    fclose(snap_f);
+
+    // Open the KSR file
+    rec_file_ = fopen(path.c_str(), "wb");
+    if (!rec_file_) return false;
+
+    // Write header (32 bytes)
+    uint8_t header[KSR_HEADER_SIZE] = {};
+    header[0] = 'K'; header[1] = 'S'; header[2] = 'R'; header[3] = 0x1A;
+    header[4] = KSR_VERSION;
+    // SNA size at offset 8 (LE32)
+    header[8]  = static_cast<uint8_t>(snap_size);
+    header[9]  = static_cast<uint8_t>(snap_size >> 8);
+    header[10] = static_cast<uint8_t>(snap_size >> 16);
+    header[11] = static_cast<uint8_t>(snap_size >> 24);
+    // Event count at offset 12 will be filled on stop
+    if (fwrite(header, 1, KSR_HEADER_SIZE, rec_file_) != KSR_HEADER_SIZE) {
+        fclose(rec_file_);
+        rec_file_ = nullptr;
+        return false;
+    }
+
+    // Write embedded SNA
+    if (fwrite(snap_data.data(), 1, snap_data.size(), rec_file_) != snap_data.size()) {
+        fclose(rec_file_);
+        rec_file_ = nullptr;
+        return false;
+    }
+
+    path_ = path;
+    state_ = SessionState::RECORDING;
+    frame_count_ = 0;
+    event_count_ = 0;
+    return true;
+}
+
+void SessionRecorder::record_event(SessionEventType type, uint16_t data) {
+    if (state_ != SessionState::RECORDING || !rec_file_) return;
+    uint8_t t = static_cast<uint8_t>(type);
+    fwrite(&t, 1, 1, rec_file_);
+    if (type != SessionEventType::FRAME_SYNC) {
+        write_le16(rec_file_, data);
+    }
+    event_count_++;
+}
+
+void SessionRecorder::record_frame_sync() {
+    record_event(SessionEventType::FRAME_SYNC);
+    frame_count_++;
+}
+
+bool SessionRecorder::stop_recording() {
+    if (state_ != SessionState::RECORDING) return false;
+    if (rec_file_) {
+        // Update event count in header (offset 12)
+        fseek(rec_file_, 12, SEEK_SET);
+        write_le32(rec_file_, event_count_);
+        fclose(rec_file_);
+        rec_file_ = nullptr;
+    }
+    state_ = SessionState::IDLE;
+    return true;
+}
+
+bool SessionRecorder::start_playback(const std::string& path, std::string& snap_path_out) {
+    if (state_ != SessionState::IDLE) return false;
+
+    FILE* f = fopen(path.c_str(), "rb");
+    if (!f) return false;
+
+    // Read header
+    uint8_t header[KSR_HEADER_SIZE];
+    if (fread(header, 1, KSR_HEADER_SIZE, f) != KSR_HEADER_SIZE) {
+        fclose(f);
+        return false;
+    }
+    if (header[0] != 'K' || header[1] != 'S' || header[2] != 'R' || header[3] != 0x1A) {
+        fclose(f);
+        return false;
+    }
+    if (header[4] != KSR_VERSION) {
+        fclose(f);
+        return false;
+    }
+
+    uint32_t sna_size = read_le32(header + 8);
+    uint32_t evt_count = read_le32(header + 12);
+
+    // Read and write SNA to temp file
+    std::vector<uint8_t> sna_data(sna_size);
+    if (fread(sna_data.data(), 1, sna_size, f) != sna_size) {
+        fclose(f);
+        return false;
+    }
+
+    // Write SNA to a temp file for snapshot_load
+    snap_path_out = path + ".sna";
+    FILE* snap_f = fopen(snap_path_out.c_str(), "wb");
+    if (!snap_f) { fclose(f); return false; }
+    if (fwrite(sna_data.data(), 1, sna_size, snap_f) != sna_size) {
+        fclose(snap_f);
+        fclose(f);
+        return false;
+    }
+    fclose(snap_f);
+
+    // Read all events
+    events_.clear();
+    events_.reserve(evt_count);
+    total_frames_ = 0;
+
+    while (!feof(f)) {
+        uint8_t type_byte;
+        if (fread(&type_byte, 1, 1, f) != 1) break;
+
+        SessionEvent evt;
+        evt.type = static_cast<SessionEventType>(type_byte);
+        evt.data = 0;
+
+        if (evt.type != SessionEventType::FRAME_SYNC) {
+            uint8_t d[2];
+            if (fread(d, 1, 2, f) != 2) break;
+            evt.data = read_le16(d);
+        } else {
+            total_frames_++;
+        }
+        events_.push_back(evt);
+    }
+    fclose(f);
+
+    path_ = path;
+    state_ = SessionState::PLAYING;
+    frame_count_ = 0;
+    event_count_ = static_cast<uint32_t>(events_.size());
+    play_pos_ = 0;
+    return true;
+}
+
+bool SessionRecorder::next_event(SessionEvent& evt) {
+    if (state_ != SessionState::PLAYING) return false;
+    while (play_pos_ < events_.size()) {
+        if (events_[play_pos_].type == SessionEventType::FRAME_SYNC) {
+            return false;  // hit frame boundary, caller should call advance_frame()
+        }
+        evt = events_[play_pos_++];
+        return true;
+    }
+    return false;  // end of recording
+}
+
+bool SessionRecorder::advance_frame() {
+    if (state_ != SessionState::PLAYING) return false;
+    // Skip to the FRAME_SYNC and past it
+    while (play_pos_ < events_.size()) {
+        if (events_[play_pos_].type == SessionEventType::FRAME_SYNC) {
+            play_pos_++;
+            frame_count_++;
+            // If no more events remain, the recording is finished
+            if (play_pos_ >= events_.size()) {
+                stop_playback();
+                return false;
+            }
+            return true;
+        }
+        play_pos_++;  // skip events that weren't consumed
+    }
+    // End of recording
+    stop_playback();
+    return false;
+}
+
+bool SessionRecorder::stop_playback() {
+    if (state_ != SessionState::PLAYING && state_ != SessionState::IDLE) return false;
+    events_.clear();
+    play_pos_ = 0;
+    state_ = SessionState::IDLE;
+    return true;
+}

--- a/src/session_recording.h
+++ b/src/session_recording.h
@@ -1,0 +1,86 @@
+#pragma once
+#include <cstdint>
+#include <string>
+#include <vector>
+
+// konCePCja Session Recording (.ksr format)
+//
+// File layout:
+//   [32-byte header]
+//   [SNA snapshot data (variable length)]
+//   [event records until EOF]
+//
+// Header (32 bytes):
+//   0-3:   magic "KSR\x1A"
+//   4:     version (1)
+//   5-7:   reserved
+//   8-11:  SNA size (LE32)
+//   12-15: event count (LE32) — filled on close
+//   16-31: reserved
+
+constexpr uint32_t KSR_MAGIC = 0x1A52534B;  // "KSR\x1A" little-endian
+constexpr uint8_t KSR_VERSION = 1;
+constexpr size_t KSR_HEADER_SIZE = 32;
+
+// Event types
+enum class SessionEventType : uint8_t {
+    FRAME_SYNC = 0x00,    // 1 byte: type only (marks frame boundary)
+    KEY_DOWN   = 0x01,    // 3 bytes: type + CPC key code (uint16_t LE)
+    KEY_UP     = 0x02,    // 3 bytes: type + CPC key code (uint16_t LE)
+    JOY_STATE  = 0x03,    // 3 bytes: type + joystick bitmask (uint16_t LE)
+};
+
+struct SessionEvent {
+    SessionEventType type;
+    uint16_t data;        // key code or joystick state
+};
+
+// Recording states
+enum class SessionState {
+    IDLE,
+    RECORDING,
+    PLAYING,
+};
+
+class SessionRecorder {
+public:
+    SessionRecorder() = default;
+    ~SessionRecorder();
+
+    // Recording
+    bool start_recording(const std::string& path, const std::string& snap_path);
+    void record_event(SessionEventType type, uint16_t data = 0);
+    void record_frame_sync();
+    bool stop_recording();
+
+    // Playback
+    bool start_playback(const std::string& path, std::string& snap_path_out);
+    // Get next event for current frame. Returns false when no more events this frame.
+    bool next_event(SessionEvent& evt);
+    // Advance to next frame. Returns false if recording is finished.
+    bool advance_frame();
+    bool stop_playback();
+
+    // State
+    SessionState state() const { return state_; }
+    uint32_t frame_count() const { return frame_count_; }
+    uint32_t event_count() const { return event_count_; }
+    uint32_t total_frames() const { return total_frames_; }
+    const std::string& path() const { return path_; }
+
+private:
+    SessionState state_ = SessionState::IDLE;
+    std::string path_;
+    uint32_t frame_count_ = 0;
+    uint32_t event_count_ = 0;
+    uint32_t total_frames_ = 0;
+
+    // Recording state
+    FILE* rec_file_ = nullptr;
+
+    // Playback state
+    std::vector<SessionEvent> events_;  // all events loaded at once
+    size_t play_pos_ = 0;              // current position in events_
+};
+
+extern SessionRecorder g_session;

--- a/test/session_recording.cpp
+++ b/test/session_recording.cpp
@@ -1,0 +1,177 @@
+#include <gtest/gtest.h>
+#include "session_recording.h"
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+
+namespace {
+
+class SessionRecorderTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        tmp_dir_ = std::filesystem::temp_directory_path() / "ksr_test";
+        std::filesystem::create_directories(tmp_dir_);
+        rec_ = SessionRecorder();
+    }
+    void TearDown() override {
+        // Ensure any open recording/playback files are closed before cleanup
+        // (Windows locks open files, preventing remove_all)
+        rec_.stop_recording();
+        rec_.stop_playback();
+        std::filesystem::remove_all(tmp_dir_);
+    }
+
+    // Create a minimal fake SNA file for testing
+    std::string create_fake_sna() {
+        std::string path = (tmp_dir_ / "test.sna").string();
+        std::ofstream f(path, std::ios::binary);
+        // Minimal SNA: 256 bytes of header + 64K RAM
+        std::vector<uint8_t> data(256 + 65536, 0);
+        memcpy(data.data(), "MV - SNA", 8);
+        data[16] = 3; // version 3
+        f.write(reinterpret_cast<const char*>(data.data()), static_cast<std::streamsize>(data.size()));
+        return path;
+    }
+
+    std::filesystem::path tmp_dir_;
+    SessionRecorder rec_;
+};
+
+TEST_F(SessionRecorderTest, InitialStateIsIdle) {
+    EXPECT_EQ(rec_.state(), SessionState::IDLE);
+    EXPECT_EQ(rec_.frame_count(), 0u);
+    EXPECT_EQ(rec_.event_count(), 0u);
+}
+
+TEST_F(SessionRecorderTest, StartRecordingChangesState) {
+    std::string snap = create_fake_sna();
+    std::string ksr = (tmp_dir_ / "test.ksr").string();
+    ASSERT_TRUE(rec_.start_recording(ksr, snap));
+    EXPECT_EQ(rec_.state(), SessionState::RECORDING);
+}
+
+TEST_F(SessionRecorderTest, StartRecordingFailsIfNotIdle) {
+    std::string snap = create_fake_sna();
+    std::string ksr = (tmp_dir_ / "test.ksr").string();
+    ASSERT_TRUE(rec_.start_recording(ksr, snap));
+    std::string ksr2 = (tmp_dir_ / "test2.ksr").string();
+    EXPECT_FALSE(rec_.start_recording(ksr2, snap));
+}
+
+TEST_F(SessionRecorderTest, RecordAndStopUpdatesEventCount) {
+    std::string snap = create_fake_sna();
+    std::string ksr = (tmp_dir_ / "test.ksr").string();
+    ASSERT_TRUE(rec_.start_recording(ksr, snap));
+
+    rec_.record_event(SessionEventType::KEY_DOWN, 0x1234);
+    rec_.record_event(SessionEventType::KEY_UP, 0x1234);
+    rec_.record_frame_sync();
+    rec_.record_event(SessionEventType::KEY_DOWN, 0x5678);
+    rec_.record_frame_sync();
+
+    EXPECT_EQ(rec_.event_count(), 5u);  // 2 key + 2 sync + 1 key
+    EXPECT_EQ(rec_.frame_count(), 2u);
+
+    ASSERT_TRUE(rec_.stop_recording());
+    EXPECT_EQ(rec_.state(), SessionState::IDLE);
+}
+
+TEST_F(SessionRecorderTest, RecordAndPlaybackRoundTrip) {
+    std::string snap = create_fake_sna();
+    std::string ksr = (tmp_dir_ / "test.ksr").string();
+
+    // Record a session
+    ASSERT_TRUE(rec_.start_recording(ksr, snap));
+    rec_.record_event(SessionEventType::KEY_DOWN, 0x00FF);  // row 0, value 0xFF
+    rec_.record_frame_sync();
+    rec_.record_event(SessionEventType::KEY_DOWN, 0x01FE);  // row 1, value 0xFE
+    rec_.record_event(SessionEventType::KEY_DOWN, 0x02FD);  // row 2, value 0xFD
+    rec_.record_frame_sync();
+    rec_.record_frame_sync();  // empty frame
+    ASSERT_TRUE(rec_.stop_recording());
+
+    // Playback
+    std::string snap_out;
+    ASSERT_TRUE(rec_.start_playback(ksr, snap_out));
+    EXPECT_EQ(rec_.state(), SessionState::PLAYING);
+    EXPECT_EQ(rec_.total_frames(), 3u);
+
+    // Frame 1: one KEY_DOWN event
+    SessionEvent evt;
+    EXPECT_TRUE(rec_.next_event(evt));
+    EXPECT_EQ(evt.type, SessionEventType::KEY_DOWN);
+    EXPECT_EQ(evt.data, 0x00FF);
+    EXPECT_FALSE(rec_.next_event(evt));  // hit frame boundary
+    EXPECT_TRUE(rec_.advance_frame());
+
+    // Frame 2: two KEY_DOWN events
+    EXPECT_TRUE(rec_.next_event(evt));
+    EXPECT_EQ(evt.data, 0x01FE);
+    EXPECT_TRUE(rec_.next_event(evt));
+    EXPECT_EQ(evt.data, 0x02FD);
+    EXPECT_FALSE(rec_.next_event(evt));
+    EXPECT_TRUE(rec_.advance_frame());
+
+    // Frame 3: empty
+    EXPECT_FALSE(rec_.next_event(evt));
+    EXPECT_FALSE(rec_.advance_frame());  // end of recording
+
+    // Clean up temp SNA
+    std::filesystem::remove(snap_out);
+}
+
+TEST_F(SessionRecorderTest, PlaybackRejectsInvalidFile) {
+    std::string bad = (tmp_dir_ / "bad.ksr").string();
+    std::ofstream f(bad, std::ios::binary);
+    f << "NOT_A_KSR_FILE";
+    f.close();
+
+    std::string snap_out;
+    EXPECT_FALSE(rec_.start_playback(bad, snap_out));
+    EXPECT_EQ(rec_.state(), SessionState::IDLE);
+}
+
+TEST_F(SessionRecorderTest, StopPlaybackReturnsToIdle) {
+    std::string snap = create_fake_sna();
+    std::string ksr = (tmp_dir_ / "test.ksr").string();
+    ASSERT_TRUE(rec_.start_recording(ksr, snap));
+    rec_.record_frame_sync();
+    ASSERT_TRUE(rec_.stop_recording());
+
+    std::string snap_out;
+    ASSERT_TRUE(rec_.start_playback(ksr, snap_out));
+    ASSERT_TRUE(rec_.stop_playback());
+    EXPECT_EQ(rec_.state(), SessionState::IDLE);
+    std::filesystem::remove(snap_out);
+}
+
+TEST_F(SessionRecorderTest, HeaderMagicAndVersion) {
+    std::string snap = create_fake_sna();
+    std::string ksr = (tmp_dir_ / "test.ksr").string();
+    ASSERT_TRUE(rec_.start_recording(ksr, snap));
+    rec_.record_frame_sync();
+    ASSERT_TRUE(rec_.stop_recording());
+
+    // Verify file header
+    std::ifstream f(ksr, std::ios::binary);
+    uint8_t header[KSR_HEADER_SIZE];
+    f.read(reinterpret_cast<char*>(header), KSR_HEADER_SIZE);
+    EXPECT_EQ(header[0], 'K');
+    EXPECT_EQ(header[1], 'S');
+    EXPECT_EQ(header[2], 'R');
+    EXPECT_EQ(header[3], 0x1A);
+    EXPECT_EQ(header[4], KSR_VERSION);
+}
+
+TEST_F(SessionRecorderTest, StartRecordingFailsWithBadSnapPath) {
+    std::string ksr = (tmp_dir_ / "test.ksr").string();
+    EXPECT_FALSE(rec_.start_recording(ksr, "/nonexistent/path.sna"));
+    EXPECT_EQ(rec_.state(), SessionState::IDLE);
+}
+
+TEST_F(SessionRecorderTest, Constants) {
+    EXPECT_EQ(KSR_HEADER_SIZE, 32u);
+    EXPECT_EQ(KSR_VERSION, 1);
+}
+
+} // namespace


### PR DESCRIPTION
## Summary
- Record and replay keyboard input sessions with frame-accurate timing
- `.ksr` binary format embeds a full SNA snapshot for deterministic replay
- SessionRecorder class with record/playback state machine
- Binary event stream: FRAME_SYNC markers + KEY_DOWN/KEY_UP/JOY events
- Portable little-endian serialization (no struct packing)
- Main loop hooks capture keyboard_matrix diffs per frame
- IPC commands: `session record/play/stop/status`
- 10 unit tests covering round-trip, validation, edge cases

## Test plan
- [x] `./test_runner --gtest_filter='SessionRecorder*'` — 10 tests pass
- [x] Full test suite: 599 pass, 2 skipped (same baseline)
- [ ] Manual: record a session, play it back, verify deterministic replay
- [ ] Manual: `echo "session status" | nc localhost 6543`