### PR TITLE
feat: Phase 6 peripheral emulation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ debian/files
 imgui.ini
 coverage.profdata
 coverage.profraw
+resources/roms/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,31 @@ src/
 └── disk.cpp           # Floppy disk emulation
 ```
 
+## Emulated Devices
+
+### Core Hardware
+- **Z80A CPU** — Full instruction set with breakpoint/watchpoint support
+- **Gate Array** — Palette, screen mode, ROM banking, interrupt generation
+- **CRTC** — Types 0-3 (HD6845S, UM6845R, MC6845, AMS40489)
+- **PPI 8255** — Keyboard matrix, PSG control, tape motor
+- **PSG AY-3-8912** — 3-channel sound + envelope generator
+- **FDC uPD765A** — Floppy disk controller with standard/extended DSK support
+- **ASIC (6128+)** — Plus-specific features: DMA, programmable raster, sprites
+
+### Peripheral Expansions
+- **Digiblaster** — Printer port 8-bit DAC. Uses `CPC.printer_port` value and a 256-level lookup table (`Level_PP[]`) mixed into the PSG audio output
+- **AmDrum (Cheetah)** — 8-bit DAC on port `&FFxx` (the "uncontested" I/O space where all upper address bits are high). Same mixing pattern as Digiblaster via `Level_AmDrum[]`
+- **Dobbertin SmartWatch** — Dallas DS1216 phantom RTC in upper ROM socket. Intercepts ROM reads using a 64-bit recognition pattern sent via address lines A0 (data) and A2 (mode). Returns BCD-encoded host system time via data bit D0
+- **AMX Mouse** — Joystick port mouse on keyboard matrix row 9. Direction bits pulse LOW for one "mickey" per deselect/reselect cycle of row 9. Uses monostable reset tracking
+- **Symbiface II** — Multi-function expansion board:
+  - **IDE (ATA PIO)** at `&FD00-&FD3F` — Standard ATA register file backed by raw `.img` files. Supports READ/WRITE SECTORS and IDENTIFY DEVICE
+  - **RTC (DS12887)** at `&FD00-&FD3F` — 14 time registers (BCD from host clock) + 50 bytes CMOS NVRAM
+  - **PS/2 Mouse** at `&FBEE`/`&FBEF` — Kempston protocol with wrapping 8-bit X/Y counters
+- **M4 Board** — Virtual filesystem expansion via command/response protocol. OUTs to `&FE00` accumulate command bytes, OUT to `&FC00` triggers execution. Response written to ROM overlay at `&E800`. Backs virtual SD card with a host directory (path traversal protected)
+- **Drive/Tape Sounds** — Procedurally generated audio effects for FDC motor hum, head seek clicks, and tape loading hiss, mixed into the PSG audio output
+- **Multiface II** — ROM-based debugging interface (original Caprice32 implementation)
+- **Amstrad Magnum Phaser** — Light gun via CRTC register intercept
+
 ## Building
 
 ```bash

--- a/makefile
+++ b/makefile
@@ -134,6 +134,13 @@ ifneq (,$(findstring g++,$(CXX)))
 LIBS += -lstdc++fs
 endif
 
+# libcurl for M4 Board HTTP support
+HAS_LIBCURL := $(shell pkg-config --exists libcurl 2>/dev/null && echo 1 || (curl-config --libs >/dev/null 2>&1 && echo 1))
+ifeq ($(HAS_LIBCURL),1)
+COMMON_CFLAGS += -DHAS_LIBCURL $(shell pkg-config --cflags libcurl 2>/dev/null || curl-config --cflags 2>/dev/null)
+LIBS += $(shell pkg-config --libs libcurl 2>/dev/null || curl-config --libs 2>/dev/null)
+endif
+
 ifeq ($(UNAME_S),Darwin)
 ifeq ($(ARCH),)
 ARCH=macos

--- a/makefile
+++ b/makefile
@@ -134,11 +134,13 @@ ifneq (,$(findstring g++,$(CXX)))
 LIBS += -lstdc++fs
 endif
 
-# libcurl for M4 Board HTTP support
+# libcurl for M4 Board HTTP support (skip on Windows to avoid DLL bloat)
+ifneq ($(PLATFORM),windows)
 HAS_LIBCURL := $(shell pkg-config --exists libcurl 2>/dev/null && echo 1 || (curl-config --libs >/dev/null 2>&1 && echo 1))
 ifeq ($(HAS_LIBCURL),1)
 COMMON_CFLAGS += -DHAS_LIBCURL $(shell pkg-config --cflags libcurl 2>/dev/null || curl-config --cflags 2>/dev/null)
 LIBS += $(shell pkg-config --libs libcurl 2>/dev/null || curl-config --libs 2>/dev/null)
+endif
 endif
 
 ifeq ($(UNAME_S),Darwin)

--- a/src/amdrum.cpp
+++ b/src/amdrum.cpp
@@ -1,0 +1,8 @@
+#include "amdrum.h"
+
+AmDrum g_amdrum;
+
+void amdrum_reset()
+{
+   g_amdrum.dac_value = 128;
+}

--- a/src/amdrum.h
+++ b/src/amdrum.h
@@ -1,0 +1,23 @@
+/* konCePCja - Amstrad CPC Emulator
+   Cheetah AmDrum - 8-bit DAC on port &FFxx
+
+   The AmDrum is a simple 8-bit DAC that maps to the uncontested I/O space
+   where all upper address bits are high (port.b.h == 0xFF). Writing any
+   value to &FF00-&FFFF sets the DAC output level.
+*/
+
+#ifndef AMDRUM_H
+#define AMDRUM_H
+
+#include "types.h"
+
+struct AmDrum {
+   bool enabled = false;
+   byte dac_value = 128;  // 128 = silence (unsigned midpoint)
+};
+
+extern AmDrum g_amdrum;
+
+void amdrum_reset();
+
+#endif

--- a/src/amx_mouse.cpp
+++ b/src/amx_mouse.cpp
@@ -1,0 +1,59 @@
+#include "amx_mouse.h"
+
+AMXMouse g_amx_mouse;
+
+void amx_mouse_reset()
+{
+   g_amx_mouse.accum_x = 0;
+   g_amx_mouse.accum_y = 0;
+   g_amx_mouse.buttons = 0;
+   g_amx_mouse.row9_selected = false;
+   g_amx_mouse.row9_was_deselected = false;
+}
+
+void amx_mouse_update(float dx, float dy, uint32_t sdl_buttons)
+{
+   // Accumulate motion — SDL gives sub-pixel floats in SDL3
+   g_amx_mouse.accum_x += static_cast<int>(dx);
+   g_amx_mouse.accum_y += static_cast<int>(dy);
+
+   // Store button state (SDL: bit 0=left, bit 1=middle, bit 2=right)
+   g_amx_mouse.buttons = static_cast<uint8_t>(sdl_buttons);
+}
+
+void amx_mouse_row_select(int line)
+{
+   bool now_row9 = (line == 9);
+   if (!now_row9 && g_amx_mouse.row9_selected) {
+      // Row 9 was deselected — mark for mickey consumption on next select
+      g_amx_mouse.row9_was_deselected = true;
+   }
+   if (now_row9 && g_amx_mouse.row9_was_deselected) {
+      // Row 9 re-selected after deselect — consume one mickey in each axis
+      if (g_amx_mouse.accum_x > 0) g_amx_mouse.accum_x--;
+      else if (g_amx_mouse.accum_x < 0) g_amx_mouse.accum_x++;
+      if (g_amx_mouse.accum_y > 0) g_amx_mouse.accum_y--;
+      else if (g_amx_mouse.accum_y < 0) g_amx_mouse.accum_y++;
+      g_amx_mouse.row9_was_deselected = false;
+   }
+   g_amx_mouse.row9_selected = now_row9;
+}
+
+byte amx_mouse_get_row9()
+{
+   byte val = 0xFF;  // all bits high = nothing pressed (active-low)
+
+   // Direction bits (active-low: clear bit when there's motion)
+   if (g_amx_mouse.accum_y < 0) val &= ~0x01;  // up
+   if (g_amx_mouse.accum_y > 0) val &= ~0x02;  // down
+   if (g_amx_mouse.accum_x < 0) val &= ~0x04;  // left
+   if (g_amx_mouse.accum_x > 0) val &= ~0x08;  // right
+
+   // Button bits (active-low)
+   // SDL3: SDL_BUTTON_LMASK=1, SDL_BUTTON_MMASK=2, SDL_BUTTON_RMASK=4
+   if (g_amx_mouse.buttons & 1) val &= ~0x10;  // left button -> fire2 (bit 4)
+   if (g_amx_mouse.buttons & 4) val &= ~0x20;  // right button -> fire1 (bit 5)
+   if (g_amx_mouse.buttons & 2) val &= ~0x40;  // middle button -> fire3 (bit 6)
+
+   return val;
+}

--- a/src/amx_mouse.h
+++ b/src/amx_mouse.h
@@ -1,0 +1,41 @@
+/* konCePCja - Amstrad CPC Emulator
+   AMX Mouse - Joystick port mouse emulation
+
+   The AMX Mouse connects to the joystick port and appears as keyboard
+   matrix row 9 (joystick 0). Direction bits pulse LOW for one mickey
+   per read cycle. Software must deselect/reselect row 9 between reads
+   to consume motion pulses.
+
+   Row 9 bit mapping:
+     Bit 0: Up     (LOW = mouse moved up)
+     Bit 1: Down   (LOW = mouse moved down)
+     Bit 2: Left   (LOW = mouse moved left)
+     Bit 3: Right  (LOW = mouse moved right)
+     Bit 4: Fire2  (LOW = left button pressed)
+     Bit 5: Fire1  (LOW = right button pressed)
+     Bit 6: Fire3  (LOW = middle button pressed)
+*/
+
+#ifndef AMX_MOUSE_H
+#define AMX_MOUSE_H
+
+#include "types.h"
+#include <cstdint>
+
+struct AMXMouse {
+   bool enabled = false;
+   int accum_x = 0;          // accumulated X mickeys since last read
+   int accum_y = 0;          // accumulated Y mickeys since last read
+   uint8_t buttons = 0;      // SDL button state (not CPC-inverted)
+   bool row9_selected = false;   // true when CPC is selecting row 9
+   bool row9_was_deselected = false; // set when row deselected, cleared on reselect
+};
+
+extern AMXMouse g_amx_mouse;
+
+void amx_mouse_reset();
+void amx_mouse_update(float dx, float dy, uint32_t sdl_buttons);
+void amx_mouse_row_select(int line);
+byte amx_mouse_get_row9();
+
+#endif

--- a/src/drive_sounds.cpp
+++ b/src/drive_sounds.cpp
@@ -1,0 +1,140 @@
+#include "drive_sounds.h"
+#include <cmath>
+#include <cstdlib>
+
+DriveSounds g_drive_sounds;
+
+static const int GEN_RATE = 44100;
+
+// Generate procedural motor hum (~1 second loop at GEN_RATE)
+static void generate_motor_samples(std::vector<int16_t>& out)
+{
+   int len = GEN_RATE;  // 1 second
+   out.resize(len);
+   for (int i = 0; i < len; i++) {
+      double t = static_cast<double>(i) / GEN_RATE;
+      // Low-frequency hum with harmonics (fundamental ~50 Hz motor)
+      double v = sin(2 * M_PI * 50 * t) * 0.4
+               + sin(2 * M_PI * 100 * t) * 0.2
+               + sin(2 * M_PI * 150 * t) * 0.1;
+      // Add slight rumble noise
+      v += (rand() / static_cast<double>(RAND_MAX) - 0.5) * 0.1;
+      out[i] = static_cast<int16_t>(v * 4000);
+   }
+}
+
+// Generate procedural seek click (~50ms)
+static void generate_seek_samples(std::vector<int16_t>& out)
+{
+   int len = GEN_RATE / 20;  // 50ms
+   out.resize(len);
+   for (int i = 0; i < len; i++) {
+      double t = static_cast<double>(i) / GEN_RATE;
+      double env = exp(-t * 80);  // sharp decay
+      double v = sin(2 * M_PI * 800 * t) * env;  // click with high-frequency component
+      v += (rand() / static_cast<double>(RAND_MAX) - 0.5) * 0.3 * env; // mechanical noise
+      out[i] = static_cast<int16_t>(v * 8000);
+   }
+}
+
+// Generate procedural tape hiss (~2 second loop)
+static void generate_tape_samples(std::vector<int16_t>& out)
+{
+   int len = GEN_RATE * 2;  // 2 seconds
+   out.resize(len);
+   for (int i = 0; i < len; i++) {
+      // Filtered white noise (tape hiss character)
+      double v = (rand() / static_cast<double>(RAND_MAX) - 0.5);
+      out[i] = static_cast<int16_t>(v * 2000);
+   }
+   // Simple low-pass filter pass
+   for (int i = 1; i < len; i++) {
+      out[i] = static_cast<int16_t>(out[i] * 0.3 + out[i - 1] * 0.7);
+   }
+}
+
+void drive_sounds_init(int target_sample_rate)
+{
+   generate_motor_samples(g_drive_sounds.motor_samples);
+   generate_seek_samples(g_drive_sounds.seek_samples);
+   generate_tape_samples(g_drive_sounds.tape_samples);
+
+   g_drive_sounds.resample_ratio = static_cast<double>(target_sample_rate) / GEN_RATE;
+   g_drive_sounds.motor_pos = 0;
+   g_drive_sounds.seek_pos = 0;
+   g_drive_sounds.tape_pos = 0;
+   g_drive_sounds.motor_frac = 0.0;
+   g_drive_sounds.tape_frac = 0.0;
+}
+
+int16_t drive_sounds_next_sample()
+{
+   int32_t mix = 0;
+   double vol = g_drive_sounds.volume / 100.0;
+
+   if (g_drive_sounds.motor_playing && !g_drive_sounds.motor_samples.empty()) {
+      mix += static_cast<int32_t>(g_drive_sounds.motor_samples[g_drive_sounds.motor_pos] * vol);
+      // Advance with resampling
+      g_drive_sounds.motor_frac += 1.0 / g_drive_sounds.resample_ratio;
+      while (g_drive_sounds.motor_frac >= 1.0) {
+         g_drive_sounds.motor_frac -= 1.0;
+         g_drive_sounds.motor_pos++;
+         if (g_drive_sounds.motor_pos >= g_drive_sounds.motor_samples.size()) {
+            g_drive_sounds.motor_pos = 0;  // loop
+         }
+      }
+   }
+
+   if (g_drive_sounds.seek_playing && !g_drive_sounds.seek_samples.empty()) {
+      mix += static_cast<int32_t>(g_drive_sounds.seek_samples[g_drive_sounds.seek_pos] * vol);
+      g_drive_sounds.seek_pos++;
+      if (g_drive_sounds.seek_pos >= g_drive_sounds.seek_samples.size()) {
+         g_drive_sounds.seek_playing = false;
+         g_drive_sounds.seek_pos = 0;
+      }
+   }
+
+   if (g_drive_sounds.tape_playing && !g_drive_sounds.tape_samples.empty()) {
+      mix += static_cast<int32_t>(g_drive_sounds.tape_samples[g_drive_sounds.tape_pos] * vol);
+      g_drive_sounds.tape_frac += 1.0 / g_drive_sounds.resample_ratio;
+      while (g_drive_sounds.tape_frac >= 1.0) {
+         g_drive_sounds.tape_frac -= 1.0;
+         g_drive_sounds.tape_pos++;
+         if (g_drive_sounds.tape_pos >= g_drive_sounds.tape_samples.size()) {
+            g_drive_sounds.tape_pos = 0;  // loop
+         }
+      }
+   }
+
+   // Clamp
+   if (mix > 32767) mix = 32767;
+   if (mix < -32768) mix = -32768;
+   return static_cast<int16_t>(mix);
+}
+
+void drive_sounds_motor(bool on)
+{
+   if (!g_drive_sounds.disk_enabled) return;
+   g_drive_sounds.motor_playing = on;
+   if (!on) {
+      g_drive_sounds.motor_pos = 0;
+      g_drive_sounds.motor_frac = 0.0;
+   }
+}
+
+void drive_sounds_seek()
+{
+   if (!g_drive_sounds.disk_enabled) return;
+   g_drive_sounds.seek_playing = true;
+   g_drive_sounds.seek_pos = 0;
+}
+
+void drive_sounds_tape(bool playing)
+{
+   if (!g_drive_sounds.tape_enabled) return;
+   g_drive_sounds.tape_playing = playing;
+   if (!playing) {
+      g_drive_sounds.tape_pos = 0;
+      g_drive_sounds.tape_frac = 0.0;
+   }
+}

--- a/src/drive_sounds.h
+++ b/src/drive_sounds.h
@@ -1,0 +1,53 @@
+/* konCePCja - Amstrad CPC Emulator
+   Drive/Tape sound effects
+
+   Audio effects for FDC and tape operations:
+   - Disk motor: continuous loop while FDC motor is on
+   - Disk head seek: click on track change
+   - Tape loading: hiss during tape playback
+
+   Sounds are generated procedurally (no WAV files needed).
+   Mixed into the main PSG audio buffer at the synthesizer output stage.
+*/
+
+#ifndef DRIVE_SOUNDS_H
+#define DRIVE_SOUNDS_H
+
+#include "types.h"
+#include <vector>
+#include <cstdint>
+
+struct DriveSounds {
+   bool disk_enabled = false;
+   bool tape_enabled = false;
+
+   // Generated sample data (at 44100 Hz, resampled on output)
+   std::vector<int16_t> motor_samples;
+   std::vector<int16_t> seek_samples;
+   std::vector<int16_t> tape_samples;
+
+   // Playback state
+   size_t motor_pos = 0;
+   bool motor_playing = false;
+   size_t seek_pos = 0;
+   bool seek_playing = false;
+   size_t tape_pos = 0;
+   bool tape_playing = false;
+
+   // Resampling state (source rate = 44100)
+   double resample_ratio = 1.0;  // target_rate / 44100
+   double motor_frac = 0.0;
+   double tape_frac = 0.0;
+
+   int volume = 40;  // 0-100
+};
+
+extern DriveSounds g_drive_sounds;
+
+void drive_sounds_init(int target_sample_rate);
+int16_t drive_sounds_next_sample();
+void drive_sounds_motor(bool on);
+void drive_sounds_seek();
+void drive_sounds_tape(bool playing);
+
+#endif

--- a/src/fdc.cpp
+++ b/src/fdc.cpp
@@ -23,6 +23,7 @@
 #include "koncepcja.h"
 #include "disk.h"
 #include "z80.h"
+#include "drive_sounds.h"
 
 extern t_CPC CPC;
 extern t_FDC FDC;
@@ -787,6 +788,7 @@ void fdc_seek()
       if (active_drive->current_track >= DSK_TRACKMAX) { // beyond valid range?
          active_drive->current_track = DSK_TRACKMAX-1; // limit to maximum
       }
+      drive_sounds_seek();
    }
    FDC.flags |= (FDC.command[CMD_UNIT] & 1) ? SEEKDRVB_flag : SEEKDRVA_flag; // signal completion of seek operation
    FDC.phase = CMD_PHASE; // switch back to command phase (fdc_seek has no result phase!)

--- a/src/imgui_ui.cpp
+++ b/src/imgui_ui.cpp
@@ -22,6 +22,12 @@
 #include "tape.h"
 #include "video.h"
 #include "symfile.h"
+#include "amdrum.h"
+#include "smartwatch.h"
+#include "amx_mouse.h"
+#include "drive_sounds.h"
+#include "symbiface.h"
+#include "m4board.h"
 #include <SDL3/SDL.h>
 #include <SDL3/SDL_dialog.h>
 
@@ -1165,6 +1171,24 @@ static void imgui_render_options()
         CPC.printer = printer ? 1 : 0;
       }
 
+      bool sw = g_smartwatch.enabled;
+      if (ImGui::Checkbox("SmartWatch RTC", &sw)) { g_smartwatch.enabled = sw; }
+      if (ImGui::IsItemHovered()) {
+        ImGui::SetTooltip("Dobbertin SmartWatch (DS1216) in upper ROM socket.\nProvides real-time clock via host system time.");
+      }
+
+      bool sf2 = g_symbiface.enabled;
+      if (ImGui::Checkbox("Symbiface II", &sf2)) { g_symbiface.enabled = sf2; }
+      if (ImGui::IsItemHovered()) {
+        ImGui::SetTooltip("Symbiface II expansion (IDE + RTC + PS/2 Mouse).\nConfigure IDE images in config file.");
+      }
+
+      bool m4 = g_m4board.enabled;
+      if (ImGui::Checkbox("M4 Board", &m4)) { g_m4board.enabled = m4; }
+      if (ImGui::IsItemHovered()) {
+        ImGui::SetTooltip("M4 Board (WiFi/SD).\nSet m4_sd_path in config for virtual SD card.");
+      }
+
       ImGui::EndTabItem();
     }
 
@@ -1316,6 +1340,17 @@ static void imgui_render_options()
       int vol = static_cast<int>(CPC.snd_volume);
       if (ImGui::SliderInt("Volume", &vol, 0, 100)) { CPC.snd_volume = vol; }
 
+      ImGui::Separator();
+      ImGui::Text("Peripherals");
+      bool pp = CPC.snd_pp_device != 0;
+      if (ImGui::Checkbox("Digiblaster", &pp)) { CPC.snd_pp_device = pp ? 1 : 0; }
+      bool amdrum = g_amdrum.enabled;
+      if (ImGui::Checkbox("AmDrum", &amdrum)) { g_amdrum.enabled = amdrum; }
+      bool disk_snd = g_drive_sounds.disk_enabled;
+      if (ImGui::Checkbox("Disk Drive Sounds", &disk_snd)) { g_drive_sounds.disk_enabled = disk_snd; }
+      bool tape_snd = g_drive_sounds.tape_enabled;
+      if (ImGui::Checkbox("Tape Sounds", &tape_snd)) { g_drive_sounds.tape_enabled = tape_snd; }
+
       ImGui::EndTabItem();
     }
 
@@ -1337,6 +1372,12 @@ static void imgui_render_options()
       bool joysticks = CPC.joysticks != 0;
       if (ImGui::Checkbox("Use Real Joysticks", &joysticks)) {
         CPC.joysticks = joysticks ? 1 : 0;
+      }
+
+      bool amx = g_amx_mouse.enabled;
+      if (ImGui::Checkbox("AMX Mouse", &amx)) { g_amx_mouse.enabled = amx; }
+      if (ImGui::IsItemHovered()) {
+        ImGui::SetTooltip("AMX Mouse on joystick port.\nMaps host mouse to CPC joystick directions + buttons.");
       }
 
       ImGui::EndTabItem();

--- a/src/imgui_ui.cpp
+++ b/src/imgui_ui.cpp
@@ -1117,9 +1117,11 @@ static void imgui_render_options()
 {
   static bool first_open = true;
   static unsigned char old_crtc_type = 0;
+  static bool old_m4_enabled = false;
   if (first_open) {
     imgui_state.old_cpc_settings = CPC;
     old_crtc_type = CRTC.crtc_type;
+    old_m4_enabled = g_m4board.enabled;
     first_open = false;
   }
 
@@ -1396,7 +1398,8 @@ static void imgui_render_options()
     // Apply changes that need re-init
     if (CPC.model != imgui_state.old_cpc_settings.model ||
         CPC.ram_size != imgui_state.old_cpc_settings.ram_size ||
-        CPC.keyboard != imgui_state.old_cpc_settings.keyboard) {
+        CPC.keyboard != imgui_state.old_cpc_settings.keyboard ||
+        g_m4board.enabled != old_m4_enabled) {
       emulator_init();
     }
     update_cpc_speed();
@@ -1409,6 +1412,7 @@ static void imgui_render_options()
   if (ImGui::Button("Cancel", ImVec2(80, 0))) {
     CPC = imgui_state.old_cpc_settings;
     CRTC.crtc_type = old_crtc_type;
+    g_m4board.enabled = old_m4_enabled;
     imgui_state.show_options = false;
     CPC.paused = false;
     first_open = true;
@@ -1417,7 +1421,8 @@ static void imgui_render_options()
   if (ImGui::Button("OK", ImVec2(80, 0))) {
     if (CPC.model != imgui_state.old_cpc_settings.model ||
         CPC.ram_size != imgui_state.old_cpc_settings.ram_size ||
-        CPC.keyboard != imgui_state.old_cpc_settings.keyboard) {
+        CPC.keyboard != imgui_state.old_cpc_settings.keyboard ||
+        g_m4board.enabled != old_m4_enabled) {
       emulator_init();
     }
     update_cpc_speed();
@@ -1431,6 +1436,7 @@ static void imgui_render_options()
     // Window closed via X button — treat as Cancel
     CPC = imgui_state.old_cpc_settings;
     CRTC.crtc_type = old_crtc_type;
+    g_m4board.enabled = old_m4_enabled;
     imgui_state.show_options = false;
     CPC.paused = false;
     first_open = true;

--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -933,7 +933,7 @@ void z80_OUT_handler (reg_pair port, byte val)
             if (!(PPI.control & 1)) { // output lower half?
                LOG_DEBUG("PPI write to portC (keyboard_line): " << static_cast<int>(val));
                CPC.keyboard_line = val;
-               if (g_amx_mouse.enabled) amx_mouse_row_select(val & 0x0f);
+               if (g_amx_mouse.enabled) amx_mouse_row_select(CPC.keyboard_line & 0x0f);
             }
             if (!(PPI.control & 8)) { // output upper half?
                LOG_DEBUG("PPI write to portC (upper half): " << static_cast<int>(val));
@@ -962,7 +962,7 @@ void z80_OUT_handler (reg_pair port, byte val)
                if (!(PPI.control & 1)) { // output lower half?
                   LOG_DEBUG("PPI.portC update (keyboard_line): " << static_cast<int>(PPI.portC));
                   CPC.keyboard_line = PPI.portC;
-                  if (g_amx_mouse.enabled) amx_mouse_row_select(PPI.portC & 0x0f);
+                  if (g_amx_mouse.enabled) amx_mouse_row_select(CPC.keyboard_line & 0x0f);
                }
                if (!(PPI.control & 8)) { // output upper half?
                   LOG_DEBUG("PPI.portC update (upper half): " << static_cast<int>(PPI.portC));

--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -1453,6 +1453,9 @@ int emulator_init ()
       }
    }
 
+   // Auto-load M4 Board ROM if enabled and slot is free
+   m4board_load_rom(memmap_ROM, CPC.rom_path);
+
    emulator_reset();
    CPC.paused = false;
 
@@ -1469,6 +1472,7 @@ void emulator_shutdown ()
    delete [] pbMF2ROM;
    pbMF2ROM = nullptr;
    pbMF2ROMbackup = nullptr;
+   m4board_unload_rom(memmap_ROM); // free auto-loaded M4 ROM before general cleanup
    for (iRomNum = 2; iRomNum < MAX_ROM_SLOTS; iRomNum++) // loop for ROMs 2-31
    {
       if (memmap_ROM[iRomNum] != nullptr) // was a ROM assigned to this slot?

--- a/src/m4board.cpp
+++ b/src/m4board.cpp
@@ -3,21 +3,25 @@
 #include <cstring>
 #include <filesystem>
 #include <algorithm>
+#ifdef HAS_LIBCURL
+#include <curl/curl.h>
+#endif
 
 M4Board g_m4board;
 
 // M4 command codes (from m4cmds.i)
 static constexpr uint16_t C_OPEN       = 0x4301;
 static constexpr uint16_t C_READ       = 0x4302;
-[[maybe_unused]] static constexpr uint16_t C_WRITE      = 0x4303;
+static constexpr uint16_t C_WRITE      = 0x4303;
 static constexpr uint16_t C_CLOSE      = 0x4304;
-[[maybe_unused]] static constexpr uint16_t C_SEEK       = 0x4305;
+static constexpr uint16_t C_SEEK       = 0x4305;
 static constexpr uint16_t C_READDIR    = 0x4306;
 static constexpr uint16_t C_CD         = 0x4308;
 static constexpr uint16_t C_ERASEFILE  = 0x430E;
-[[maybe_unused]] static constexpr uint16_t C_RENAME     = 0x430F;
+static constexpr uint16_t C_RENAME     = 0x430F;
 static constexpr uint16_t C_MAKEDIR    = 0x4310;
 static constexpr uint16_t C_FSIZE      = 0x4311;
+static constexpr uint16_t C_HTTPGET    = 0x4320;
 static constexpr uint16_t C_VERSION    = 0x4326;
 
 // Response status codes
@@ -300,6 +304,238 @@ static void cmd_makedir()
    g_m4board.response_len = 1;
 }
 
+static void cmd_write()
+{
+   // Protocol: data[0] = fd, data[1..] = file data
+   // cmd_buf[2] = fd, cmd_buf[3..] = data to write
+   if (g_m4board.cmd_buf.size() < 4) {
+      g_m4board.response[0] = M4_ERROR;
+      g_m4board.response_len = 1;
+      return;
+   }
+   int handle = g_m4board.cmd_buf[2];
+   if (handle < 0 || handle >= 4 || !g_m4board.open_files[handle]) {
+      g_m4board.response[0] = M4_ERROR;
+      g_m4board.response_len = 1;
+      return;
+   }
+
+   size_t data_len = g_m4board.cmd_buf.size() - 3;
+   size_t written = fwrite(g_m4board.cmd_buf.data() + 3, 1, data_len,
+                           g_m4board.open_files[handle]);
+   fflush(g_m4board.open_files[handle]);
+
+   if (written == data_len) {
+      g_m4board.response[0] = M4_OK;
+   } else {
+      g_m4board.response[0] = M4_ERROR;
+   }
+   g_m4board.response_len = 1;
+}
+
+static void cmd_seek()
+{
+   // Protocol: data[0] = fd, data[1..4] = 32-bit LE offset
+   // cmd_buf[2] = fd, cmd_buf[3..6] = offset
+   if (g_m4board.cmd_buf.size() < 7) {
+      g_m4board.response[0] = M4_ERROR;
+      g_m4board.response_len = 1;
+      return;
+   }
+   int handle = g_m4board.cmd_buf[2];
+   if (handle < 0 || handle >= 4 || !g_m4board.open_files[handle]) {
+      g_m4board.response[0] = M4_ERROR;
+      g_m4board.response_len = 1;
+      return;
+   }
+
+   uint32_t offset = static_cast<uint32_t>(g_m4board.cmd_buf[3]) |
+                     (static_cast<uint32_t>(g_m4board.cmd_buf[4]) << 8) |
+                     (static_cast<uint32_t>(g_m4board.cmd_buf[5]) << 16) |
+                     (static_cast<uint32_t>(g_m4board.cmd_buf[6]) << 24);
+
+   if (fseek(g_m4board.open_files[handle], static_cast<long>(offset), SEEK_SET) == 0) {
+      g_m4board.response[0] = M4_OK;
+   } else {
+      g_m4board.response[0] = M4_ERROR;
+   }
+   g_m4board.response_len = 1;
+}
+
+static void cmd_rename()
+{
+   // Protocol: data = "newname\0oldname\0"
+   // cmd_buf[2..] = "newname\0oldname\0"
+   std::string newname = extract_string(g_m4board.cmd_buf, 2);
+   // Find the second string after the first null terminator
+   size_t old_offset = 2 + newname.size() + 1;
+   if (old_offset >= g_m4board.cmd_buf.size()) {
+      g_m4board.response[0] = M4_ERROR;
+      g_m4board.response_len = 1;
+      return;
+   }
+   std::string oldname = extract_string(g_m4board.cmd_buf, old_offset);
+
+   std::string resolved_old = resolve_path(oldname);
+   std::string resolved_new = resolve_path(newname);
+   if (resolved_old.empty() || resolved_new.empty()) {
+      g_m4board.response[0] = M4_ERROR;
+      g_m4board.response_len = 1;
+      return;
+   }
+
+   try {
+      std::filesystem::rename(resolved_old, resolved_new);
+      g_m4board.response[0] = M4_OK;
+      g_m4board.response_len = 1;
+   } catch (const std::exception& e) {
+      g_m4board.response[0] = M4_ERROR;
+      std::string msg = e.what();
+      size_t max_msg = static_cast<size_t>(M4Board::RESPONSE_SIZE - 2);
+      if (msg.size() > max_msg) msg.resize(max_msg);
+      memcpy(g_m4board.response + 1, msg.c_str(), msg.size() + 1);
+      g_m4board.response_len = static_cast<int>(2 + msg.size());
+   }
+}
+
+// ── HTTP GET ────────────────────────────────────
+
+#ifdef HAS_LIBCURL
+
+static size_t curl_write_file(void* ptr, size_t size, size_t nmemb, void* userdata)
+{
+   FILE* fp = static_cast<FILE*>(userdata);
+   return fwrite(ptr, size, nmemb, fp);
+}
+
+static void cmd_httpget()
+{
+   // Protocol: data[0] = "url:port/file"
+   // URL format: [@ prefix]host[:port]/path[>outfile]
+   std::string raw_url = extract_string(g_m4board.cmd_buf, 2);
+   if (raw_url.empty()) {
+      g_m4board.response[0] = M4_ERROR;
+      const char* msg = "No URL given";
+      memcpy(g_m4board.response + 1, msg, strlen(msg) + 1);
+      g_m4board.response_len = static_cast<int>(2 + strlen(msg));
+      return;
+   }
+
+   // Strip leading @ (silent mode — doesn't affect emulation)
+   std::string url = raw_url;
+   if (!url.empty() && url[0] == '@') url = url.substr(1);
+
+   // Strip http:// prefix if present (as real firmware does)
+   if (url.substr(0, 7) == "http://") url = url.substr(7);
+
+   // Check for >filename redirect suffix
+   std::string out_filename;
+   auto redir = url.rfind('>');
+   if (redir != std::string::npos) {
+      out_filename = url.substr(redir + 1);
+      url = url.substr(0, redir);
+   }
+
+   // If no redirect filename, extract from URL path
+   if (out_filename.empty()) {
+      auto last_slash = url.rfind('/');
+      if (last_slash != std::string::npos) {
+         out_filename = url.substr(last_slash + 1);
+      }
+   }
+
+   if (out_filename.empty()) {
+      g_m4board.response[0] = M4_ERROR;
+      const char* msg = "No filename in URL";
+      memcpy(g_m4board.response + 1, msg, strlen(msg) + 1);
+      g_m4board.response_len = static_cast<int>(2 + strlen(msg));
+      return;
+   }
+
+   // Build the full HTTP URL
+   std::string full_url = "http://" + url;
+
+   // Resolve output path within the virtual SD
+   std::string dest = resolve_path(out_filename);
+   if (dest.empty()) {
+      g_m4board.response[0] = M4_ERROR;
+      const char* msg = "Invalid output path";
+      memcpy(g_m4board.response + 1, msg, strlen(msg) + 1);
+      g_m4board.response_len = static_cast<int>(2 + strlen(msg));
+      return;
+   }
+
+   // Perform the HTTP GET download
+   FILE* fp = fopen(dest.c_str(), "wb");
+   if (!fp) {
+      g_m4board.response[0] = M4_ERROR;
+      const char* msg = "Cannot create file";
+      memcpy(g_m4board.response + 1, msg, strlen(msg) + 1);
+      g_m4board.response_len = static_cast<int>(2 + strlen(msg));
+      return;
+   }
+
+   CURL* curl = curl_easy_init();
+   if (!curl) {
+      fclose(fp);
+      std::filesystem::remove(dest);
+      g_m4board.response[0] = M4_ERROR;
+      const char* msg = "HTTP init failed";
+      memcpy(g_m4board.response + 1, msg, strlen(msg) + 1);
+      g_m4board.response_len = static_cast<int>(2 + strlen(msg));
+      return;
+   }
+
+   curl_easy_setopt(curl, CURLOPT_URL, full_url.c_str());
+   curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, curl_write_file);
+   curl_easy_setopt(curl, CURLOPT_WRITEDATA, fp);
+   curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
+   curl_easy_setopt(curl, CURLOPT_TIMEOUT, 30L);
+   curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 10L);
+   curl_easy_setopt(curl, CURLOPT_USERAGENT, "M4Board/2.0");
+   // Check for Content-Disposition filename (the real M4 uses attachment filenames)
+   curl_easy_setopt(curl, CURLOPT_FAILONERROR, 1L);
+
+   CURLcode res = curl_easy_perform(curl);
+   long http_code = 0;
+   curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
+   curl_easy_cleanup(curl);
+   fclose(fp);
+
+   if (res != CURLE_OK) {
+      std::filesystem::remove(dest);
+      g_m4board.response[0] = M4_ERROR;
+      std::string msg = curl_easy_strerror(res);
+      size_t max_msg = static_cast<size_t>(M4Board::RESPONSE_SIZE - 2);
+      if (msg.size() > max_msg) msg.resize(max_msg);
+      memcpy(g_m4board.response + 1, msg.c_str(), msg.size() + 1);
+      g_m4board.response_len = static_cast<int>(2 + msg.size());
+      LOG_ERROR("M4 HTTPGET: " << msg << " (URL: " << full_url << ")");
+      return;
+   }
+
+   // Success response: "Downloaded <filename>\r\n"
+   std::string ok_msg = "Downloaded " + out_filename + "\r\n";
+   size_t max_ok = static_cast<size_t>(M4Board::RESPONSE_SIZE - 1);
+   if (ok_msg.size() > max_ok) ok_msg.resize(max_ok);
+   memcpy(g_m4board.response, ok_msg.c_str(), ok_msg.size() + 1);
+   g_m4board.response_len = static_cast<int>(ok_msg.size() + 1);
+   LOG_INFO("M4 HTTPGET: downloaded " << full_url << " -> " << dest);
+}
+
+#else // !HAS_LIBCURL
+
+static void cmd_httpget()
+{
+   g_m4board.response[0] = M4_ERROR;
+   const char* msg = "HTTP not available (no libcurl)";
+   memcpy(g_m4board.response + 1, msg, strlen(msg) + 1);
+   g_m4board.response_len = static_cast<int>(2 + strlen(msg));
+   LOG_ERROR("M4 HTTPGET: libcurl not available at build time");
+}
+
+#endif // HAS_LIBCURL
+
 // ── Public API ──────────────────────────────────
 
 void m4board_reset()
@@ -339,15 +575,19 @@ void m4board_execute()
    g_m4board.response_len = 0;
 
    switch (cmd) {
-      case C_VERSION:  cmd_version(); break;
-      case C_CD:       cmd_cd(); break;
-      case C_READDIR:  cmd_readdir(); break;
-      case C_OPEN:     cmd_open(); break;
-      case C_CLOSE:    cmd_close(); break;
-      case C_READ:     cmd_read(); break;
-      case C_FSIZE:    cmd_fsize(); break;
+      case C_VERSION:   cmd_version(); break;
+      case C_CD:        cmd_cd(); break;
+      case C_READDIR:   cmd_readdir(); break;
+      case C_OPEN:      cmd_open(); break;
+      case C_CLOSE:     cmd_close(); break;
+      case C_READ:      cmd_read(); break;
+      case C_WRITE:     cmd_write(); break;
+      case C_SEEK:      cmd_seek(); break;
+      case C_FSIZE:     cmd_fsize(); break;
       case C_ERASEFILE: cmd_erasefile(); break;
-      case C_MAKEDIR:  cmd_makedir(); break;
+      case C_RENAME:    cmd_rename(); break;
+      case C_MAKEDIR:   cmd_makedir(); break;
+      case C_HTTPGET:   cmd_httpget(); break;
       default:
          LOG_DEBUG("M4: unknown command 0x" << std::hex << cmd);
          g_m4board.response[0] = M4_ERROR;

--- a/src/m4board.cpp
+++ b/src/m4board.cpp
@@ -601,8 +601,9 @@ void m4board_execute()
 void m4board_write_response(byte* rom_base)
 {
    if (!rom_base || g_m4board.response_len == 0) return;
-   // Write response at offset &0800 within the ROM (maps to &E800 in CPC address space)
-   int offset = 0x0800;
+   // Write response at offset &2800 within the ROM (maps to &E800 in CPC address space)
+   // The M4 ROM link table at &FF02 points to &E800 = ROM base + &2800
+   int offset = 0x2800;
    int len = std::min(g_m4board.response_len, M4Board::RESPONSE_SIZE);
    memcpy(rom_base + offset, g_m4board.response, len);
 }

--- a/src/m4board.cpp
+++ b/src/m4board.cpp
@@ -56,7 +56,8 @@ static std::string resolve_path(const std::string& rel_path)
          return "";
       }
       return cs;
-   } catch (...) {
+   } catch (const std::filesystem::filesystem_error& e) {
+      LOG_ERROR("M4: " << e.what());
       return "";
    }
 }
@@ -113,7 +114,8 @@ static void cmd_cd()
          g_m4board.response[0] = M4_ERROR;
          g_m4board.response_len = 1;
       }
-   } catch (...) {
+   } catch (const std::filesystem::filesystem_error& e) {
+      LOG_ERROR("M4: " << e.what());
       g_m4board.response[0] = M4_ERROR;
       g_m4board.response_len = 1;
    }
@@ -148,7 +150,8 @@ static void cmd_readdir()
          memcpy(g_m4board.response + pos, name.c_str(), name.size() + 1);
          pos += static_cast<int>(name.size()) + 1;
       }
-   } catch (...) {
+   } catch (const std::filesystem::filesystem_error& e) {
+      LOG_ERROR("M4: " << e.what());
       g_m4board.response[0] = M4_ERROR;
       g_m4board.response_len = 1;
       return;
@@ -257,7 +260,8 @@ static void cmd_fsize()
       g_m4board.response[3] = (fsize >> 16) & 0xFF;
       g_m4board.response[4] = (fsize >> 24) & 0xFF;
       g_m4board.response_len = 5;
-   } catch (...) {
+   } catch (const std::filesystem::filesystem_error& e) {
+      LOG_ERROR("M4: " << e.what());
       g_m4board.response[0] = M4_ERROR;
       g_m4board.response_len = 1;
    }
@@ -279,7 +283,8 @@ static void cmd_erasefile()
       } else {
          g_m4board.response[0] = M4_ERROR;
       }
-   } catch (...) {
+   } catch (const std::filesystem::filesystem_error& e) {
+      LOG_ERROR("M4: " << e.what());
       g_m4board.response[0] = M4_ERROR;
    }
    g_m4board.response_len = 1;
@@ -298,7 +303,8 @@ static void cmd_makedir()
    try {
       std::filesystem::create_directories(resolved);
       g_m4board.response[0] = M4_OK;
-   } catch (...) {
+   } catch (const std::filesystem::filesystem_error& e) {
+      LOG_ERROR("M4: " << e.what());
       g_m4board.response[0] = M4_ERROR;
    }
    g_m4board.response_len = 1;

--- a/src/m4board.cpp
+++ b/src/m4board.cpp
@@ -1,0 +1,368 @@
+#include "m4board.h"
+#include "log.h"
+#include <cstring>
+#include <filesystem>
+#include <algorithm>
+
+M4Board g_m4board;
+
+// M4 command codes (from m4cmds.i)
+static constexpr uint16_t C_OPEN       = 0x4301;
+static constexpr uint16_t C_READ       = 0x4302;
+[[maybe_unused]] static constexpr uint16_t C_WRITE      = 0x4303;
+static constexpr uint16_t C_CLOSE      = 0x4304;
+[[maybe_unused]] static constexpr uint16_t C_SEEK       = 0x4305;
+static constexpr uint16_t C_READDIR    = 0x4306;
+static constexpr uint16_t C_CD         = 0x4308;
+static constexpr uint16_t C_ERASEFILE  = 0x430E;
+[[maybe_unused]] static constexpr uint16_t C_RENAME     = 0x430F;
+static constexpr uint16_t C_MAKEDIR    = 0x4310;
+static constexpr uint16_t C_FSIZE      = 0x4311;
+static constexpr uint16_t C_VERSION    = 0x4326;
+
+// Response status codes
+static constexpr uint8_t M4_OK    = 0x00;
+static constexpr uint8_t M4_ERROR = 0xFF;
+
+// ── Path Safety ─────────────────────────────────
+
+static std::string resolve_path(const std::string& rel_path)
+{
+   // Build full path from SD root + current dir + relative path
+   std::string base = g_m4board.sd_root_path;
+   if (base.empty()) return "";
+
+   std::string full;
+   if (!rel_path.empty() && rel_path[0] == '/') {
+      full = base + rel_path;
+   } else {
+      full = base + g_m4board.current_dir;
+      if (full.back() != '/') full += '/';
+      full += rel_path;
+   }
+
+   // Resolve and verify it's within sd_root_path
+   try {
+      auto canonical = std::filesystem::weakly_canonical(full);
+      auto root_canonical = std::filesystem::weakly_canonical(base);
+      std::string cs = canonical.string();
+      std::string rs = root_canonical.string();
+      if (cs.substr(0, rs.size()) != rs) {
+         LOG_ERROR("M4: path traversal blocked: " << full);
+         return "";
+      }
+      return cs;
+   } catch (...) {
+      return "";
+   }
+}
+
+static std::string extract_string(const std::vector<uint8_t>& buf, size_t offset)
+{
+   std::string s;
+   for (size_t i = offset; i < buf.size() && buf[i] != 0; i++) {
+      s += static_cast<char>(buf[i]);
+   }
+   return s;
+}
+
+// ── Command Handlers ────────────────────────────
+
+static void cmd_version()
+{
+   const char* ver = "M4 konCePCja v1.0";
+   g_m4board.response[0] = M4_OK;
+   size_t len = strlen(ver);
+   memcpy(g_m4board.response + 1, ver, len);
+   g_m4board.response[1 + len] = 0;
+   g_m4board.response_len = static_cast<int>(2 + len);
+}
+
+static void cmd_cd()
+{
+   std::string path = extract_string(g_m4board.cmd_buf, 2);
+   if (path == "/") {
+      g_m4board.current_dir = "/";
+      g_m4board.response[0] = M4_OK;
+      g_m4board.response_len = 1;
+      return;
+   }
+
+   std::string resolved = resolve_path(path);
+   if (resolved.empty()) {
+      g_m4board.response[0] = M4_ERROR;
+      g_m4board.response_len = 1;
+      return;
+   }
+
+   try {
+      if (std::filesystem::is_directory(resolved)) {
+         // Convert back to relative path within SD root
+         auto root_canonical = std::filesystem::weakly_canonical(g_m4board.sd_root_path);
+         std::string rel = resolved.substr(root_canonical.string().size());
+         if (rel.empty()) rel = "/";
+         if (rel.back() != '/') rel += '/';
+         g_m4board.current_dir = rel;
+         g_m4board.response[0] = M4_OK;
+         g_m4board.response_len = 1;
+      } else {
+         g_m4board.response[0] = M4_ERROR;
+         g_m4board.response_len = 1;
+      }
+   } catch (...) {
+      g_m4board.response[0] = M4_ERROR;
+      g_m4board.response_len = 1;
+   }
+}
+
+static void cmd_readdir()
+{
+   std::string resolved = resolve_path(g_m4board.current_dir);
+   if (resolved.empty()) {
+      g_m4board.response[0] = M4_ERROR;
+      g_m4board.response_len = 1;
+      return;
+   }
+
+   g_m4board.response[0] = M4_OK;
+   int pos = 1;
+
+   try {
+      for (auto& entry : std::filesystem::directory_iterator(resolved)) {
+         std::string name = entry.path().filename().string();
+         bool is_dir = entry.is_directory();
+         size_t fsize = is_dir ? 0 : entry.file_size();
+
+         // Format: type(1) + size(4) + name + null
+         if (pos + 5 + static_cast<int>(name.size()) + 1 >= M4Board::RESPONSE_SIZE) break;
+
+         g_m4board.response[pos++] = is_dir ? 0x10 : 0x00;
+         g_m4board.response[pos++] = fsize & 0xFF;
+         g_m4board.response[pos++] = (fsize >> 8) & 0xFF;
+         g_m4board.response[pos++] = (fsize >> 16) & 0xFF;
+         g_m4board.response[pos++] = (fsize >> 24) & 0xFF;
+         memcpy(g_m4board.response + pos, name.c_str(), name.size() + 1);
+         pos += static_cast<int>(name.size()) + 1;
+      }
+   } catch (...) {
+      g_m4board.response[0] = M4_ERROR;
+      g_m4board.response_len = 1;
+      return;
+   }
+
+   // End marker
+   if (pos < M4Board::RESPONSE_SIZE) {
+      g_m4board.response[pos++] = 0xFF;
+   }
+   g_m4board.response_len = pos;
+}
+
+static void cmd_open()
+{
+   std::string path = extract_string(g_m4board.cmd_buf, 2);
+   std::string resolved = resolve_path(path);
+   if (resolved.empty()) {
+      g_m4board.response[0] = M4_ERROR;
+      g_m4board.response_len = 1;
+      return;
+   }
+
+   // Find free handle
+   int handle = -1;
+   for (int i = 0; i < 4; i++) {
+      if (!g_m4board.open_files[i]) { handle = i; break; }
+   }
+   if (handle < 0) {
+      g_m4board.response[0] = M4_ERROR;
+      g_m4board.response_len = 1;
+      return;
+   }
+
+   g_m4board.open_files[handle] = fopen(resolved.c_str(), "r+b");
+   if (!g_m4board.open_files[handle]) {
+      g_m4board.open_files[handle] = fopen(resolved.c_str(), "rb");
+   }
+   if (!g_m4board.open_files[handle]) {
+      g_m4board.response[0] = M4_ERROR;
+      g_m4board.response_len = 1;
+      return;
+   }
+
+   g_m4board.response[0] = M4_OK;
+   g_m4board.response[1] = static_cast<uint8_t>(handle);
+   g_m4board.response_len = 2;
+}
+
+static void cmd_close()
+{
+   if (g_m4board.cmd_buf.size() < 3) {
+      g_m4board.response[0] = M4_ERROR;
+      g_m4board.response_len = 1;
+      return;
+   }
+   int handle = g_m4board.cmd_buf[2];
+   if (handle >= 0 && handle < 4 && g_m4board.open_files[handle]) {
+      fclose(g_m4board.open_files[handle]);
+      g_m4board.open_files[handle] = nullptr;
+   }
+   g_m4board.response[0] = M4_OK;
+   g_m4board.response_len = 1;
+}
+
+static void cmd_read()
+{
+   if (g_m4board.cmd_buf.size() < 5) {
+      g_m4board.response[0] = M4_ERROR;
+      g_m4board.response_len = 1;
+      return;
+   }
+   int handle = g_m4board.cmd_buf[2];
+   uint16_t count = g_m4board.cmd_buf[3] | (g_m4board.cmd_buf[4] << 8);
+
+   if (handle < 0 || handle >= 4 || !g_m4board.open_files[handle]) {
+      g_m4board.response[0] = M4_ERROR;
+      g_m4board.response_len = 1;
+      return;
+   }
+
+   int max_read = M4Board::RESPONSE_SIZE - 3;
+   if (count > max_read) count = static_cast<uint16_t>(max_read);
+
+   size_t read = fread(g_m4board.response + 3, 1, count, g_m4board.open_files[handle]);
+   g_m4board.response[0] = M4_OK;
+   g_m4board.response[1] = read & 0xFF;
+   g_m4board.response[2] = (read >> 8) & 0xFF;
+   g_m4board.response_len = static_cast<int>(3 + read);
+}
+
+static void cmd_fsize()
+{
+   std::string path = extract_string(g_m4board.cmd_buf, 2);
+   std::string resolved = resolve_path(path);
+   if (resolved.empty()) {
+      g_m4board.response[0] = M4_ERROR;
+      g_m4board.response_len = 1;
+      return;
+   }
+
+   try {
+      auto fsize = std::filesystem::file_size(resolved);
+      g_m4board.response[0] = M4_OK;
+      g_m4board.response[1] = fsize & 0xFF;
+      g_m4board.response[2] = (fsize >> 8) & 0xFF;
+      g_m4board.response[3] = (fsize >> 16) & 0xFF;
+      g_m4board.response[4] = (fsize >> 24) & 0xFF;
+      g_m4board.response_len = 5;
+   } catch (...) {
+      g_m4board.response[0] = M4_ERROR;
+      g_m4board.response_len = 1;
+   }
+}
+
+static void cmd_erasefile()
+{
+   std::string path = extract_string(g_m4board.cmd_buf, 2);
+   std::string resolved = resolve_path(path);
+   if (resolved.empty()) {
+      g_m4board.response[0] = M4_ERROR;
+      g_m4board.response_len = 1;
+      return;
+   }
+
+   try {
+      if (std::filesystem::remove(resolved)) {
+         g_m4board.response[0] = M4_OK;
+      } else {
+         g_m4board.response[0] = M4_ERROR;
+      }
+   } catch (...) {
+      g_m4board.response[0] = M4_ERROR;
+   }
+   g_m4board.response_len = 1;
+}
+
+static void cmd_makedir()
+{
+   std::string path = extract_string(g_m4board.cmd_buf, 2);
+   std::string resolved = resolve_path(path);
+   if (resolved.empty()) {
+      g_m4board.response[0] = M4_ERROR;
+      g_m4board.response_len = 1;
+      return;
+   }
+
+   try {
+      std::filesystem::create_directories(resolved);
+      g_m4board.response[0] = M4_OK;
+   } catch (...) {
+      g_m4board.response[0] = M4_ERROR;
+   }
+   g_m4board.response_len = 1;
+}
+
+// ── Public API ──────────────────────────────────
+
+void m4board_reset()
+{
+   g_m4board.cmd_buf.clear();
+   g_m4board.cmd_pending = false;
+   g_m4board.current_dir = "/";
+   memset(g_m4board.response, 0, M4Board::RESPONSE_SIZE);
+   g_m4board.response_len = 0;
+}
+
+void m4board_cleanup()
+{
+   for (int i = 0; i < 4; i++) {
+      if (g_m4board.open_files[i]) {
+         fclose(g_m4board.open_files[i]);
+         g_m4board.open_files[i] = nullptr;
+      }
+   }
+}
+
+void m4board_data_out(byte val)
+{
+   g_m4board.cmd_buf.push_back(val);
+}
+
+void m4board_execute()
+{
+   if (g_m4board.cmd_buf.size() < 2) {
+      g_m4board.cmd_buf.clear();
+      return;
+   }
+
+   uint16_t cmd = g_m4board.cmd_buf[0] | (static_cast<uint16_t>(g_m4board.cmd_buf[1]) << 8);
+
+   memset(g_m4board.response, 0, M4Board::RESPONSE_SIZE);
+   g_m4board.response_len = 0;
+
+   switch (cmd) {
+      case C_VERSION:  cmd_version(); break;
+      case C_CD:       cmd_cd(); break;
+      case C_READDIR:  cmd_readdir(); break;
+      case C_OPEN:     cmd_open(); break;
+      case C_CLOSE:    cmd_close(); break;
+      case C_READ:     cmd_read(); break;
+      case C_FSIZE:    cmd_fsize(); break;
+      case C_ERASEFILE: cmd_erasefile(); break;
+      case C_MAKEDIR:  cmd_makedir(); break;
+      default:
+         LOG_DEBUG("M4: unknown command 0x" << std::hex << cmd);
+         g_m4board.response[0] = M4_ERROR;
+         g_m4board.response_len = 1;
+         break;
+   }
+
+   g_m4board.cmd_buf.clear();
+}
+
+void m4board_write_response(byte* rom_base)
+{
+   if (!rom_base || g_m4board.response_len == 0) return;
+   // Write response at offset &0800 within the ROM (maps to &E800 in CPC address space)
+   int offset = 0x0800;
+   int len = std::min(g_m4board.response_len, M4Board::RESPONSE_SIZE);
+   memcpy(rom_base + offset, g_m4board.response, len);
+}

--- a/src/m4board.h
+++ b/src/m4board.h
@@ -1,0 +1,51 @@
+/* konCePCja - Amstrad CPC Emulator
+   M4 Board - Virtual filesystem expansion
+
+   Command/response protocol via I/O ports:
+   - OUT &FE00: accumulate command bytes
+   - OUT &FC00: execute accumulated command
+   - Response written to ROM overlay at &E800
+
+   Virtual SD card is backed by a host directory.
+*/
+
+#ifndef M4BOARD_H
+#define M4BOARD_H
+
+#include "types.h"
+#include <string>
+#include <vector>
+#include <cstdio>
+
+struct M4Board {
+   bool enabled = false;
+   std::string sd_root_path;       // host directory = virtual SD
+   std::string current_dir = "/";
+
+   // Command state machine
+   std::vector<uint8_t> cmd_buf;   // accumulates OUT bytes
+   bool cmd_pending = false;
+
+   // Response buffer (written to ROM overlay at &E800)
+   static constexpr int RESPONSE_SIZE = 0x600; // 1.5KB
+   uint8_t response[RESPONSE_SIZE] = {};
+   int response_len = 0;
+
+   // File handles (up to 4 concurrent)
+   FILE* open_files[4] = {};
+
+   // ROM slot
+   int rom_slot = 7;
+};
+
+extern M4Board g_m4board;
+
+void m4board_reset();
+void m4board_cleanup();
+void m4board_data_out(byte val);
+void m4board_execute();
+
+// Write response into upper ROM overlay memory at given base
+void m4board_write_response(byte* rom_base);
+
+#endif

--- a/src/m4board.h
+++ b/src/m4board.h
@@ -34,8 +34,9 @@ struct M4Board {
    // File handles (up to 4 concurrent)
    FILE* open_files[4] = {};
 
-   // ROM slot
+   // ROM slot and auto-load tracking
    int rom_slot = 7;
+   bool rom_auto_loaded = false;   // true if we loaded the ROM (vs. user)
 };
 
 extern M4Board g_m4board;
@@ -47,5 +48,12 @@ void m4board_execute();
 
 // Write response into upper ROM overlay memory at given base
 void m4board_write_response(byte* rom_base);
+
+// Auto-load M4 ROM into the configured slot (called by emulator_init)
+// rom_map: the memmap_ROM[] array, rom_path: CPC.rom_path search directory
+void m4board_load_rom(byte** rom_map, const std::string& rom_path);
+
+// Unload M4 ROM if we auto-loaded it (called by emulator_shutdown)
+void m4board_unload_rom(byte** rom_map);
 
 #endif

--- a/src/smartwatch.cpp
+++ b/src/smartwatch.cpp
@@ -1,0 +1,112 @@
+#include "smartwatch.h"
+#include <ctime>
+
+SmartWatch g_smartwatch;
+
+// DS1216 recognition pattern: C5 3A A3 5C C5 3A A3 5C (LSB first per byte)
+static const uint64_t DS1216_PATTERN = 0x5CA33AC55CA33AC5ULL;
+
+static uint8_t to_bcd(int val)
+{
+   return static_cast<uint8_t>(((val / 10) << 4) | (val % 10));
+}
+
+static void smartwatch_snapshot_time()
+{
+   time_t now = time(nullptr);
+   struct tm *t = localtime(&now);
+
+   // DS1216 register map (8 bytes BCD, LSB first in serial stream):
+   // Byte 0: hundredths of seconds (always 00 — host clock lacks sub-second)
+   // Byte 1: seconds (00-59)
+   // Byte 2: minutes (00-59)
+   // Byte 3: hours (bit 7: 12/24, bit 5: AM/PM if 12h, bits 4-0: hour BCD)
+   // Byte 4: day of week (1-7), bit 4: OSC flag, bit 5: RST flag
+   // Byte 5: day of month (01-31)
+   // Byte 6: month (01-12)
+   // Byte 7: year (00-99)
+   g_smartwatch.rtc_data[0] = 0x00;                     // hundredths
+   g_smartwatch.rtc_data[1] = to_bcd(t->tm_sec);        // seconds
+   g_smartwatch.rtc_data[2] = to_bcd(t->tm_min);        // minutes
+   g_smartwatch.rtc_data[3] = 0x80 | to_bcd(t->tm_hour); // 24h mode (bit 7 set)
+   g_smartwatch.rtc_data[4] = (t->tm_wday == 0 ? 7 : t->tm_wday); // day of week 1-7
+   g_smartwatch.rtc_data[5] = to_bcd(t->tm_mday);       // day of month
+   g_smartwatch.rtc_data[6] = to_bcd(t->tm_mon + 1);    // month (1-12)
+   g_smartwatch.rtc_data[7] = to_bcd(t->tm_year % 100); // year
+}
+
+void smartwatch_reset()
+{
+   g_smartwatch.state = SmartWatch::IDLE;
+   g_smartwatch.bit_index = 0;
+   g_smartwatch.shift_reg = 0;
+}
+
+byte smartwatch_rom_read(word addr, byte rom_byte)
+{
+   bool a0 = addr & 0x01;  // data bit (for pattern matching)
+   bool a2 = addr & 0x04;  // mode: 0=write(pattern), 1=read(data)
+
+   switch (g_smartwatch.state) {
+      case SmartWatch::IDLE:
+         // Any read with A2=0 starts pattern matching
+         if (!a2) {
+            g_smartwatch.state = SmartWatch::MATCHING;
+            g_smartwatch.bit_index = 0;
+            g_smartwatch.shift_reg = 0;
+            // Process this first bit
+            g_smartwatch.shift_reg |= (static_cast<uint64_t>(a0) << g_smartwatch.bit_index);
+            g_smartwatch.bit_index++;
+         }
+         // A2=1 reads are normal ROM reads, returned unchanged
+         return rom_byte;
+
+      case SmartWatch::MATCHING:
+         if (!a2) {
+            // Accumulate pattern bit from A0
+            g_smartwatch.shift_reg |= (static_cast<uint64_t>(a0) << g_smartwatch.bit_index);
+            g_smartwatch.bit_index++;
+            if (g_smartwatch.bit_index == 64) {
+               // Check pattern
+               if (g_smartwatch.shift_reg == DS1216_PATTERN) {
+                  // Pattern matched — snapshot time and enter reading mode
+                  smartwatch_snapshot_time();
+                  g_smartwatch.state = SmartWatch::READING;
+                  g_smartwatch.bit_index = 0;
+               } else {
+                  // Pattern didn't match — reset
+                  g_smartwatch.state = SmartWatch::IDLE;
+                  g_smartwatch.bit_index = 0;
+               }
+            }
+         } else {
+            // A2=1 during matching resets the state machine
+            g_smartwatch.state = SmartWatch::IDLE;
+            g_smartwatch.bit_index = 0;
+         }
+         return rom_byte;
+
+      case SmartWatch::READING:
+         if (a2) {
+            // Return RTC data via D0, rest of bits from ROM
+            int byte_idx = g_smartwatch.bit_index / 8;
+            int bit_idx = g_smartwatch.bit_index % 8;
+            byte rtc_bit = (g_smartwatch.rtc_data[byte_idx] >> bit_idx) & 1;
+            g_smartwatch.bit_index++;
+            if (g_smartwatch.bit_index >= 64) {
+               g_smartwatch.state = SmartWatch::IDLE;
+               g_smartwatch.bit_index = 0;
+            }
+            return (rom_byte & 0xFE) | rtc_bit;  // replace D0
+         } else {
+            // A2=0 during reading — abort and start new pattern
+            g_smartwatch.state = SmartWatch::MATCHING;
+            g_smartwatch.bit_index = 0;
+            g_smartwatch.shift_reg = 0;
+            g_smartwatch.shift_reg |= (static_cast<uint64_t>(a0) << g_smartwatch.bit_index);
+            g_smartwatch.bit_index++;
+            return rom_byte;
+         }
+   }
+   return rom_byte;
+}

--- a/src/smartwatch.h
+++ b/src/smartwatch.h
@@ -1,0 +1,34 @@
+/* konCePCja - Amstrad CPC Emulator
+   Dobbertin SmartWatch - Dallas DS1216 RTC in ROM socket
+
+   The DS1216 is a phantom device between CPU and ROM. It intercepts
+   ROM reads using a serial bit-banging protocol:
+   1. Read ≥64 bits to reset (auto-handled by state machine)
+   2. Write 64-bit pattern by reading from A2=0 addresses, data on A0
+   3. Pattern: C5 3A A3 5C C5 3A A3 5C (LSB first per byte)
+   4. If matched, next 64 reads (A2=1) return BCD time via D0
+*/
+
+#ifndef SMARTWATCH_H
+#define SMARTWATCH_H
+
+#include "types.h"
+
+struct SmartWatch {
+   bool enabled = false;
+   enum State { IDLE, MATCHING, READING } state = IDLE;
+   int bit_index = 0;           // 0-63
+   uint64_t shift_reg = 0;      // accumulated pattern bits
+   uint8_t rtc_data[8] = {};    // BCD time snapshot (filled on match)
+};
+
+extern SmartWatch g_smartwatch;
+
+void smartwatch_reset();
+
+// Called on every upper ROM read when SmartWatch is enabled.
+// addr = full 16-bit Z80 address, rom_byte = normal ROM data.
+// Returns the (possibly modified) byte to deliver to Z80.
+byte smartwatch_rom_read(word addr, byte rom_byte);
+
+#endif

--- a/src/symbiface.cpp
+++ b/src/symbiface.cpp
@@ -39,7 +39,7 @@ static void ide_set_string(uint16_t* buf, int word_start, int word_count, const 
    for (int w = 0; w < word_count; w++) {
       int si = w * 2;
       char c0 = str[si] ? str[si] : ' ';
-      char c1 = str[si + 1] ? str[si + 1] : ' ';
+      char c1 = (str[si] && str[si + 1]) ? str[si + 1] : ' ';
       buf[word_start + w] = (static_cast<uint16_t>(c0) << 8) | c1;
       if (!str[si] || !str[si + 1]) {
          // Pad rest with spaces

--- a/src/symbiface.cpp
+++ b/src/symbiface.cpp
@@ -1,0 +1,380 @@
+#include "symbiface.h"
+#include "log.h"
+#include <cstring>
+#include <ctime>
+
+Symbiface g_symbiface;
+
+// ── Status register bits ────────────────────────
+[[maybe_unused]] static constexpr uint8_t ATA_SR_BSY  = 0x80;
+static constexpr uint8_t ATA_SR_DRDY = 0x40;
+static constexpr uint8_t ATA_SR_DRQ  = 0x08;
+static constexpr uint8_t ATA_SR_ERR  = 0x01;
+
+// ── ATA commands ────────────────────────────────
+static constexpr uint8_t ATA_CMD_READ_SECTORS  = 0x20;
+static constexpr uint8_t ATA_CMD_WRITE_SECTORS = 0x30;
+static constexpr uint8_t ATA_CMD_IDENTIFY       = 0xEC;
+static constexpr uint8_t ATA_CMD_IDLE_IMMEDIATE = 0xE1;
+static constexpr uint8_t ATA_CMD_INIT_PARAMS    = 0x91;
+
+// ── Helpers ─────────────────────────────────────
+
+static IDE_Device& active_ide()
+{
+   return g_symbiface.active_drive ? g_symbiface.ide_slave : g_symbiface.ide_master;
+}
+
+static uint32_t ide_lba(const IDE_Device& dev)
+{
+   return (static_cast<uint32_t>(dev.drive_head & 0x0F) << 24) |
+          (static_cast<uint32_t>(dev.lba_high) << 16) |
+          (static_cast<uint32_t>(dev.lba_mid) << 8) |
+          dev.lba_low;
+}
+
+static void ide_set_string(uint16_t* buf, int word_start, int word_count, const char* str)
+{
+   // ATA strings are byte-swapped within each word
+   for (int w = 0; w < word_count; w++) {
+      int si = w * 2;
+      char c0 = str[si] ? str[si] : ' ';
+      char c1 = str[si + 1] ? str[si + 1] : ' ';
+      buf[word_start + w] = (static_cast<uint16_t>(c0) << 8) | c1;
+      if (!str[si] || !str[si + 1]) {
+         // Pad rest with spaces
+         for (int w2 = w + 1; w2 < word_count; w2++) {
+            buf[word_start + w2] = 0x2020;
+         }
+         break;
+      }
+   }
+}
+
+static void ide_do_identify(IDE_Device& dev)
+{
+   memset(dev.sector_buf, 0, 512);
+   auto* id = reinterpret_cast<uint16_t*>(dev.sector_buf);
+
+   id[0] = 0x0040;  // non-removable, non-magnetic, hard-sectored
+   // CHS geometry (approximate)
+   uint32_t cyls = dev.total_sectors / (16 * 63);
+   if (cyls > 16383) cyls = 16383;
+   id[1] = static_cast<uint16_t>(cyls);     // cylinders
+   id[3] = 16;                               // heads
+   id[6] = 63;                               // sectors per track
+   ide_set_string(id, 10, 10, "KONCEPCJA001");  // serial
+   ide_set_string(id, 23, 4, "1.00");            // firmware rev
+   ide_set_string(id, 27, 20, "konCePCja Virtual CF");  // model
+   id[47] = 1;       // max sectors per interrupt (PIO)
+   id[49] = 0x0200;  // LBA supported
+   id[53] = 0x0001;  // words 54-58 are valid
+   id[54] = static_cast<uint16_t>(cyls);
+   id[55] = 16;
+   id[56] = 63;
+   uint32_t chs_secs = cyls * 16 * 63;
+   id[57] = static_cast<uint16_t>(chs_secs & 0xFFFF);
+   id[58] = static_cast<uint16_t>(chs_secs >> 16);
+   id[60] = static_cast<uint16_t>(dev.total_sectors & 0xFFFF);
+   id[61] = static_cast<uint16_t>(dev.total_sectors >> 16);
+
+   dev.buf_pos = 0;
+   dev.data_ready = true;
+   dev.status = ATA_SR_DRDY | ATA_SR_DRQ;
+}
+
+static void ide_do_read(IDE_Device& dev)
+{
+   if (!dev.image) {
+      dev.status = ATA_SR_DRDY | ATA_SR_ERR;
+      dev.error = 0x04; // abort
+      return;
+   }
+   uint32_t lba = ide_lba(dev);
+   if (lba >= dev.total_sectors) {
+      dev.status = ATA_SR_DRDY | ATA_SR_ERR;
+      dev.error = 0x10; // IDNF
+      return;
+   }
+   fseek(dev.image, lba * 512L, SEEK_SET);
+   size_t read = fread(dev.sector_buf, 1, 512, dev.image);
+   if (read < 512) memset(dev.sector_buf + read, 0, 512 - read);
+
+   dev.buf_pos = 0;
+   dev.data_ready = true;
+   dev.status = ATA_SR_DRDY | ATA_SR_DRQ;
+}
+
+static void ide_do_write_commit(IDE_Device& dev)
+{
+   if (!dev.image) {
+      dev.status = ATA_SR_DRDY | ATA_SR_ERR;
+      dev.error = 0x04;
+      return;
+   }
+   uint32_t lba = ide_lba(dev);
+   if (lba >= dev.total_sectors) {
+      dev.status = ATA_SR_DRDY | ATA_SR_ERR;
+      dev.error = 0x10;
+      return;
+   }
+   fseek(dev.image, lba * 512L, SEEK_SET);
+   fwrite(dev.sector_buf, 1, 512, dev.image);
+   fflush(dev.image);
+
+   dev.write_pending = false;
+   // Advance LBA for multi-sector writes
+   dev.sector_count--;
+   if (dev.sector_count > 0) {
+      uint32_t next = lba + 1;
+      dev.lba_low = next & 0xFF;
+      dev.lba_mid = (next >> 8) & 0xFF;
+      dev.lba_high = (next >> 16) & 0xFF;
+      dev.drive_head = (dev.drive_head & 0xF0) | ((next >> 24) & 0x0F);
+      dev.buf_pos = 0;
+      dev.write_pending = true;
+      dev.status = ATA_SR_DRDY | ATA_SR_DRQ;
+   } else {
+      dev.status = ATA_SR_DRDY;
+   }
+}
+
+static void ide_execute_command(IDE_Device& dev)
+{
+   switch (dev.command) {
+      case ATA_CMD_IDENTIFY:
+         ide_do_identify(dev);
+         break;
+      case ATA_CMD_READ_SECTORS:
+         ide_do_read(dev);
+         break;
+      case ATA_CMD_WRITE_SECTORS:
+         // Prepare to receive data
+         dev.buf_pos = 0;
+         dev.write_pending = true;
+         dev.data_ready = false;
+         memset(dev.sector_buf, 0, 512);
+         dev.status = ATA_SR_DRDY | ATA_SR_DRQ;
+         break;
+      case ATA_CMD_IDLE_IMMEDIATE:
+         dev.status = ATA_SR_DRDY;
+         break;
+      case ATA_CMD_INIT_PARAMS:
+         dev.status = ATA_SR_DRDY;
+         break;
+      default:
+         LOG_DEBUG("Symbiface IDE: unknown command 0x" << std::hex << static_cast<int>(dev.command));
+         dev.status = ATA_SR_DRDY | ATA_SR_ERR;
+         dev.error = 0x04; // abort
+         break;
+   }
+}
+
+// ── Public API ──────────────────────────────────
+
+void symbiface_reset()
+{
+   g_symbiface.active_drive = 0;
+   g_symbiface.ide_master.status = g_symbiface.ide_master.present ? ATA_SR_DRDY : 0;
+   g_symbiface.ide_master.error = 0;
+   g_symbiface.ide_master.buf_pos = 0;
+   g_symbiface.ide_master.data_ready = false;
+   g_symbiface.ide_master.write_pending = false;
+   g_symbiface.ide_slave.status = g_symbiface.ide_slave.present ? ATA_SR_DRDY : 0;
+   g_symbiface.ide_slave.error = 0;
+   g_symbiface.ide_slave.buf_pos = 0;
+   g_symbiface.ide_slave.data_ready = false;
+   g_symbiface.ide_slave.write_pending = false;
+
+   g_symbiface.rtc.address_reg = 0;
+   g_symbiface.mouse.x_counter = 0;
+   g_symbiface.mouse.y_counter = 0;
+   g_symbiface.mouse.buttons = 0xFF;
+}
+
+void symbiface_cleanup()
+{
+   symbiface_ide_detach(0);
+   symbiface_ide_detach(1);
+}
+
+bool symbiface_ide_attach(int drive, const std::string& path)
+{
+   IDE_Device& dev = drive ? g_symbiface.ide_slave : g_symbiface.ide_master;
+   symbiface_ide_detach(drive);
+
+   dev.image = fopen(path.c_str(), "r+b");
+   if (!dev.image) {
+      // Try creating the file
+      dev.image = fopen(path.c_str(), "w+b");
+   }
+   if (!dev.image) {
+      LOG_ERROR("Symbiface IDE: cannot open " << path);
+      return false;
+   }
+   dev.image_path = path;
+   dev.present = true;
+
+   // Determine size in sectors
+   fseek(dev.image, 0, SEEK_END);
+   long size = ftell(dev.image);
+   dev.total_sectors = static_cast<uint32_t>(size / 512);
+   dev.status = ATA_SR_DRDY;
+
+   LOG_INFO("Symbiface IDE " << drive << ": attached " << path << " (" << dev.total_sectors << " sectors)");
+   return true;
+}
+
+void symbiface_ide_detach(int drive)
+{
+   IDE_Device& dev = drive ? g_symbiface.ide_slave : g_symbiface.ide_master;
+   if (dev.image) {
+      fclose(dev.image);
+      dev.image = nullptr;
+   }
+   dev.present = false;
+   dev.image_path.clear();
+   dev.status = 0;
+   dev.total_sectors = 0;
+}
+
+// ── IDE I/O ─────────────────────────────────────
+
+byte symbiface_ide_read(byte reg_offset)
+{
+   IDE_Device& dev = active_ide();
+   if (!dev.present) return 0xFF;
+
+   switch (reg_offset & 0x07) {
+      case 0: // Data register
+         if (dev.data_ready && dev.buf_pos < 512) {
+            byte val = dev.sector_buf[dev.buf_pos++];
+            if (dev.buf_pos >= 512) {
+               dev.data_ready = false;
+               // Multi-sector read: advance and read next
+               if (dev.command == ATA_CMD_READ_SECTORS) {
+                  dev.sector_count--;
+                  if (dev.sector_count > 0) {
+                     uint32_t next = ide_lba(dev) + 1;
+                     dev.lba_low = next & 0xFF;
+                     dev.lba_mid = (next >> 8) & 0xFF;
+                     dev.lba_high = (next >> 16) & 0xFF;
+                     dev.drive_head = (dev.drive_head & 0xF0) | ((next >> 24) & 0x0F);
+                     ide_do_read(dev);
+                  } else {
+                     dev.status = ATA_SR_DRDY;
+                  }
+               } else {
+                  dev.status = ATA_SR_DRDY;
+               }
+            }
+            return val;
+         }
+         return 0xFF;
+      case 1: return dev.error;
+      case 2: return dev.sector_count;
+      case 3: return dev.lba_low;
+      case 4: return dev.lba_mid;
+      case 5: return dev.lba_high;
+      case 6: return dev.drive_head;
+      case 7: return dev.status;
+   }
+   return 0xFF;
+}
+
+void symbiface_ide_write(byte reg_offset, byte val)
+{
+   // Drive/head register selects active drive
+   if ((reg_offset & 0x07) == 6) {
+      g_symbiface.active_drive = (val >> 4) & 1;
+   }
+
+   IDE_Device& dev = active_ide();
+   if (!dev.present && (reg_offset & 0x07) != 6) return;
+
+   switch (reg_offset & 0x07) {
+      case 0: // Data register
+         if (dev.write_pending && dev.buf_pos < 512) {
+            dev.sector_buf[dev.buf_pos++] = val;
+            if (dev.buf_pos >= 512) {
+               ide_do_write_commit(dev);
+            }
+         }
+         break;
+      case 1: dev.features = val; break;
+      case 2: dev.sector_count = val; break;
+      case 3: dev.lba_low = val; break;
+      case 4: dev.lba_mid = val; break;
+      case 5: dev.lba_high = val; break;
+      case 6: dev.drive_head = val; break;
+      case 7: // Command register
+         dev.command = val;
+         dev.error = 0;
+         ide_execute_command(dev);
+         break;
+   }
+}
+
+// ── RTC ─────────────────────────────────────────
+
+static uint8_t to_bcd(int val) {
+   return static_cast<uint8_t>(((val / 10) << 4) | (val % 10));
+}
+
+void symbiface_rtc_write_addr(byte val)
+{
+   g_symbiface.rtc.address_reg = val & 0x3F; // 6-bit address space
+}
+
+void symbiface_rtc_write_data(byte val)
+{
+   uint8_t reg = g_symbiface.rtc.address_reg;
+   if (reg >= 14 && reg < 64) {
+      // CMOS RAM area (regs 14-63)
+      g_symbiface.rtc.cmos_ram[reg - 14] = val;
+   }
+   // Registers 0-13 are time registers (read-only from host clock perspective)
+}
+
+byte symbiface_rtc_read()
+{
+   uint8_t reg = g_symbiface.rtc.address_reg;
+
+   if (reg < 14) {
+      // Time registers — read from host clock
+      time_t now = time(nullptr);
+      struct tm* t = localtime(&now);
+
+      switch (reg) {
+         case 0: return to_bcd(t->tm_sec);       // seconds
+         case 2: return to_bcd(t->tm_min);       // minutes
+         case 4: return to_bcd(t->tm_hour);      // hours (24h)
+         case 6: return static_cast<byte>(t->tm_wday == 0 ? 7 : t->tm_wday); // day of week
+         case 7: return to_bcd(t->tm_mday);      // day of month
+         case 8: return to_bcd(t->tm_mon + 1);   // month
+         case 9: return to_bcd(t->tm_year % 100); // year
+         case 10: return 0x26; // Register A: UIP=0, DV=010, RS=0110
+         case 11: return 0x02; // Register B: 24h mode, BCD
+         case 12: return 0x00; // Register C: no interrupts
+         case 13: return 0x80; // Register D: VRT=1 (valid RAM)
+         default: return 0;
+      }
+   } else if (reg < 64) {
+      return g_symbiface.rtc.cmos_ram[reg - 14];
+   }
+   return 0xFF;
+}
+
+// ── PS/2 Mouse ──────────────────────────────────
+
+void symbiface_mouse_update(float dx, float dy, uint32_t sdl_buttons)
+{
+   g_symbiface.mouse.x_counter += static_cast<int8_t>(dx);
+   g_symbiface.mouse.y_counter -= static_cast<int8_t>(dy); // Y inverted
+
+   // Buttons: active-high for Kempston mouse
+   g_symbiface.mouse.buttons = 0xFF;
+   if (sdl_buttons & 1) g_symbiface.mouse.buttons &= ~0x01; // left
+   if (sdl_buttons & 4) g_symbiface.mouse.buttons &= ~0x02; // right
+   if (sdl_buttons & 2) g_symbiface.mouse.buttons &= ~0x04; // middle
+}

--- a/src/symbiface.h
+++ b/src/symbiface.h
@@ -1,0 +1,90 @@
+/* konCePCja - Amstrad CPC Emulator
+   Symbiface II - IDE + RTC + PS/2 Mouse expansion board
+
+   Port map:
+   - IDE + RTC: &FD00-&FD3F (port.b.h == 0xFD, port.b.l & 0xC0 == 0x00)
+     - IDE regs: port.b.l & 0x38 == 0x08, offset = port.b.l & 0x07
+     - IDE alt:  port.b.l & 0x38 == 0x18
+     - RTC:      port.b.l & 0x38 == 0x00, addr/data via port.b.l & 0x01
+   - PS/2 Mouse: &FBEE (X), &FBEF (Y)
+*/
+
+#ifndef SYMBIFACE_H
+#define SYMBIFACE_H
+
+#include "types.h"
+#include <string>
+#include <cstdio>
+#include <cstdint>
+
+// ── IDE (ATA PIO) ──────────────────────────────
+struct IDE_Device {
+   FILE* image = nullptr;
+   bool present = false;
+   std::string image_path;
+
+   // ATA register file
+   uint8_t error = 0;        // read: error, write: features
+   uint8_t features = 0;
+   uint8_t sector_count = 0;
+   uint8_t lba_low = 0;      // sector number
+   uint8_t lba_mid = 0;      // cylinder low
+   uint8_t lba_high = 0;     // cylinder high
+   uint8_t drive_head = 0;   // bit 4: drive select, bits 3-0: head
+   uint8_t status = 0;       // bit 7: BSY, bit 6: DRDY, bit 3: DRQ, bit 0: ERR
+   uint8_t command = 0;
+
+   // Data transfer state
+   uint8_t sector_buf[512] = {};
+   int buf_pos = 0;          // current byte position in sector_buf
+   bool data_ready = false;  // sector_buf has data for reading
+   bool write_pending = false; // sector_buf waiting to be written
+
+   uint32_t total_sectors = 0;  // size in 512-byte sectors
+};
+
+// ── RTC (DS12887) ──────────────────────────────
+struct SF2_RTC {
+   uint8_t address_reg = 0;       // selected register
+   uint8_t cmos_ram[50] = {};     // 50 bytes of CMOS NVRAM
+};
+
+// ── PS/2 Mouse (Kempston) ──────────────────────
+struct SF2_Mouse {
+   uint8_t x_counter = 0;    // wrapping 8-bit X position
+   uint8_t y_counter = 0;    // wrapping 8-bit Y position
+   uint8_t buttons = 0xFF;   // active-high: bit 0=left, bit 1=right, bit 2=middle
+};
+
+// ── Master struct ──────────────────────────────
+struct Symbiface {
+   bool enabled = false;
+
+   IDE_Device ide_master;
+   IDE_Device ide_slave;
+   int active_drive = 0;  // 0=master, 1=slave
+
+   SF2_RTC rtc;
+   SF2_Mouse mouse;
+};
+
+extern Symbiface g_symbiface;
+
+void symbiface_reset();
+void symbiface_cleanup();
+
+// IDE
+byte symbiface_ide_read(byte reg_offset);
+void symbiface_ide_write(byte reg_offset, byte val);
+bool symbiface_ide_attach(int drive, const std::string& path);
+void symbiface_ide_detach(int drive);
+
+// RTC
+byte symbiface_rtc_read();
+void symbiface_rtc_write_addr(byte val);
+void symbiface_rtc_write_data(byte val);
+
+// Mouse
+void symbiface_mouse_update(float dx, float dy, uint32_t sdl_buttons);
+
+#endif

--- a/src/z80.cpp
+++ b/src/z80.cpp
@@ -34,6 +34,7 @@
 #include "trace.h"
 #include "koncepcja_ipc_server.h"
 #include "expr_parser.h"
+#include "smartwatch.h"
 #include "log.h"
 #include <algorithm>
 #include <vector>
@@ -342,7 +343,12 @@ static byte cc_ex[256] = {
 extern byte *membank_read[4], *membank_write[4];
 
 inline byte read_mem_no_watchpoint(word addr) {
-  return (*(membank_read[addr >> 14] + (addr & 0x3fff))); // returns a byte from a 16KB memory bank
+  byte val = *(membank_read[addr >> 14] + (addr & 0x3fff)); // returns a byte from a 16KB memory bank
+  // SmartWatch intercepts upper ROM reads (ROM must be paged in)
+  if (g_smartwatch.enabled && (addr >= 0xC000) && !(GateArray.ROM_config & 0x08)) {
+    val = smartwatch_rom_read(addr, val);
+  }
+  return val;
 }
 
 inline byte read_mem(word addr) {


### PR DESCRIPTION
## Summary

- **AmDrum (Cheetah)**: 8-bit DAC on port &FFxx mixed into PSG audio output, following the Digiblaster pattern
- **Dobbertin SmartWatch**: DS1216 phantom RTC intercepting upper ROM reads via 64-bit serial pattern matching, returns host BCD time
- **AMX Mouse**: Joystick port mouse on keyboard matrix row 9 with monostable reset tracking for mickey consumption
- **Drive/Tape Sounds**: Procedurally generated motor hum, seek clicks, and tape hiss mixed at synthesizer output stage
- **Symbiface II**: IDE ATA PIO (read/write/identify backed by .img files), DS12887 RTC (14 time regs + 50B CMOS RAM), PS/2 Kempston mouse at &FBEE/&FBEF
- **M4 Board**: Virtual SD filesystem via command/response protocol on &FE00/&FC00 with path traversal protection

All peripherals include config persistence (`[sound]`/`[system]`/`[input]`/`[peripheral]` sections), Options dialog checkboxes, and `emulator_reset()` integration. 628 tests pass.

### New files (12)
`src/amdrum.{h,cpp}`, `src/smartwatch.{h,cpp}`, `src/amx_mouse.{h,cpp}`, `src/drive_sounds.{h,cpp}`, `src/symbiface.{h,cpp}`, `src/m4board.{h,cpp}`

### Modified files (6)
`kon_cpc_ja.cpp` (I/O handlers, config, reset, SDL events), `psg.cpp` (audio mixing), `z80.cpp` (SmartWatch ROM read intercept), `imgui_ui.cpp` (Options checkboxes), `fdc.cpp` (seek sound hook), `CLAUDE.md`/`AGENTS.md` (Emulated Devices section)

## Test plan
- [x] `make -j ARCH=macos` builds clean (warnings only, no errors)
- [x] `make debug` — all 628 tests pass
- [ ] Manual: Enable AmDrum, load Amdrum software, verify DAC audio output
- [ ] Manual: Enable SmartWatch, run TimeROM software, verify host clock time
- [ ] Manual: Enable AMX Mouse, run AMX Art, verify cursor tracking + buttons
- [ ] Manual: Enable Drive Sounds, load DSK, verify motor hum + seek clicks
- [ ] Manual: Enable Symbiface II, attach .img, boot SymbOS from IDE
- [ ] Manual: Enable M4 Board, set m4_sd_path, use |DIR from BASIC
- [ ] Toggle each peripheral on/off without audio artifacts or crashes