### PR TITLE
feat: debugger UI enhancements

### DIFF
--- a/src/devtools_ui.cpp
+++ b/src/devtools_ui.cpp
@@ -10,6 +10,10 @@
 #include "z80.h"
 #include "z80_disassembly.h"
 #include "symfile.h"
+#include "data_areas.h"
+
+#include <fstream>
+#include <sstream>
 
 extern t_CPC CPC;
 extern t_z80regs z80;
@@ -22,12 +26,14 @@ DevToolsUI g_devtools_ui;
 
 bool* DevToolsUI::window_ptr(const std::string& name)
 {
-  if (name == "registers")   return &show_registers_;
-  if (name == "disassembly") return &show_disassembly_;
-  if (name == "memory_hex")  return &show_memory_hex_;
-  if (name == "stack")       return &show_stack_;
-  if (name == "breakpoints") return &show_breakpoints_;
-  if (name == "symbols")     return &show_symbols_;
+  if (name == "registers")    return &show_registers_;
+  if (name == "disassembly")  return &show_disassembly_;
+  if (name == "memory_hex")   return &show_memory_hex_;
+  if (name == "stack")        return &show_stack_;
+  if (name == "breakpoints")  return &show_breakpoints_;
+  if (name == "symbols")      return &show_symbols_;
+  if (name == "data_areas")   return &show_data_areas_;
+  if (name == "disasm_export") return &show_disasm_export_;
   return nullptr;
 }
 
@@ -39,19 +45,22 @@ void DevToolsUI::toggle_window(const std::string& name)
 
 bool DevToolsUI::is_window_open(const std::string& name) const
 {
-  if (name == "registers")   return show_registers_;
-  if (name == "disassembly") return show_disassembly_;
-  if (name == "memory_hex")  return show_memory_hex_;
-  if (name == "stack")       return show_stack_;
-  if (name == "breakpoints") return show_breakpoints_;
-  if (name == "symbols")     return show_symbols_;
+  if (name == "registers")    return show_registers_;
+  if (name == "disassembly")  return show_disassembly_;
+  if (name == "memory_hex")   return show_memory_hex_;
+  if (name == "stack")        return show_stack_;
+  if (name == "breakpoints")  return show_breakpoints_;
+  if (name == "symbols")      return show_symbols_;
+  if (name == "data_areas")   return show_data_areas_;
+  if (name == "disasm_export") return show_disasm_export_;
   return false;
 }
 
 bool DevToolsUI::any_window_open() const
 {
   return show_registers_ || show_disassembly_ || show_memory_hex_ ||
-         show_stack_ || show_breakpoints_ || show_symbols_;
+         show_stack_ || show_breakpoints_ || show_symbols_ ||
+         show_data_areas_ || show_disasm_export_;
 }
 
 void DevToolsUI::navigate_disassembly(word addr)
@@ -68,12 +77,14 @@ void DevToolsUI::navigate_disassembly(word addr)
 
 void DevToolsUI::render()
 {
-  if (show_registers_)   render_registers();
-  if (show_disassembly_) render_disassembly();
-  if (show_memory_hex_)  render_memory_hex();
-  if (show_stack_)       render_stack();
-  if (show_breakpoints_) render_breakpoints();
-  if (show_symbols_)     render_symbols();
+  if (show_registers_)    render_registers();
+  if (show_disassembly_)  render_disassembly();
+  if (show_memory_hex_)   render_memory_hex();
+  if (show_stack_)        render_stack();
+  if (show_breakpoints_)  render_breakpoints();
+  if (show_symbols_)      render_symbols();
+  if (show_data_areas_)   render_data_areas();
+  if (show_disasm_export_) render_disasm_export();
 }
 
 // -----------------------------------------------
@@ -618,6 +629,61 @@ void DevToolsUI::render_breakpoints()
     ImGui::EndTable();
   }
 
+  // Add Watchpoint form
+  ImGui::Spacing();
+  if (ImGui::CollapsingHeader("Add Watchpoint")) {
+    ImGui::SetNextItemWidth(60);
+    ImGui::InputText("Addr##wp", wp_addr_, sizeof(wp_addr_),
+                     ImGuiInputTextFlags_CharsHexadecimal);
+    ImGui::SameLine();
+    ImGui::SetNextItemWidth(40);
+    ImGui::InputText("Len##wp", wp_len_, sizeof(wp_len_),
+                     ImGuiInputTextFlags_CharsDecimal);
+    ImGui::SameLine();
+    ImGui::SetNextItemWidth(80);
+    const char* wp_types[] = { "Read", "Write", "R/W" };
+    ImGui::Combo("Type##wp", &wp_type_, wp_types, 3);
+    ImGui::SameLine();
+    if (ImGui::Button("Add WP")) {
+      unsigned long addr;
+      if (parse_hex(wp_addr_, &addr, 0xFFFF)) {
+        int len = std::atoi(wp_len_);
+        if (len < 1) len = 1;
+        WatchpointType wt = (wp_type_ == 0) ? READ :
+                            (wp_type_ == 1) ? WRITE : READWRITE;
+        z80_add_watchpoint(static_cast<word>(addr), static_cast<word>(len), wt);
+        wp_addr_[0] = '\0';
+      }
+    }
+  }
+
+  // Add IO Breakpoint form
+  if (ImGui::CollapsingHeader("Add IO Breakpoint")) {
+    ImGui::SetNextItemWidth(60);
+    ImGui::InputText("Port##iobp", iobp_port_, sizeof(iobp_port_),
+                     ImGuiInputTextFlags_CharsHexadecimal);
+    ImGui::SameLine();
+    ImGui::SetNextItemWidth(60);
+    ImGui::InputText("Mask##iobp", iobp_mask_, sizeof(iobp_mask_),
+                     ImGuiInputTextFlags_CharsHexadecimal);
+    ImGui::SameLine();
+    ImGui::SetNextItemWidth(80);
+    const char* iobp_dirs[] = { "IN", "OUT", "Both" };
+    ImGui::Combo("Dir##iobp", &iobp_dir_, iobp_dirs, 3);
+    ImGui::SameLine();
+    if (ImGui::Button("Add IOBP")) {
+      unsigned long port, mask;
+      if (parse_hex(iobp_port_, &port, 0xFFFF) &&
+          parse_hex(iobp_mask_, &mask, 0xFFFF)) {
+        IOBreakpointDir dir = (iobp_dir_ == 0) ? IO_IN :
+                              (iobp_dir_ == 1) ? IO_OUT : IO_BOTH;
+        z80_add_io_breakpoint(static_cast<word>(port),
+                              static_cast<word>(mask), dir);
+        iobp_port_[0] = '\0';
+      }
+    }
+  }
+
   if (!open) show_breakpoints_ = false;
   ImGui::End();
 }
@@ -643,6 +709,44 @@ void DevToolsUI::render_symbols()
     return;
   }
 
+  // Load / Save buttons
+  if (ImGui::Button("Load .sym")) {
+    if (sym_path_[0] != '\0') {
+      Symfile loaded(sym_path_);
+      for (const auto& [addr, name] : loaded.Symbols()) {
+        g_symfile.addSymbol(addr, name);
+      }
+    }
+  }
+  ImGui::SameLine();
+  if (ImGui::Button("Save .sym")) {
+    if (sym_path_[0] != '\0') {
+      g_symfile.SaveTo(sym_path_);
+    }
+  }
+  ImGui::SameLine();
+  ImGui::SetNextItemWidth(-1);
+  ImGui::InputTextWithHint("##sympath", "Symbol file path...", sym_path_,
+                           sizeof(sym_path_));
+
+  // Add Symbol form
+  ImGui::SetNextItemWidth(60);
+  ImGui::InputText("Addr##addsym", sym_addr_, sizeof(sym_addr_),
+                   ImGuiInputTextFlags_CharsHexadecimal);
+  ImGui::SameLine();
+  ImGui::SetNextItemWidth(150);
+  ImGui::InputText("Name##addsym", sym_name_, sizeof(sym_name_));
+  ImGui::SameLine();
+  if (ImGui::Button("Add##addsym")) {
+    unsigned long addr;
+    if (parse_hex(sym_addr_, &addr, 0xFFFF) && sym_name_[0] != '\0') {
+      g_symfile.addSymbol(static_cast<word>(addr), sym_name_);
+      sym_addr_[0] = '\0';
+      sym_name_[0] = '\0';
+    }
+  }
+
+  ImGui::Separator();
   ImGui::SetNextItemWidth(-1);
   ImGui::InputTextWithHint("##symfilter", "Filter...", symtable_filter_,
                            sizeof(symtable_filter_));
@@ -680,5 +784,204 @@ void DevToolsUI::render_symbols()
   }
 
   if (!open) show_symbols_ = false;
+  ImGui::End();
+}
+
+// -----------------------------------------------
+// Debug Window 7: Data Areas
+// -----------------------------------------------
+
+void DevToolsUI::render_data_areas()
+{
+  ImGui::SetNextWindowSize(ImVec2(450, 350), ImGuiCond_FirstUseEver);
+
+  bool open = true;
+  if (!ImGui::Begin("Data Areas", &open)) {
+    if (!open) show_data_areas_ = false;
+    ImGui::End();
+    return;
+  }
+
+  if (ImGui::Button("Clear All")) g_data_areas.clear_all();
+  ImGui::Separator();
+
+  // Mark form
+  ImGui::SetNextItemWidth(60);
+  ImGui::InputText("Start##da", da_start_, sizeof(da_start_),
+                   ImGuiInputTextFlags_CharsHexadecimal);
+  ImGui::SameLine();
+  ImGui::SetNextItemWidth(60);
+  ImGui::InputText("End##da", da_end_, sizeof(da_end_),
+                   ImGuiInputTextFlags_CharsHexadecimal);
+  ImGui::SameLine();
+  ImGui::SetNextItemWidth(80);
+  const char* da_types[] = { "Bytes", "Words", "Text" };
+  ImGui::Combo("Type##da", &da_type_, da_types, 3);
+  ImGui::SameLine();
+  ImGui::SetNextItemWidth(100);
+  ImGui::InputText("Label##da", da_label_, sizeof(da_label_));
+  ImGui::SameLine();
+  if (ImGui::Button("Mark")) {
+    unsigned long s, e;
+    if (parse_hex(da_start_, &s, 0xFFFF) && parse_hex(da_end_, &e, 0xFFFF) && s <= e) {
+      DataType dt = (da_type_ == 0) ? DataType::BYTES :
+                    (da_type_ == 1) ? DataType::WORDS : DataType::TEXT;
+      g_data_areas.mark(static_cast<uint16_t>(s), static_cast<uint16_t>(e), dt,
+                        da_label_[0] ? da_label_ : "");
+      da_start_[0] = '\0';
+      da_end_[0] = '\0';
+      da_label_[0] = '\0';
+    }
+  }
+  ImGui::Separator();
+
+  // List data areas in a table
+  auto areas = g_data_areas.list();
+  if (ImGui::BeginTable("da_table", 5,
+      ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg | ImGuiTableFlags_ScrollY)) {
+    ImGui::TableSetupScrollFreeze(0, 1);
+    ImGui::TableSetupColumn("Start", ImGuiTableColumnFlags_WidthFixed, 50);
+    ImGui::TableSetupColumn("End", ImGuiTableColumnFlags_WidthFixed, 50);
+    ImGui::TableSetupColumn("Type", ImGuiTableColumnFlags_WidthFixed, 50);
+    ImGui::TableSetupColumn("Label", ImGuiTableColumnFlags_WidthStretch);
+    ImGui::TableSetupColumn("##del", ImGuiTableColumnFlags_WidthFixed, 20);
+    ImGui::TableHeadersRow();
+
+    for (const auto& da : areas) {
+      ImGui::TableNextRow();
+      ImGui::TableSetColumnIndex(0);
+      ImGui::Text("%04X", da.start);
+      ImGui::TableSetColumnIndex(1);
+      ImGui::Text("%04X", da.end);
+      ImGui::TableSetColumnIndex(2);
+      const char* type_str = (da.type == DataType::BYTES) ? "Bytes" :
+                             (da.type == DataType::WORDS) ? "Words" : "Text";
+      ImGui::Text("%s", type_str);
+      ImGui::TableSetColumnIndex(3);
+      if (!da.label.empty()) ImGui::TextUnformatted(da.label.c_str());
+      ImGui::TableSetColumnIndex(4);
+      ImGui::PushID(static_cast<int>(da.start));
+      if (ImGui::SmallButton("X")) {
+        g_data_areas.clear(da.start);
+      }
+      ImGui::PopID();
+    }
+    ImGui::EndTable();
+  }
+
+  if (!open) show_data_areas_ = false;
+  ImGui::End();
+}
+
+// -----------------------------------------------
+// Debug Window 8: Disassembly Export
+// -----------------------------------------------
+
+void DevToolsUI::render_disasm_export()
+{
+  ImGui::SetNextWindowSize(ImVec2(420, 220), ImGuiCond_FirstUseEver);
+
+  bool open = true;
+  if (!ImGui::Begin("Disassembly Export", &open)) {
+    if (!open) show_disasm_export_ = false;
+    ImGui::End();
+    return;
+  }
+
+  ImGui::SetNextItemWidth(60);
+  ImGui::InputText("Start##dex", dex_start_, sizeof(dex_start_),
+                   ImGuiInputTextFlags_CharsHexadecimal);
+  ImGui::SameLine();
+  ImGui::SetNextItemWidth(60);
+  ImGui::InputText("End##dex", dex_end_, sizeof(dex_end_),
+                   ImGuiInputTextFlags_CharsHexadecimal);
+  ImGui::SameLine();
+  ImGui::Checkbox("Symbols", &dex_symbols_);
+
+  ImGui::SetNextItemWidth(-1);
+  ImGui::InputTextWithHint("##dexpath", "Output path (e.g. /tmp/out.asm)...",
+                           dex_path_, sizeof(dex_path_));
+
+  if (ImGui::Button("Export")) {
+    unsigned long start_addr, end_addr;
+    if (parse_hex(dex_start_, &start_addr, 0xFFFF) &&
+        parse_hex(dex_end_, &end_addr, 0xFFFF) &&
+        start_addr <= end_addr) {
+      std::ostringstream oss;
+      char hexbuf[32];
+      snprintf(hexbuf, sizeof(hexbuf), "$%04X", static_cast<unsigned>(start_addr));
+      oss << "; Disassembly export from konCePCja\n";
+      oss << "org " << hexbuf << "\n\n";
+
+      DisassembledCode code;
+      std::vector<dword> entry_points;
+      word pos = static_cast<word>(start_addr);
+      word end_pos = static_cast<word>(end_addr);
+
+      while (pos <= end_pos) {
+        if (dex_symbols_) {
+          std::string sym = g_symfile.lookupAddr(pos);
+          if (!sym.empty()) oss << sym << ":\n";
+        }
+
+        const DataArea* da = g_data_areas.find(pos);
+        if (da) {
+          int remaining = static_cast<int>(da->end) - static_cast<int>(pos) + 1;
+          int max_bytes = (da->type == DataType::TEXT) ? 64 : 8;
+          int buf_len = std::min(remaining, max_bytes);
+          if (pos + buf_len - 1 > end_pos) buf_len = end_pos - pos + 1;
+          std::vector<uint8_t> membuf(buf_len);
+          for (int mi = 0; mi < buf_len; mi++)
+            membuf[mi] = z80_read_mem(static_cast<word>(pos + mi));
+          int line_bytes = 0;
+          std::string formatted = g_data_areas.format_at(pos, membuf.data(),
+                                                          membuf.size(), &line_bytes);
+          oss << "  " << formatted << "\n";
+          if (line_bytes == 0) line_bytes = 1;
+          unsigned int next = static_cast<unsigned int>(pos) + line_bytes;
+          if (next > 0xFFFF || next > end_addr + 1u) break;
+          pos = static_cast<word>(next);
+        } else {
+          auto line = disassemble_one(pos, code, entry_points);
+          code.lines.insert(line);
+          std::string instr = line.instruction_;
+          if (dex_symbols_ && !line.ref_address_string_.empty()) {
+            std::string sym = g_symfile.lookupAddr(line.ref_address_);
+            if (!sym.empty()) {
+              auto ref_pos = instr.find(line.ref_address_string_);
+              if (ref_pos != std::string::npos)
+                instr.replace(ref_pos, line.ref_address_string_.size(), sym);
+            }
+          }
+          oss << "  " << instr << "\n";
+          unsigned int next = static_cast<unsigned int>(pos) + line.Size();
+          if (next > 0xFFFF || next > end_addr + 1u) break;
+          pos = static_cast<word>(next);
+        }
+      }
+
+      std::string result = oss.str();
+      if (dex_path_[0] != '\0') {
+        std::ofstream f(dex_path_);
+        if (f) {
+          f << result;
+          f.close();
+          dex_status_ = "Exported " + std::to_string(result.size()) + " bytes to " + dex_path_;
+        } else {
+          dex_status_ = "Error: cannot write to " + std::string(dex_path_);
+        }
+      } else {
+        dex_status_ = "Error: no output path specified";
+      }
+    } else {
+      dex_status_ = "Error: invalid address range";
+    }
+  }
+
+  if (!dex_status_.empty()) {
+    ImGui::TextWrapped("%s", dex_status_.c_str());
+  }
+
+  if (!open) show_disasm_export_ = false;
   ImGui::End();
 }

--- a/src/devtools_ui.h
+++ b/src/devtools_ui.h
@@ -20,6 +20,8 @@ private:
     bool show_stack_ = false;
     bool show_breakpoints_ = false;
     bool show_symbols_ = false;
+    bool show_data_areas_ = false;
+    bool show_disasm_export_ = false;
 
     bool disasm_follow_pc_ = true;
     char disasm_goto_addr_[8] = "";
@@ -31,12 +33,42 @@ private:
 
     char symtable_filter_[64] = "";
 
+    // Add Watchpoint form state
+    char wp_addr_[8] = "";
+    char wp_len_[8] = "1";
+    int wp_type_ = 2;  // 0=R, 1=W, 2=RW
+
+    // Add IO Breakpoint form state
+    char iobp_port_[8] = "";
+    char iobp_mask_[8] = "FFFF";
+    int iobp_dir_ = 2;  // 0=IN, 1=OUT, 2=BOTH
+
+    // Add Symbol form state
+    char sym_addr_[8] = "";
+    char sym_name_[64] = "";
+    char sym_path_[256] = "";
+
+    // Data Areas window state
+    char da_start_[8] = "";
+    char da_end_[8] = "";
+    char da_label_[64] = "";
+    int da_type_ = 0;  // 0=BYTES, 1=WORDS, 2=TEXT
+
+    // Disasm Export window state
+    char dex_start_[8] = "0000";
+    char dex_end_[8] = "FFFF";
+    char dex_path_[256] = "";
+    bool dex_symbols_ = true;
+    std::string dex_status_;
+
     void render_registers();
     void render_disassembly();
     void render_memory_hex();
     void render_stack();
     void render_breakpoints();
     void render_symbols();
+    void render_data_areas();
+    void render_disasm_export();
 };
 
 extern DevToolsUI g_devtools_ui;

--- a/src/imgui_ui.cpp
+++ b/src/imgui_ui.cpp
@@ -255,6 +255,10 @@ void imgui_init_ui()
       []() { g_devtools_ui.toggle_window("breakpoints"); });
   g_command_palette.register_command("Symbol Table", "Show symbol table", "",
       []() { g_devtools_ui.toggle_window("symbols"); });
+  g_command_palette.register_command("Data Areas", "Show data area manager", "",
+      []() { g_devtools_ui.toggle_window("data_areas"); });
+  g_command_palette.register_command("Disasm Export", "Export disassembly to file", "",
+      []() { g_devtools_ui.toggle_window("disasm_export"); });
 }
 
 // ─────────────────────────────────────────────────
@@ -1678,6 +1682,8 @@ static void imgui_render_devtools()
       ImGui::MenuItem("Stack",           nullptr, g_devtools_ui.window_ptr("stack"));
       ImGui::MenuItem("Breakpoints/WP",  nullptr, g_devtools_ui.window_ptr("breakpoints"));
       ImGui::MenuItem("Symbols",         nullptr, g_devtools_ui.window_ptr("symbols"));
+      ImGui::MenuItem("Data Areas",      nullptr, g_devtools_ui.window_ptr("data_areas"));
+      ImGui::MenuItem("Disasm Export",   nullptr, g_devtools_ui.window_ptr("disasm_export"));
       ImGui::EndMenu();
     }
     ImGui::Separator();


### PR DESCRIPTION
## Summary

- Add "Add Watchpoint" collapsible form to breakpoints window (addr, length, R/W/RW selector)
- Add "Add IO Breakpoint" collapsible form to breakpoints window (port, mask, IN/OUT/BOTH)
- Add Load/Save `.sym` buttons and "Add Symbol" form to symbols window
- New **Data Areas** floating window: list areas in table, mark form (start/end/type/label), clear individual or all
- New **Disasm Export** dialog: start/end address inputs, symbols toggle, file path, export button

All wired to existing backend APIs. No new dependencies. 621 tests pass.

Closes UI beads: qo6 (watchpoints), 5jm (IO breakpoints), 098 (symbols), dy7 (data areas), 066 (disasm export)

## Test plan

- [ ] Build succeeds with zero warnings on macOS and MINGW
- [ ] All 621 existing tests pass
- [ ] Open DevTools > Debug menu shows new "Data Areas" and "Disasm Export" entries
- [ ] Breakpoints window: expand "Add Watchpoint", enter address/len/type, click Add — watchpoint appears in table
- [ ] Breakpoints window: expand "Add IO Breakpoint", enter port/mask/dir, click Add — IOBP appears in table
- [ ] Symbols window: Load/Save buttons work with .sym file path
- [ ] Symbols window: Add form creates new symbol visible in table and disassembly
- [ ] Data Areas: Mark a range, see it in table, delete with X, clear all works
- [ ] Disasm Export: Enter range, path, click Export — file is written with correct asm output