### PR TITLE
test: rewrite CRTC tests to use production I/O handlers

### DIFF
--- a/test/crtc_types.cpp
+++ b/test/crtc_types.cpp
@@ -41,7 +41,7 @@ class CrtcTypesTest : public testing::Test {
 protected:
    void SetUp() override {
       memset(&CRTC, 0, sizeof(CRTC));
-      memset(&z80, 0, sizeof(z80));
+      z80 = t_z80regs();
       CRTC.registers[0] = 0x3f;
       CRTC.registers[2] = 0x2e;
       CRTC.registers[3] = 0x8e;

--- a/test/crtc_types.cpp
+++ b/test/crtc_types.cpp
@@ -3,19 +3,53 @@
 
 #include "koncepcja.h"
 #include "crtc.h"
+#include "z80.h"
 
 extern t_CPC CPC;
 extern t_CRTC CRTC;
+extern t_z80regs z80;
+
+// Port addresses for CRTC I/O (active when bit 6 of high byte is clear)
+// 0xBCxx = register select (port.b.h & 3 == 0)
+// 0xBDxx = register write  (port.b.h & 3 == 1)
+// 0xBExx = status read     (port.b.h & 3 == 2)
+// 0xBFxx = register read   (port.b.h & 3 == 3)
+
+static reg_pair make_port(word addr) {
+   reg_pair p;
+   p.w.l = addr;
+   return p;
+}
+
+static const reg_pair PORT_REG_SELECT = make_port(0xBC00);
+static const reg_pair PORT_REG_WRITE  = make_port(0xBD00);
+static const reg_pair PORT_REG_READ   = make_port(0xBF00);
+
+// Helper: select a CRTC register and read it via z80_IN_handler
+static byte crtc_read_register(byte reg) {
+   z80_OUT_handler(PORT_REG_SELECT, reg);
+   return z80_IN_handler(PORT_REG_READ);
+}
+
+// Helper: select a CRTC register and write a value via z80_OUT_handler
+static void crtc_write_register(byte reg, byte val) {
+   z80_OUT_handler(PORT_REG_SELECT, reg);
+   z80_OUT_handler(PORT_REG_WRITE, val);
+}
 
 class CrtcTypesTest : public testing::Test {
 protected:
    void SetUp() override {
       memset(&CRTC, 0, sizeof(CRTC));
+      memset(&z80, 0, sizeof(z80));
       CRTC.registers[0] = 0x3f;
       CRTC.registers[2] = 0x2e;
       CRTC.registers[3] = 0x8e;
+      CPC.model = 2;  // default to 6128
    }
 };
+
+// --- crtc_type_for_model() ---
 
 TEST_F(CrtcTypesTest, DefaultTypeForCPC464) { EXPECT_EQ(0, crtc_type_for_model(0)); }
 TEST_F(CrtcTypesTest, DefaultTypeForCPC664) { EXPECT_EQ(0, crtc_type_for_model(1)); }
@@ -23,116 +57,111 @@ TEST_F(CrtcTypesTest, DefaultTypeForCPC6128) { EXPECT_EQ(1, crtc_type_for_model(
 TEST_F(CrtcTypesTest, DefaultTypeForPlus) { EXPECT_EQ(3, crtc_type_for_model(3)); }
 TEST_F(CrtcTypesTest, DefaultTypeForUnknownModel) { EXPECT_EQ(0, crtc_type_for_model(99)); }
 
+// --- R3 VSYNC width via z80_OUT_handler ---
+// Writing R3 sets hsw (lower nibble) and vsw (upper nibble, type-dependent)
+
 TEST_F(CrtcTypesTest, R3VsyncWidthType0UsesUpperBits) {
    CRTC.crtc_type = 0;
-   CRTC.hsw = 0x4e & 0x0f;
-   CRTC.vsw = 0x4e >> 4;
+   crtc_write_register(3, 0x4E);
    EXPECT_EQ(14u, CRTC.hsw);
    EXPECT_EQ(4u, CRTC.vsw);
 }
 
 TEST_F(CrtcTypesTest, R3VsyncWidthType1FixedAt16) {
    CRTC.crtc_type = 1;
-   CRTC.hsw = 0x4e & 0x0f;
-   CRTC.vsw = 0;
-   EXPECT_EQ(0u, CRTC.vsw);
+   crtc_write_register(3, 0x4E);
+   EXPECT_EQ(14u, CRTC.hsw);
+   EXPECT_EQ(0u, CRTC.vsw);  // Types 1/2: VSYNC width fixed (0 = 16 lines)
 }
 
 TEST_F(CrtcTypesTest, R3VsyncWidthType2FixedAt16) {
    CRTC.crtc_type = 2;
-   CRTC.hsw = 0x8e & 0x0f;
-   CRTC.vsw = 0;
+   crtc_write_register(3, 0x8E);
+   EXPECT_EQ(14u, CRTC.hsw);
    EXPECT_EQ(0u, CRTC.vsw);
 }
 
 TEST_F(CrtcTypesTest, R3VsyncWidthType3UsesUpperBits) {
    CRTC.crtc_type = 3;
-   CRTC.hsw = 0x5e & 0x0f;
-   CRTC.vsw = 0x5e >> 4;
+   crtc_write_register(3, 0x5E);
+   EXPECT_EQ(14u, CRTC.hsw);
    EXPECT_EQ(5u, CRTC.vsw);
 }
 
+// --- Register read tests via z80_IN_handler ---
+// Each CRTC type has different readable register ranges
+
 TEST_F(CrtcTypesTest, Type0ReturnsZeroForWriteOnlyRegs) {
    CRTC.crtc_type = 0;
-   CRTC.registers[0] = 0x3f;
-   byte reg = 0;
-   byte result = (reg >= 12 && reg <= 17) ? CRTC.registers[reg] : 0;
-   EXPECT_EQ(0, result);
+   CRTC.registers[0] = 0x3F;
+   EXPECT_EQ(0, crtc_read_register(0));  // R0 is write-only on all types
 }
 
 TEST_F(CrtcTypesTest, Type0CanReadR12R13) {
    CRTC.crtc_type = 0;
    CRTC.registers[12] = 0x30;
    CRTC.registers[13] = 0x42;
-   byte r12 = (12 >= 12 && 12 <= 17) ? CRTC.registers[12] : 0;
-   byte r13 = (13 >= 12 && 13 <= 17) ? CRTC.registers[13] : 0;
-   EXPECT_EQ(0x30, r12);
-   EXPECT_EQ(0x42, r13);
+   EXPECT_EQ(0x30, crtc_read_register(12));
+   EXPECT_EQ(0x42, crtc_read_register(13));
 }
 
 TEST_F(CrtcTypesTest, Type1CannotReadR12R13) {
    CRTC.crtc_type = 1;
    CRTC.registers[12] = 0x30;
-   // Type 1: R12 is write-only, returns 0
-   byte reg = 12;
-   byte result = (reg >= 14 && reg <= 17) ? CRTC.registers[reg] : (reg == 31 ? 0xff : 0);
-   EXPECT_EQ(0, result);
+   EXPECT_EQ(0, crtc_read_register(12));  // Type 1: R12 is write-only
 }
 
 TEST_F(CrtcTypesTest, Type1CanReadR14R15) {
    CRTC.crtc_type = 1;
    CRTC.registers[14] = 0x10;
-   byte reg = 14;
-   byte result = (reg >= 14 && reg <= 17) ? CRTC.registers[reg] : (reg == 31 ? 0xff : 0);
-   EXPECT_EQ(0x10, result);
+   EXPECT_EQ(0x10, crtc_read_register(14));
 }
 
 TEST_F(CrtcTypesTest, Type1R31ReturnsFF) {
    CRTC.crtc_type = 1;
-   byte reg = 31;
-   byte result = (reg >= 14 && reg <= 17) ? CRTC.registers[reg] : (reg == 31 ? 0xff : 0);
-   EXPECT_EQ(0xff, result);
+   EXPECT_EQ(0xFF, crtc_read_register(31));
 }
 
 TEST_F(CrtcTypesTest, Type2CannotReadR12R13) {
    CRTC.crtc_type = 2;
    CRTC.registers[12] = 0x30;
-   byte reg = 12;
-   byte result = (reg >= 14 && reg <= 17) ? CRTC.registers[reg] : 0;
-   EXPECT_EQ(0, result);
+   EXPECT_EQ(0, crtc_read_register(12));
 }
 
 TEST_F(CrtcTypesTest, Type3CanReadR12R13) {
    CRTC.crtc_type = 3;
    CRTC.registers[12] = 0x30;
-   byte reg = 12;
-   byte result = (reg >= 12 && reg <= 17) ? CRTC.registers[reg] : 0;
-   EXPECT_EQ(0x30, result);
+   EXPECT_EQ(0x30, crtc_read_register(12));
 }
+
+// --- R8 write behaviour via z80_OUT_handler ---
+// Type 0/3: full 8 bits stored. Type 1/2: only bits 0-1 (interlace mode).
 
 TEST_F(CrtcTypesTest, R8Type0FullRegister) {
    CRTC.crtc_type = 0;
-   CRTC.registers[8] = 0x33;
+   crtc_write_register(8, 0x33);
    EXPECT_EQ(0x33, CRTC.registers[8]);
 }
 
 TEST_F(CrtcTypesTest, R8Type1OnlyInterlaceBits) {
    CRTC.crtc_type = 1;
-   CRTC.registers[8] = 0x33 & 0x03;
-   EXPECT_EQ(0x03, CRTC.registers[8]);
+   crtc_write_register(8, 0x33);
+   EXPECT_EQ(0x03, CRTC.registers[8]);  // Type 1: masked to val & 0x03 on write
 }
 
 TEST_F(CrtcTypesTest, R8Type2OnlyInterlaceBits) {
    CRTC.crtc_type = 2;
-   CRTC.registers[8] = 0x33 & 0x03;
-   EXPECT_EQ(0x03, CRTC.registers[8]);
+   crtc_write_register(8, 0x33);
+   EXPECT_EQ(0x03, CRTC.registers[8]);  // Type 2: masked to val & 0x03 on write
 }
 
 TEST_F(CrtcTypesTest, R8Type3FullRegister) {
    CRTC.crtc_type = 3;
-   CRTC.registers[8] = 0x33;
+   crtc_write_register(8, 0x33);
    EXPECT_EQ(0x33, CRTC.registers[8]);
 }
+
+// --- Type field tests ---
 
 TEST_F(CrtcTypesTest, SettingTypeChangesField) {
    CRTC.crtc_type = 0;
@@ -149,6 +178,8 @@ TEST_F(CrtcTypesTest, ValidTypeRange) {
       EXPECT_EQ(t, CRTC.crtc_type);
    }
 }
+
+// --- R12/R13 address update tests ---
 
 TEST_F(CrtcTypesTest, Type1R12R13ImmediateUpdateWhenVCC0) {
    CRTC.crtc_type = 1;
@@ -185,6 +216,8 @@ TEST_F(CrtcTypesTest, Type0R12R13AlwaysDeferred) {
    EXPECT_EQ(0x1020u, CRTC.requested_addr);
    EXPECT_EQ(0u, CRTC.addr);
 }
+
+// --- Chip info tests (pure functions) ---
 
 TEST_F(CrtcTypesTest, ChipNameType0) { EXPECT_STREQ("HD6845S", crtc_type_chip_name(0)); }
 TEST_F(CrtcTypesTest, ChipNameType1) { EXPECT_STREQ("UM6845R", crtc_type_chip_name(1)); }


### PR DESCRIPTION
## Summary
- Rewrote `test/crtc_types.cpp` to call `z80_IN_handler()`/`z80_OUT_handler()` via helper functions instead of reimplementing register read/write logic inline
- Uncovered that R8 on CRTC types 1/2 is masked to `val & 0x03` during the OUT handler — old tests manually applied the mask, hiding actual hardware behavior
- Investigated search engine hex case sensitivity (bead 1zh) — confirmed not a bug: `match_pattern` takes explicit `bool case_insensitive`, HEX mode passes `false`

## Test plan
- [x] All 622 tests pass (620 passed, 2 skipped)
- [x] CRTC register read tests verify actual I/O handler behavior per type (0-3)
- [x] R3 hsw/vsw tests verify write masking per CRTC type
- [x] R8 interlace tests now correctly expect `0x03` for types 1/2 (masked on write)