### PR TITLE
fix: check fwrite/fputc return values in recorders

### DIFF
--- a/src/wav_recorder.cpp
+++ b/src/wav_recorder.cpp
@@ -2,15 +2,15 @@
 #include <cstring>
 
 namespace {
-void write_le_u16(uint16_t val, FILE* f) {
-    fputc(val & 0xff, f);
-    fputc((val >> 8) & 0xff, f);
+bool write_le_u16(uint16_t val, FILE* f) {
+    return fputc(val & 0xff, f) != EOF &&
+           fputc((val >> 8) & 0xff, f) != EOF;
 }
-void write_le_u32(uint32_t val, FILE* f) {
-    fputc(val & 0xff, f);
-    fputc((val >> 8) & 0xff, f);
-    fputc((val >> 16) & 0xff, f);
-    fputc((val >> 24) & 0xff, f);
+bool write_le_u32(uint32_t val, FILE* f) {
+    return fputc(val & 0xff, f) != EOF &&
+           fputc((val >> 8) & 0xff, f) != EOF &&
+           fputc((val >> 16) & 0xff, f) != EOF &&
+           fputc((val >> 24) & 0xff, f) != EOF;
 }
 } // namespace
 
@@ -97,37 +97,43 @@ bool WavRecorder::has_error() const {
 void WavRecorder::write_header() {
     uint32_t byte_rate = sample_rate_ * channels_ * (bits_per_sample_ / 8);
     uint16_t block_align = static_cast<uint16_t>(channels_ * (bits_per_sample_ / 8));
+    bool ok = true;
 
     // RIFF header
-    fwrite("RIFF", 1, 4, file_);
-    write_le_u32(0, file_);  // file size placeholder, will be patched
-    fwrite("WAVE", 1, 4, file_);
+    ok = ok && fwrite("RIFF", 1, 4, file_) == 4;
+    ok = ok && write_le_u32(0, file_);  // file size placeholder, will be patched
+    ok = ok && fwrite("WAVE", 1, 4, file_) == 4;
 
     // fmt sub-chunk
-    fwrite("fmt ", 1, 4, file_);
-    write_le_u32(16, file_);           // fmt chunk size
-    write_le_u16(1, file_);            // audio format = PCM
-    write_le_u16(channels_, file_);
-    write_le_u32(sample_rate_, file_);
-    write_le_u32(byte_rate, file_);
-    write_le_u16(block_align, file_);
-    write_le_u16(bits_per_sample_, file_);
+    ok = ok && fwrite("fmt ", 1, 4, file_) == 4;
+    ok = ok && write_le_u32(16, file_);           // fmt chunk size
+    ok = ok && write_le_u16(1, file_);            // audio format = PCM
+    ok = ok && write_le_u16(channels_, file_);
+    ok = ok && write_le_u32(sample_rate_, file_);
+    ok = ok && write_le_u32(byte_rate, file_);
+    ok = ok && write_le_u16(block_align, file_);
+    ok = ok && write_le_u16(bits_per_sample_, file_);
 
     // data sub-chunk
-    fwrite("data", 1, 4, file_);
-    write_le_u32(0, file_);  // data size placeholder, will be patched
+    ok = ok && fwrite("data", 1, 4, file_) == 4;
+    ok = ok && write_le_u32(0, file_);  // data size placeholder, will be patched
+
+    if (!ok) error_ = true;
 }
 
 // Seek back to the header and patch the file size and data size fields.
 void WavRecorder::finalize_header() {
+    bool ok = true;
+
     // Patch data sub-chunk size at offset 40
-    fseek(file_, 40, SEEK_SET);
-    write_le_u32(data_bytes_, file_);
+    ok = ok && fseek(file_, 40, SEEK_SET) == 0;
+    ok = ok && write_le_u32(data_bytes_, file_);
 
     // Patch RIFF chunk size at offset 4: total file size - 8
     uint32_t riff_size = data_bytes_ + 36;  // 44 - 8 = 36 bytes of header after RIFF size
-    fseek(file_, 4, SEEK_SET);
-    write_le_u32(riff_size, file_);
+    ok = ok && fseek(file_, 4, SEEK_SET) == 0;
+    ok = ok && write_le_u32(riff_size, file_);
 
     fflush(file_);
+    if (!ok) error_ = true;
 }

--- a/src/wav_recorder.cpp
+++ b/src/wav_recorder.cpp
@@ -134,6 +134,7 @@ void WavRecorder::finalize_header() {
     ok = ok && fseek(file_, 4, SEEK_SET) == 0;
     ok = ok && write_le_u32(riff_size, file_);
 
-    fflush(file_);
-    if (!ok) error_ = true;
+    if (!ok || fflush(file_) != 0) {
+        error_ = true;
+    }
 }

--- a/src/ym_recorder.cpp
+++ b/src/ym_recorder.cpp
@@ -144,13 +144,15 @@ bool YmRecorder::write_ym5_file() {
     // 14 blocks, each block is num_frames bytes (one byte per frame for that register)
     for (int reg = 0; reg < NUM_REGISTERS && ok; reg++) {
         for (uint32_t frame = 0; frame < num_frames && ok; frame++) {
-            ok = fputc(frames_[frame][reg], f) != EOF;
+            ok = ok && (fputc(frames_[frame][reg], f) != EOF);
         }
     }
 
     // 14. End marker: "End!"
     ok = ok && fwrite("End!", 1, 4, f) == 4;
 
-    fclose(f);
+    if (fclose(f) != 0) {
+        ok = false;
+    }
     return ok;
 }

--- a/src/ym_recorder.h
+++ b/src/ym_recorder.h
@@ -21,6 +21,7 @@ public:
     void capture_frame(const uint8_t* regs);
 
     bool is_recording() const;
+    bool has_error() const;
     uint32_t frame_count() const;
     std::string current_path() const;
 
@@ -30,6 +31,7 @@ private:
     std::string path_;
     std::vector<std::array<uint8_t, 14>> frames_;
     bool recording_ = false;
+    bool error_ = false;
     mutable std::mutex mutex_;
 
     bool write_ym5_file();


### PR DESCRIPTION
## Summary

- **YM recorder**: `write_ym5_file()` now checks every `fwrite`/`fputc` return value using a `bool ok` accumulator. `stop()` checks the return and sets `error_` flag. Added `has_error()` accessor
- **WAV recorder**: `write_header()` and `finalize_header()` now check all write and `fseek` return values, setting `error_` on failure
- Both recorders' byte-order helpers (`write_be_u16/u32`, `write_le_u16/u32`) now return `bool` to propagate I/O errors

Note: WAV header already uses byte-wise writes (not `memcpy`/`fwrite` on raw ints), so endianness is already handled correctly.

Closes beads: konCePCja-65z (P1)

## Test plan

- [x] All 622 tests pass (620 passed, 2 skipped)
- [x] All 23 YmRecorder + WavRecorder tests pass
- [ ] CI passes on macOS + MINGW32 + MINGW64