### PR TITLE
refactor: code quality cleanup — dedup, exceptions, constants

### DIFF
--- a/src/autotype.cpp
+++ b/src/autotype.cpp
@@ -1,75 +1,21 @@
 #include "autotype.h"
-#include "keyboard.h"
-#include <map>
+#include "cpc_key_tables.h"
 #include <cctype>
 #include <cstdlib>
 
 AutoTypeQueue g_autotype_queue;
-
-// Key name map: matches ipc_key_names from koncepcja_ipc_server.cpp
-static const std::map<std::string, CPC_KEYS> autotype_key_names = {
-  {"ESC", CPC_ESC}, {"RETURN", CPC_RETURN}, {"ENTER", CPC_RETURN},
-  {"SPACE", CPC_SPACE}, {"TAB", CPC_TAB}, {"DEL", CPC_DEL},
-  {"COPY", CPC_COPY}, {"CONTROL", CPC_CONTROL}, {"CTRL", CPC_CONTROL},
-  {"SHIFT", CPC_LSHIFT}, {"LSHIFT", CPC_LSHIFT}, {"RSHIFT", CPC_RSHIFT},
-  {"UP", CPC_CUR_UP}, {"DOWN", CPC_CUR_DOWN},
-  {"LEFT", CPC_CUR_LEFT}, {"RIGHT", CPC_CUR_RIGHT},
-  {"CLR", CPC_CLR},
-  {"F0", CPC_F0}, {"F1", CPC_F1}, {"F2", CPC_F2}, {"F3", CPC_F3},
-  {"F4", CPC_F4}, {"F5", CPC_F5}, {"F6", CPC_F6}, {"F7", CPC_F7},
-  {"F8", CPC_F8}, {"F9", CPC_F9},
-  // Joystick
-  {"J0_UP", CPC_J0_UP}, {"J0_DOWN", CPC_J0_DOWN},
-  {"J0_LEFT", CPC_J0_LEFT}, {"J0_RIGHT", CPC_J0_RIGHT},
-  {"J0_FIRE1", CPC_J0_FIRE1}, {"J0_FIRE2", CPC_J0_FIRE2},
-  {"J1_UP", CPC_J1_UP}, {"J1_DOWN", CPC_J1_DOWN},
-  {"J1_LEFT", CPC_J1_LEFT}, {"J1_RIGHT", CPC_J1_RIGHT},
-  {"J1_FIRE1", CPC_J1_FIRE1}, {"J1_FIRE2", CPC_J1_FIRE2},
-};
-
-// Char-to-key map: matches ipc_char_to_key from koncepcja_ipc_server.cpp
-static const std::map<char, CPC_KEYS> autotype_char_to_key = {
-  {'a', CPC_a}, {'b', CPC_b}, {'c', CPC_c}, {'d', CPC_d}, {'e', CPC_e},
-  {'f', CPC_f}, {'g', CPC_g}, {'h', CPC_h}, {'i', CPC_i}, {'j', CPC_j},
-  {'k', CPC_k}, {'l', CPC_l}, {'m', CPC_m}, {'n', CPC_n}, {'o', CPC_o},
-  {'p', CPC_p}, {'q', CPC_q}, {'r', CPC_r}, {'s', CPC_s}, {'t', CPC_t},
-  {'u', CPC_u}, {'v', CPC_v}, {'w', CPC_w}, {'x', CPC_x}, {'y', CPC_y},
-  {'z', CPC_z},
-  {'A', CPC_A}, {'B', CPC_B}, {'C', CPC_C}, {'D', CPC_D}, {'E', CPC_E},
-  {'F', CPC_F}, {'G', CPC_G}, {'H', CPC_H}, {'I', CPC_I}, {'J', CPC_J},
-  {'K', CPC_K}, {'L', CPC_L}, {'M', CPC_M}, {'N', CPC_N}, {'O', CPC_O},
-  {'P', CPC_P}, {'Q', CPC_Q}, {'R', CPC_R}, {'S', CPC_S}, {'T', CPC_T},
-  {'U', CPC_U}, {'V', CPC_V}, {'W', CPC_W}, {'X', CPC_X}, {'Y', CPC_Y},
-  {'Z', CPC_Z},
-  {'0', CPC_0}, {'1', CPC_1}, {'2', CPC_2}, {'3', CPC_3}, {'4', CPC_4},
-  {'5', CPC_5}, {'6', CPC_6}, {'7', CPC_7}, {'8', CPC_8}, {'9', CPC_9},
-  {' ', CPC_SPACE}, {'\n', CPC_RETURN}, {'\r', CPC_RETURN},
-  {'.', CPC_PERIOD}, {',', CPC_COMMA}, {';', CPC_SEMICOLON},
-  {':', CPC_COLON}, {'-', CPC_MINUS}, {'+', CPC_PLUS},
-  {'/', CPC_SLASH}, {'*', CPC_ASTERISK}, {'=', CPC_EQUAL},
-  {'(', CPC_LEFTPAREN}, {')', CPC_RIGHTPAREN},
-  {'[', CPC_LBRACKET}, {']', CPC_RBRACKET},
-  {'{', CPC_LCBRACE}, {'}', CPC_RCBRACE},
-  {'<', CPC_LESS}, {'>', CPC_GREATER},
-  {'?', CPC_QUESTION}, {'!', CPC_EXCLAMATN},
-  {'@', CPC_AT}, {'#', CPC_HASH}, {'$', CPC_DOLLAR},
-  {'%', CPC_PERCENT}, {'^', CPC_POWER}, {'&', CPC_AMPERSAND},
-  {'|', CPC_PIPE}, {'\\', CPC_BACKSLASH},
-  {'"', CPC_DBLQUOTE}, {'\'', CPC_QUOTE},
-  {'`', CPC_BACKQUOTE}, {'_', CPC_UNDERSCORE},
-};
 
 // Resolve a key name (case-insensitive) to CPC_KEYS enum value.
 // Returns -1 if not found.
 static int resolve_key_name(const std::string& name) {
   std::string upper = name;
   for (auto& c : upper) c = static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
-  auto it = autotype_key_names.find(upper);
-  if (it != autotype_key_names.end()) return static_cast<int>(it->second);
+  auto it = cpc_key_names().find(upper);
+  if (it != cpc_key_names().end()) return static_cast<int>(it->second);
   // Single char: try char map
   if (name.size() == 1) {
-    auto cit = autotype_char_to_key.find(name[0]);
-    if (cit != autotype_char_to_key.end()) return static_cast<int>(cit->second);
+    auto cit = cpc_char_to_key().find(name[0]);
+    if (cit != cpc_char_to_key().end()) return static_cast<int>(cit->second);
   }
   return -1;
 }
@@ -148,8 +94,8 @@ std::string AutoTypeQueue::enqueue(const std::string& text) {
 
     // Regular character
     char ch = text[i];
-    auto cit = autotype_char_to_key.find(ch);
-    if (cit == autotype_char_to_key.end()) {
+    auto cit = cpc_char_to_key().find(ch);
+    if (cit == cpc_char_to_key().end()) {
       // Skip unmappable characters (consistent with input type behavior)
       i++;
       continue;

--- a/src/config_profile.cpp
+++ b/src/config_profile.cpp
@@ -217,10 +217,8 @@ std::string ConfigProfileManager::read_profile(const std::string& path, ConfigPr
         unsigned int val;
         try {
             val = static_cast<unsigned int>(std::stoul(val_str));
-        } catch (const std::invalid_argument&) {
+        } catch (const std::logic_error&) {
             continue; // skip unparseable values
-        } catch (const std::out_of_range&) {
-            continue;
         }
 
         if (key == "model") p.model = val;

--- a/src/config_profile.cpp
+++ b/src/config_profile.cpp
@@ -3,6 +3,7 @@
 #include <filesystem>
 #include <fstream>
 #include <sstream>
+#include <stdexcept>
 #include <algorithm>
 #include <cctype>
 
@@ -216,8 +217,10 @@ std::string ConfigProfileManager::read_profile(const std::string& path, ConfigPr
         unsigned int val;
         try {
             val = static_cast<unsigned int>(std::stoul(val_str));
-        } catch (...) {
+        } catch (const std::invalid_argument&) {
             continue; // skip unparseable values
+        } catch (const std::out_of_range&) {
+            continue;
         }
 
         if (key == "model") p.model = val;

--- a/src/cpc_key_tables.h
+++ b/src/cpc_key_tables.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include "keyboard.h"
+#include <map>
+#include <string>
+
+// Shared key-name and char-to-key lookup tables.
+// Used by both the IPC server and the autotype subsystem.
+
+inline const std::map<std::string, CPC_KEYS>& cpc_key_names() {
+  static const std::map<std::string, CPC_KEYS> tbl = {
+    {"ESC", CPC_ESC}, {"RETURN", CPC_RETURN}, {"ENTER", CPC_RETURN},
+    {"SPACE", CPC_SPACE}, {"TAB", CPC_TAB}, {"DEL", CPC_DEL},
+    {"COPY", CPC_COPY}, {"CONTROL", CPC_CONTROL}, {"CTRL", CPC_CONTROL},
+    {"SHIFT", CPC_LSHIFT}, {"LSHIFT", CPC_LSHIFT}, {"RSHIFT", CPC_RSHIFT},
+    {"UP", CPC_CUR_UP}, {"DOWN", CPC_CUR_DOWN},
+    {"LEFT", CPC_CUR_LEFT}, {"RIGHT", CPC_CUR_RIGHT},
+    {"CLR", CPC_CLR},
+    {"F0", CPC_F0}, {"F1", CPC_F1}, {"F2", CPC_F2}, {"F3", CPC_F3},
+    {"F4", CPC_F4}, {"F5", CPC_F5}, {"F6", CPC_F6}, {"F7", CPC_F7},
+    {"F8", CPC_F8}, {"F9", CPC_F9},
+    // Joystick
+    {"J0_UP", CPC_J0_UP}, {"J0_DOWN", CPC_J0_DOWN},
+    {"J0_LEFT", CPC_J0_LEFT}, {"J0_RIGHT", CPC_J0_RIGHT},
+    {"J0_FIRE1", CPC_J0_FIRE1}, {"J0_FIRE2", CPC_J0_FIRE2},
+    {"J1_UP", CPC_J1_UP}, {"J1_DOWN", CPC_J1_DOWN},
+    {"J1_LEFT", CPC_J1_LEFT}, {"J1_RIGHT", CPC_J1_RIGHT},
+    {"J1_FIRE1", CPC_J1_FIRE1}, {"J1_FIRE2", CPC_J1_FIRE2},
+  };
+  return tbl;
+}
+
+inline const std::map<char, CPC_KEYS>& cpc_char_to_key() {
+  static const std::map<char, CPC_KEYS> tbl = {
+    {'a', CPC_a}, {'b', CPC_b}, {'c', CPC_c}, {'d', CPC_d}, {'e', CPC_e},
+    {'f', CPC_f}, {'g', CPC_g}, {'h', CPC_h}, {'i', CPC_i}, {'j', CPC_j},
+    {'k', CPC_k}, {'l', CPC_l}, {'m', CPC_m}, {'n', CPC_n}, {'o', CPC_o},
+    {'p', CPC_p}, {'q', CPC_q}, {'r', CPC_r}, {'s', CPC_s}, {'t', CPC_t},
+    {'u', CPC_u}, {'v', CPC_v}, {'w', CPC_w}, {'x', CPC_x}, {'y', CPC_y},
+    {'z', CPC_z},
+    {'A', CPC_A}, {'B', CPC_B}, {'C', CPC_C}, {'D', CPC_D}, {'E', CPC_E},
+    {'F', CPC_F}, {'G', CPC_G}, {'H', CPC_H}, {'I', CPC_I}, {'J', CPC_J},
+    {'K', CPC_K}, {'L', CPC_L}, {'M', CPC_M}, {'N', CPC_N}, {'O', CPC_O},
+    {'P', CPC_P}, {'Q', CPC_Q}, {'R', CPC_R}, {'S', CPC_S}, {'T', CPC_T},
+    {'U', CPC_U}, {'V', CPC_V}, {'W', CPC_W}, {'X', CPC_X}, {'Y', CPC_Y},
+    {'Z', CPC_Z},
+    {'0', CPC_0}, {'1', CPC_1}, {'2', CPC_2}, {'3', CPC_3}, {'4', CPC_4},
+    {'5', CPC_5}, {'6', CPC_6}, {'7', CPC_7}, {'8', CPC_8}, {'9', CPC_9},
+    {' ', CPC_SPACE}, {'\n', CPC_RETURN}, {'\r', CPC_RETURN},
+    {'.', CPC_PERIOD}, {',', CPC_COMMA}, {';', CPC_SEMICOLON},
+    {':', CPC_COLON}, {'-', CPC_MINUS}, {'+', CPC_PLUS},
+    {'/', CPC_SLASH}, {'*', CPC_ASTERISK}, {'=', CPC_EQUAL},
+    {'(', CPC_LEFTPAREN}, {')', CPC_RIGHTPAREN},
+    {'[', CPC_LBRACKET}, {']', CPC_RBRACKET},
+    {'{', CPC_LCBRACE}, {'}', CPC_RCBRACE},
+    {'<', CPC_LESS}, {'>', CPC_GREATER},
+    {'?', CPC_QUESTION}, {'!', CPC_EXCLAMATN},
+    {'@', CPC_AT}, {'#', CPC_HASH}, {'$', CPC_DOLLAR},
+    {'%', CPC_PERCENT}, {'^', CPC_POWER}, {'&', CPC_AMPERSAND},
+    {'|', CPC_PIPE}, {'\\', CPC_BACKSLASH},
+    {'"', CPC_DBLQUOTE}, {'\'', CPC_QUOTE},
+    {'`', CPC_BACKQUOTE}, {'_', CPC_UNDERSCORE},
+  };
+  return tbl;
+}

--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -2913,9 +2913,9 @@ int koncpc_main (int argc, char **argv)
 
    try {
      binPath = std::filesystem::absolute(std::filesystem::path(argv[0]).parent_path());
-   } catch(...) {
-     // Dirty fallback in case the executable is found in the path.
-     // binPath is only use for bundles anyway, where this is not the case.
+   } catch(const std::filesystem::filesystem_error&) {
+     // Fallback in case argv[0] is unresolvable (e.g. found via PATH).
+     // binPath is only used for bundles anyway.
      binPath = std::filesystem::absolute(".");
    }
    parseArguments(argc, argv, slot_list, args);

--- a/src/koncepcja_ipc_server.cpp
+++ b/src/koncepcja_ipc_server.cpp
@@ -37,6 +37,7 @@
 #include "disk_file_editor.h"
 #include "disk_sector_editor.h"
 #include "keyboard.h"
+#include "cpc_key_tables.h"
 #include "trace.h"
 #include "gif_recorder.h"
 #include "wav_recorder.h"
@@ -69,58 +70,7 @@ extern byte *memmap_ROM[256];
 extern byte *pbExpansionROM;
 extern byte *pbROMhi;
 
-// Friendly key names → CPC_KEYS for IPC input commands
-static const std::map<std::string, CPC_KEYS> ipc_key_names = {
-  {"ESC", CPC_ESC}, {"RETURN", CPC_RETURN}, {"ENTER", CPC_RETURN},
-  {"SPACE", CPC_SPACE}, {"TAB", CPC_TAB}, {"DEL", CPC_DEL},
-  {"COPY", CPC_COPY}, {"CONTROL", CPC_CONTROL}, {"CTRL", CPC_CONTROL},
-  {"SHIFT", CPC_LSHIFT}, {"LSHIFT", CPC_LSHIFT}, {"RSHIFT", CPC_RSHIFT},
-  {"UP", CPC_CUR_UP}, {"DOWN", CPC_CUR_DOWN},
-  {"LEFT", CPC_CUR_LEFT}, {"RIGHT", CPC_CUR_RIGHT},
-  {"CLR", CPC_CLR},
-  {"F0", CPC_F0}, {"F1", CPC_F1}, {"F2", CPC_F2}, {"F3", CPC_F3},
-  {"F4", CPC_F4}, {"F5", CPC_F5}, {"F6", CPC_F6}, {"F7", CPC_F7},
-  {"F8", CPC_F8}, {"F9", CPC_F9},
-  // Joystick
-  {"J0_UP", CPC_J0_UP}, {"J0_DOWN", CPC_J0_DOWN},
-  {"J0_LEFT", CPC_J0_LEFT}, {"J0_RIGHT", CPC_J0_RIGHT},
-  {"J0_FIRE1", CPC_J0_FIRE1}, {"J0_FIRE2", CPC_J0_FIRE2},
-  {"J1_UP", CPC_J1_UP}, {"J1_DOWN", CPC_J1_DOWN},
-  {"J1_LEFT", CPC_J1_LEFT}, {"J1_RIGHT", CPC_J1_RIGHT},
-  {"J1_FIRE1", CPC_J1_FIRE1}, {"J1_FIRE2", CPC_J1_FIRE2},
-};
-
-// Char → CPC_KEYS for text typing
-static const std::map<char, CPC_KEYS> ipc_char_to_key = {
-  {'a', CPC_a}, {'b', CPC_b}, {'c', CPC_c}, {'d', CPC_d}, {'e', CPC_e},
-  {'f', CPC_f}, {'g', CPC_g}, {'h', CPC_h}, {'i', CPC_i}, {'j', CPC_j},
-  {'k', CPC_k}, {'l', CPC_l}, {'m', CPC_m}, {'n', CPC_n}, {'o', CPC_o},
-  {'p', CPC_p}, {'q', CPC_q}, {'r', CPC_r}, {'s', CPC_s}, {'t', CPC_t},
-  {'u', CPC_u}, {'v', CPC_v}, {'w', CPC_w}, {'x', CPC_x}, {'y', CPC_y},
-  {'z', CPC_z},
-  {'A', CPC_A}, {'B', CPC_B}, {'C', CPC_C}, {'D', CPC_D}, {'E', CPC_E},
-  {'F', CPC_F}, {'G', CPC_G}, {'H', CPC_H}, {'I', CPC_I}, {'J', CPC_J},
-  {'K', CPC_K}, {'L', CPC_L}, {'M', CPC_M}, {'N', CPC_N}, {'O', CPC_O},
-  {'P', CPC_P}, {'Q', CPC_Q}, {'R', CPC_R}, {'S', CPC_S}, {'T', CPC_T},
-  {'U', CPC_U}, {'V', CPC_V}, {'W', CPC_W}, {'X', CPC_X}, {'Y', CPC_Y},
-  {'Z', CPC_Z},
-  {'0', CPC_0}, {'1', CPC_1}, {'2', CPC_2}, {'3', CPC_3}, {'4', CPC_4},
-  {'5', CPC_5}, {'6', CPC_6}, {'7', CPC_7}, {'8', CPC_8}, {'9', CPC_9},
-  {' ', CPC_SPACE}, {'\n', CPC_RETURN}, {'\r', CPC_RETURN},
-  {'.', CPC_PERIOD}, {',', CPC_COMMA}, {';', CPC_SEMICOLON},
-  {':', CPC_COLON}, {'-', CPC_MINUS}, {'+', CPC_PLUS},
-  {'/', CPC_SLASH}, {'*', CPC_ASTERISK}, {'=', CPC_EQUAL},
-  {'(', CPC_LEFTPAREN}, {')', CPC_RIGHTPAREN},
-  {'[', CPC_LBRACKET}, {']', CPC_RBRACKET},
-  {'{', CPC_LCBRACE}, {'}', CPC_RCBRACE},
-  {'<', CPC_LESS}, {'>', CPC_GREATER},
-  {'?', CPC_QUESTION}, {'!', CPC_EXCLAMATN},
-  {'@', CPC_AT}, {'#', CPC_HASH}, {'$', CPC_DOLLAR},
-  {'%', CPC_PERCENT}, {'^', CPC_POWER}, {'&', CPC_AMPERSAND},
-  {'|', CPC_PIPE}, {'\\', CPC_BACKSLASH},
-  {'"', CPC_DBLQUOTE}, {'\'', CPC_QUOTE},
-  {'`', CPC_BACKQUOTE}, {'_', CPC_UNDERSCORE},
-};
+// Key tables are in cpc_key_tables.h (shared with autotype.cpp)
 
 extern byte bit_values[];
 
@@ -1170,14 +1120,14 @@ std::string handle_command(const std::string& line) {
       // Try friendly short names first (case-insensitive)
       std::string upper = name;
       for (auto& c : upper) c = static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
-      auto it = ipc_key_names.find(upper);
-      if (it != ipc_key_names.end()) {
+      auto it = cpc_key_names().find(upper);
+      if (it != cpc_key_names().end()) {
         return {true, CPC.InputMapper->CPCscancodeFromCPCkey(it->second)};
       }
       // Single char shortcut: "A" → CPC_A, "a" → CPC_a, "1" → CPC_1
       if (name.size() == 1) {
-        auto charIt = ipc_char_to_key.find(name[0]);
-        if (charIt != ipc_char_to_key.end()) {
+        auto charIt = cpc_char_to_key().find(name[0]);
+        if (charIt != cpc_char_to_key().end()) {
           return {true, CPC.InputMapper->CPCscancodeFromCPCkey(charIt->second)};
         }
       }
@@ -1225,8 +1175,8 @@ std::string handle_command(const std::string& line) {
         text = text.substr(1, text.size() - 2);
       }
       for (char ch : text) {
-        auto charIt = ipc_char_to_key.find(ch);
-        if (charIt == ipc_char_to_key.end()) continue; // skip unmappable chars
+        auto charIt = cpc_char_to_key().find(ch);
+        if (charIt == cpc_char_to_key().end()) continue; // skip unmappable chars
         CPCScancode scancode = CPC.InputMapper->CPCscancodeFromCPCkey(charIt->second);
         // Set key in matrix before resuming (bypasses CPC.paused guard)
         ipc_apply_keypress(scancode, keyboard_matrix, true);
@@ -2087,8 +2037,7 @@ std::string handle_command(const std::string& line) {
       if (parts.size() < 3) return "ERR 400 missing-action (start|stop|status)\n";
       if (parts[2] == "start") {
         if (parts.size() < 4) return "ERR 400 missing-path\n";
-        static const unsigned int wav_rates[] = {11025, 22050, 44100, 48000, 96000};
-        uint32_t rate = wav_rates[CPC.snd_playback_rate];
+        uint32_t rate = SAMPLE_RATES[CPC.snd_playback_rate];
         uint16_t bits = CPC.snd_bits ? 16 : 8;
         uint16_t channels = CPC.snd_stereo ? 2 : 1;
         auto err = g_wav_recorder.start(parts[3], rate, bits, channels);
@@ -2141,8 +2090,7 @@ std::string handle_command(const std::string& line) {
         if (parts.size() >= 5) {
           try { quality = std::stoi(parts[4]); } catch (const std::exception&) {}
         }
-        static const unsigned int wav_rates[] = {11025, 22050, 44100, 48000, 96000};
-        uint32_t rate = wav_rates[CPC.snd_playback_rate];
+        uint32_t rate = SAMPLE_RATES[CPC.snd_playback_rate];
         uint16_t bits = CPC.snd_bits ? 16 : 8;
         uint16_t channels = CPC.snd_stereo ? 2 : 1;
         auto err = g_avi_recorder.start(parts[3], quality, rate, channels, bits);

--- a/src/search_engine.cpp
+++ b/src/search_engine.cpp
@@ -27,9 +27,8 @@ std::vector<PatternElement> compile_hex_pattern(const std::string& pattern) {
           unsigned int val = 0;
           try {
             val = std::stoul(pair, nullptr, 16);
-          } catch (const std::invalid_argument&) {
-            continue;
-          } catch (const std::out_of_range&) {
+          } catch (const std::logic_error&) {
+            // Skip invalid hex
             continue;
           }
           result.push_back({PatternElement::LITERAL, static_cast<uint8_t>(val)});

--- a/src/search_engine.cpp
+++ b/src/search_engine.cpp
@@ -4,6 +4,7 @@
 #include <cctype>
 #include <iomanip>
 #include <sstream>
+#include <stdexcept>
 
 namespace search_detail {
 
@@ -26,8 +27,9 @@ std::vector<PatternElement> compile_hex_pattern(const std::string& pattern) {
           unsigned int val = 0;
           try {
             val = std::stoul(pair, nullptr, 16);
-          } catch (...) {
-            // Skip invalid hex
+          } catch (const std::invalid_argument&) {
+            continue;
+          } catch (const std::out_of_range&) {
             continue;
           }
           result.push_back({PatternElement::LITERAL, static_cast<uint8_t>(val)});

--- a/test/ipc_server.cpp
+++ b/test/ipc_server.cpp
@@ -201,7 +201,8 @@ TEST_F(IpcServerTest, WaitVblCompletes) {
 
 TEST_F(IpcServerTest, ScreenshotReturnsErrorWithoutSurface) {
   back_surface = nullptr;
-  auto resp = send_command("screenshot /tmp/kaprys_test.png");
+  auto screenshotPath = (std::filesystem::temp_directory_path() / "kaprys_test.png").string();
+  auto resp = send_command("screenshot " + screenshotPath);
   EXPECT_EQ(resp, "ERR 503 no-surface\n");
 }
 

--- a/test/rom_slots.cpp
+++ b/test/rom_slots.cpp
@@ -140,7 +140,7 @@ class RomSlotsTest : public testing::Test {
       membank_read[i] = memory[i];
       membank_write[i] = memory[i];
     }
-    for (int i = 2; i < 32; i++) {
+    for (int i = 2; i < MAX_ROM_SLOTS; i++) {
       if (memmap_ROM[i] != nullptr) {
         delete[] memmap_ROM[i];
         memmap_ROM[i] = nullptr;
@@ -156,7 +156,7 @@ class RomSlotsTest : public testing::Test {
   }
 
   void TearDown() override {
-    for (int i = 2; i < 32; i++) {
+    for (int i = 2; i < MAX_ROM_SLOTS; i++) {
       if (memmap_ROM[i] != nullptr) {
         delete[] memmap_ROM[i];
         memmap_ROM[i] = nullptr;
@@ -285,14 +285,14 @@ TEST_F(RomSlotsTest, RomInfoRejectsSlot32) {
   EXPECT_TRUE(resp.find("ERR 400 slot must be 0-31") != std::string::npos);
 }
 
-TEST_F(RomSlotsTest, ArraySizeIs32) {
-  for (int i = 0; i < 32; i++) {
+TEST_F(RomSlotsTest, ArraySizeIsMaxRomSlots) {
+  for (int i = 0; i < MAX_ROM_SLOTS; i++) {
     CPC.rom_file[i] = "slot_" + std::to_string(i);
   }
-  for (int i = 0; i < 32; i++) {
+  for (int i = 0; i < MAX_ROM_SLOTS; i++) {
     EXPECT_EQ(CPC.rom_file[i], "slot_" + std::to_string(i));
   }
-  for (int i = 0; i < 32; i++) {
+  for (int i = 0; i < MAX_ROM_SLOTS; i++) {
     CPC.rom_file[i] = "";
   }
 }
@@ -301,16 +301,16 @@ TEST_F(RomSlotsTest, BackwardCompatibility16SlotConfig) {
   for (int i = 0; i < 16; i++) {
     CPC.rom_file[i] = "legacy_rom_" + std::to_string(i);
   }
-  for (int i = 16; i < 32; i++) {
+  for (int i = 16; i < MAX_ROM_SLOTS; i++) {
     CPC.rom_file[i] = "";
   }
   for (int i = 0; i < 16; i++) {
     EXPECT_EQ(CPC.rom_file[i], "legacy_rom_" + std::to_string(i));
   }
-  for (int i = 16; i < 32; i++) {
+  for (int i = 16; i < MAX_ROM_SLOTS; i++) {
     EXPECT_EQ(CPC.rom_file[i], "");
   }
-  for (int i = 0; i < 32; i++) {
+  for (int i = 0; i < MAX_ROM_SLOTS; i++) {
     CPC.rom_file[i] = "";
   }
 }


### PR DESCRIPTION
## Summary
- Extract shared CPC key tables to `cpc_key_tables.h`, removing ~100 lines of duplication between `autotype.cpp` and `koncepcja_ipc_server.cpp`
- Replace `catch(...)` with specific exception types (`std::invalid_argument`, `std::out_of_range`, `std::filesystem::filesystem_error`) in 3 files
- Replace hardcoded `32` with `MAX_ROM_SLOTS` in `test/rom_slots.cpp` loop bounds
- Replace duplicate `wav_rates` arrays with shared `SAMPLE_RATES` constant from `imgui_ui_testable.h`
- Fix hardcoded `/tmp` in `test/ipc_server.cpp` screenshot test for MINGW portability

## Test plan
- [x] All 622 tests pass (620 passed, 2 skipped)
- [x] Zero compiler warnings
- [x] Key tables work identically via inline function returning static const map
- [x] ROM slot boundary tests still validate OOB input with literal "32" strings