### PR TITLE
feat: dockable workspace layouts

### DIFF
--- a/src/devtools_ui.cpp
+++ b/src/devtools_ui.cpp
@@ -119,6 +119,18 @@ bool DevToolsUI::any_window_open() const
          show_recording_controls_;
 }
 
+const char* const* DevToolsUI::all_window_keys(int* count)
+{
+  static const char* keys[] = {
+    "registers", "disassembly", "memory_hex", "stack", "breakpoints",
+    "symbols", "session_recording", "gfx_finder", "silicon_disc",
+    "asic", "disc_tools", "data_areas", "disasm_export",
+    "video_state", "audio_state", "recording_controls"
+  };
+  *count = 16;
+  return keys;
+}
+
 void DevToolsUI::navigate_disassembly(word addr)
 {
   show_disassembly_ = true;

--- a/src/devtools_ui.h
+++ b/src/devtools_ui.h
@@ -21,6 +21,9 @@ public:
     void navigate_to(word addr, NavTarget target);
     void navigate_memory(word addr);
 
+    // Returns the array of all window key strings (16 entries).
+    static const char* const* all_window_keys(int* count);
+
 private:
     bool show_registers_ = false;
     bool show_disassembly_ = false;

--- a/src/imgui_ui.cpp
+++ b/src/imgui_ui.cpp
@@ -1598,17 +1598,17 @@ static void imgui_render_devtools()
     }
     if (ImGui::BeginMenu("Layout")) {
       // Mode selection
-      if (ImGui::RadioButton("Classic Mode", CPC.workspace_layout == 0)) {
-        CPC.workspace_layout = 0;
+      if (ImGui::RadioButton("Classic Mode", CPC.workspace_layout == t_CPC::WorkspaceLayoutMode::Classic)) {
+        CPC.workspace_layout = t_CPC::WorkspaceLayoutMode::Classic;
       }
-      if (ImGui::RadioButton("Docked Mode", CPC.workspace_layout == 1)) {
-        CPC.workspace_layout = 1;
+      if (ImGui::RadioButton("Docked Mode", CPC.workspace_layout == t_CPC::WorkspaceLayoutMode::Docked)) {
+        CPC.workspace_layout = t_CPC::WorkspaceLayoutMode::Docked;
       }
       ImGui::Separator();
 
       // Preset layouts (apply DockBuilder templates in docked mode,
       // toggle window groups in classic mode)
-      if (CPC.workspace_layout == 1) {
+      if (CPC.workspace_layout == t_CPC::WorkspaceLayoutMode::Docked) {
         if (ImGui::MenuItem("Apply Debug Layout"))
           workspace_apply_preset(WorkspacePreset::Debug);
         if (ImGui::MenuItem("Apply IDE Layout"))
@@ -1676,13 +1676,13 @@ static void imgui_render_devtools()
       }
 
       // CPC Screen scale (only in docked mode)
-      if (CPC.workspace_layout == 1) {
+      if (CPC.workspace_layout == t_CPC::WorkspaceLayoutMode::Docked) {
         ImGui::Separator();
         ImGui::TextUnformatted("CPC Screen Scale");
-        if (ImGui::RadioButton("Fit",  CPC.cpc_screen_scale == 0)) CPC.cpc_screen_scale = 0;
-        if (ImGui::RadioButton("1x",   CPC.cpc_screen_scale == 1)) CPC.cpc_screen_scale = 1;
-        if (ImGui::RadioButton("2x",   CPC.cpc_screen_scale == 2)) CPC.cpc_screen_scale = 2;
-        if (ImGui::RadioButton("3x",   CPC.cpc_screen_scale == 3)) CPC.cpc_screen_scale = 3;
+        if (ImGui::RadioButton("Fit",  CPC.cpc_screen_scale == t_CPC::ScreenScale::Fit)) CPC.cpc_screen_scale = t_CPC::ScreenScale::Fit;
+        if (ImGui::RadioButton("1x",   CPC.cpc_screen_scale == t_CPC::ScreenScale::X1))  CPC.cpc_screen_scale = t_CPC::ScreenScale::X1;
+        if (ImGui::RadioButton("2x",   CPC.cpc_screen_scale == t_CPC::ScreenScale::X2))  CPC.cpc_screen_scale = t_CPC::ScreenScale::X2;
+        if (ImGui::RadioButton("3x",   CPC.cpc_screen_scale == t_CPC::ScreenScale::X3))  CPC.cpc_screen_scale = t_CPC::ScreenScale::X3;
       }
 
       // Save Layout modal popup

--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -2017,6 +2017,11 @@ void loadConfiguration (t_CPC &CPC, const std::string& configFilename)
    CPC.devtools_scale = conf.getIntValue("devtools", "scale", 1);
    CPC.devtools_max_stack_size = conf.getIntValue("devtools", "max_stack_size", 50);
 
+   CPC.workspace_layout = conf.getIntValue("ui", "workspace_layout", 0);
+   if (CPC.workspace_layout < 0 || CPC.workspace_layout > 1) CPC.workspace_layout = 0;
+   CPC.cpc_screen_scale = conf.getIntValue("ui", "cpc_screen_scale", 0);
+   if (CPC.cpc_screen_scale < 0 || CPC.cpc_screen_scale > 3) CPC.cpc_screen_scale = 0;
+
    CPC.scr_scale = conf.getIntValue("video", "scr_scale", 2);
    CPC.scr_preserve_aspect_ratio = conf.getIntValue("video", "scr_preserve_aspect_ratio", 1);
    CPC.scr_style = conf.getIntValue("video", "scr_style", 1);
@@ -2147,6 +2152,9 @@ bool saveConfiguration (t_CPC &CPC, const std::string& configFilename)
    conf.setIntValue("video", "scr_window", CPC.scr_window);
 
    conf.setIntValue("devtools", "scale", CPC.devtools_scale);
+
+   conf.setIntValue("ui", "workspace_layout", CPC.workspace_layout);
+   conf.setIntValue("ui", "cpc_screen_scale", CPC.cpc_screen_scale);
 
    conf.setIntValue("video", "scr_green_mode", CPC.scr_green_mode);
    conf.setIntValue("video", "scr_green_blue_percent", CPC.scr_green_blue_percent);

--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -2017,10 +2017,15 @@ void loadConfiguration (t_CPC &CPC, const std::string& configFilename)
    CPC.devtools_scale = conf.getIntValue("devtools", "scale", 1);
    CPC.devtools_max_stack_size = conf.getIntValue("devtools", "max_stack_size", 50);
 
-   CPC.workspace_layout = conf.getIntValue("ui", "workspace_layout", 0);
-   if (CPC.workspace_layout < 0 || CPC.workspace_layout > 1) CPC.workspace_layout = 0;
-   CPC.cpc_screen_scale = conf.getIntValue("ui", "cpc_screen_scale", 0);
-   if (CPC.cpc_screen_scale < 0 || CPC.cpc_screen_scale > 3) CPC.cpc_screen_scale = 0;
+   {
+      int wl = conf.getIntValue("ui", "workspace_layout", 0);
+      CPC.workspace_layout = (wl == 1) ? t_CPC::WorkspaceLayoutMode::Docked
+                                       : t_CPC::WorkspaceLayoutMode::Classic;
+      int ss = conf.getIntValue("ui", "cpc_screen_scale", 0);
+      CPC.cpc_screen_scale = (ss >= 0 && ss <= 3)
+          ? static_cast<t_CPC::ScreenScale>(ss)
+          : t_CPC::ScreenScale::Fit;
+   }
 
    CPC.scr_scale = conf.getIntValue("video", "scr_scale", 2);
    CPC.scr_preserve_aspect_ratio = conf.getIntValue("video", "scr_preserve_aspect_ratio", 1);
@@ -2153,8 +2158,8 @@ bool saveConfiguration (t_CPC &CPC, const std::string& configFilename)
 
    conf.setIntValue("devtools", "scale", CPC.devtools_scale);
 
-   conf.setIntValue("ui", "workspace_layout", CPC.workspace_layout);
-   conf.setIntValue("ui", "cpc_screen_scale", CPC.cpc_screen_scale);
+   conf.setIntValue("ui", "workspace_layout", static_cast<int>(CPC.workspace_layout));
+   conf.setIntValue("ui", "cpc_screen_scale", static_cast<int>(CPC.cpc_screen_scale));
 
    conf.setIntValue("video", "scr_green_mode", CPC.scr_green_mode);
    conf.setIntValue("video", "scr_green_blue_percent", CPC.scr_green_blue_percent);

--- a/src/koncepcja.h
+++ b/src/koncepcja.h
@@ -242,8 +242,11 @@ class t_CPC {
    int devtools_scale;
    unsigned int devtools_max_stack_size;
 
-   int workspace_layout;    // 0=Classic (floating), 1=Docked
-   int cpc_screen_scale;    // 0=Fit, 1/2/3=fixed pixel multiplier
+   enum class WorkspaceLayoutMode { Classic = 0, Docked = 1 };
+   enum class ScreenScale { Fit = 0, X1 = 1, X2 = 2, X3 = 3 };
+
+   WorkspaceLayoutMode workspace_layout;
+   ScreenScale cpc_screen_scale;
 
    unsigned int snd_enabled;
    bool snd_ready;

--- a/src/koncepcja.h
+++ b/src/koncepcja.h
@@ -242,6 +242,9 @@ class t_CPC {
    int devtools_scale;
    unsigned int devtools_max_stack_size;
 
+   int workspace_layout;    // 0=Classic (floating), 1=Docked
+   int cpc_screen_scale;    // 0=Fit, 1/2/3=fixed pixel multiplier
+
    unsigned int snd_enabled;
    bool snd_ready;
    unsigned int snd_playback_rate;

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -113,9 +113,9 @@ uintptr_t video_get_cpc_texture() {
   return static_cast<uintptr_t>(cpc_gl_texture);
 }
 
-void video_get_cpc_size(int* w, int* h) {
-  if (vid) { *w = vid->w; *h = vid->h; }
-  else     { *w = 0; *h = 0; }
+void video_get_cpc_size(int& w, int& h) {
+  if (vid) { w = vid->w; h = vid->h; }
+  else     { w = 0; h = 0; }
 }
 
 // Called from direct_flip() to capture the current frame
@@ -339,7 +339,7 @@ void direct_flip(video_plugin* t)
 
   // Draw CPC framebuffer as background image via ImGui (classic mode only;
   // in docked mode the CPC Screen window handles its own ImGui::Image())
-  if (CPC.workspace_layout == 0) {
+  if (CPC.workspace_layout == t_CPC::WorkspaceLayoutMode::Classic) {
     ImGuiViewport* vp = ImGui::GetMainViewport();
     ImGui::GetBackgroundDrawList(vp)->AddImage(
         static_cast<ImTextureID>(cpc_gl_texture),
@@ -997,7 +997,7 @@ void swscale_blit(video_plugin* t)
   ImGui::NewFrame();
 
   // Draw CPC framebuffer as background image via ImGui (classic mode only)
-  if (CPC.workspace_layout == 0) {
+  if (CPC.workspace_layout == t_CPC::WorkspaceLayoutMode::Classic) {
     ImGuiViewport* vp = ImGui::GetMainViewport();
     ImGui::GetBackgroundDrawList(vp)->AddImage(
         static_cast<ImTextureID>(cpc_gl_texture),

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -109,6 +109,15 @@ void video_request_window_screenshot(const std::string& path) {
   g_wss_pending_path = path;
 }
 
+uintptr_t video_get_cpc_texture() {
+  return static_cast<uintptr_t>(cpc_gl_texture);
+}
+
+void video_get_cpc_size(int* w, int* h) {
+  if (vid) { *w = vid->w; *h = vid->h; }
+  else     { *w = 0; *h = 0; }
+}
+
 // Called from direct_flip() to capture the current frame
 static void video_capture_if_pending(int display_w, int display_h) {
   std::string wss_path;
@@ -328,12 +337,15 @@ void direct_flip(video_plugin* t)
   ImGui_ImplSDL3_NewFrame();
   ImGui::NewFrame();
 
-  // Draw CPC framebuffer as background image via ImGui
-  ImGuiViewport* vp = ImGui::GetMainViewport();
-  ImGui::GetBackgroundDrawList(vp)->AddImage(
-      static_cast<ImTextureID>(cpc_gl_texture),
-      ImVec2(vp->Pos.x + t->x_offset, vp->Pos.y + t->y_offset),
-      ImVec2(vp->Pos.x + t->x_offset + t->width, vp->Pos.y + t->y_offset + t->height));
+  // Draw CPC framebuffer as background image via ImGui (classic mode only;
+  // in docked mode the CPC Screen window handles its own ImGui::Image())
+  if (CPC.workspace_layout == 0) {
+    ImGuiViewport* vp = ImGui::GetMainViewport();
+    ImGui::GetBackgroundDrawList(vp)->AddImage(
+        static_cast<ImTextureID>(cpc_gl_texture),
+        ImVec2(vp->Pos.x + t->x_offset, vp->Pos.y + t->y_offset),
+        ImVec2(vp->Pos.x + t->x_offset + t->width, vp->Pos.y + t->y_offset + t->height));
+  }
 
   // Render all ImGui windows
   imgui_render_ui();
@@ -984,13 +996,14 @@ void swscale_blit(video_plugin* t)
   ImGui_ImplSDL3_NewFrame();
   ImGui::NewFrame();
 
-  // Draw CPC framebuffer as background image via ImGui
-  // With viewports enabled, background draw list uses screen-space coordinates
-  ImGuiViewport* vp = ImGui::GetMainViewport();
-  ImGui::GetBackgroundDrawList(vp)->AddImage(
-      static_cast<ImTextureID>(cpc_gl_texture),
-      ImVec2(vp->Pos.x + t->x_offset, vp->Pos.y + t->y_offset),
-      ImVec2(vp->Pos.x + t->x_offset + t->width, vp->Pos.y + t->y_offset + t->height));
+  // Draw CPC framebuffer as background image via ImGui (classic mode only)
+  if (CPC.workspace_layout == 0) {
+    ImGuiViewport* vp = ImGui::GetMainViewport();
+    ImGui::GetBackgroundDrawList(vp)->AddImage(
+        static_cast<ImTextureID>(cpc_gl_texture),
+        ImVec2(vp->Pos.x + t->x_offset, vp->Pos.y + t->y_offset),
+        ImVec2(vp->Pos.x + t->x_offset + t->width, vp->Pos.y + t->y_offset + t->height));
+  }
 
   // Render all ImGui windows
   imgui_render_ui();

--- a/src/video.h
+++ b/src/video.h
@@ -20,6 +20,7 @@
 #define VIDEO_H
 
 #include "SDL3/SDL.h"
+#include <cstdint>
 #include <string>
 #include <vector>
 
@@ -61,6 +62,11 @@ void video_clear_topbar();
 int video_get_topbar_height();
 
 video_plugin video_headless_plugin();
+
+// CPC framebuffer texture/size for docked workspace mode.
+// Returns the GL texture ID as uintptr_t (from GLuint) for safe cast to ImTextureID.
+uintptr_t video_get_cpc_texture();
+void video_get_cpc_size(int* w, int* h);
 
 // Request a window screenshot (CPC display + ImGui overlay).
 // Sets path; capture happens on the next rendered frame.

--- a/src/video.h
+++ b/src/video.h
@@ -66,7 +66,7 @@ video_plugin video_headless_plugin();
 // CPC framebuffer texture/size for docked workspace mode.
 // Returns the GL texture ID as uintptr_t (from GLuint) for safe cast to ImTextureID.
 uintptr_t video_get_cpc_texture();
-void video_get_cpc_size(int* w, int* h);
+void video_get_cpc_size(int& w, int& h);
 
 // Request a window screenshot (CPC display + ImGui overlay).
 // Sets path; capture happens on the next rendered frame.

--- a/src/workspace_layout.cpp
+++ b/src/workspace_layout.cpp
@@ -260,9 +260,7 @@ static std::filesystem::path layouts_dir()
     if (dir.empty()) {
         std::string cfg = getConfigurationFilename();
         if (!cfg.empty()) {
-            auto slash = cfg.find_last_of('/');
-            std::string base = (slash != std::string::npos) ? cfg.substr(0, slash + 1) : "";
-            dir = std::filesystem::path(base) / "layouts";
+            dir = std::filesystem::path(cfg).parent_path() / "layouts";
         }
     }
     return dir;
@@ -348,6 +346,7 @@ bool workspace_load_layout(const std::string& name)
     if (!in) return false;
 
     auto size = in.tellg();
+    if (size <= 0) return false;
     in.seekg(0);
     std::string data(static_cast<size_t>(size), '\0');
     in.read(&data[0], size);
@@ -366,10 +365,12 @@ bool workspace_load_layout(const std::string& name)
         while (std::getline(ss, line)) {
             if (line.rfind("show_devtools=", 0) == 0)
                 restore_devtools = (line.substr(14) != "0");
-            else if (line.rfind("workspace_layout=", 0) == 0)
-                restore_workspace = std::stoi(line.substr(17));
-            else if (line.rfind("cpc_screen_scale=", 0) == 0)
-                restore_scale = std::stoi(line.substr(17));
+            else if (line.rfind("workspace_layout=", 0) == 0) {
+                try { restore_workspace = std::stoi(line.substr(17)); } catch (...) {}
+            }
+            else if (line.rfind("cpc_screen_scale=", 0) == 0) {
+                try { restore_scale = std::stoi(line.substr(17)); } catch (...) {}
+            }
             else if (line.rfind("windows=", 0) == 0) {
                 std::string wlist = line.substr(8);
                 std::istringstream ws(wlist);

--- a/src/workspace_layout.cpp
+++ b/src/workspace_layout.cpp
@@ -1,0 +1,238 @@
+#include "workspace_layout.h"
+#include "koncepcja.h"
+#include "video.h"
+#include "devtools_ui.h"
+#include "imgui_ui.h"
+#include "imgui.h"
+#include "imgui_internal.h"
+
+extern t_CPC CPC;
+
+// Persistent dockspace ID
+static const ImGuiID DOCKSPACE_ID = ImHashStr("KonCePCjaDockSpace");
+
+// Track whether we've ever applied a preset (to auto-apply Debug on first dock)
+static bool s_first_dock = true;
+
+// ─────────────────────────────────────────────────
+// Dockspace host window
+// ─────────────────────────────────────────────────
+
+void workspace_render_dockspace()
+{
+    if (CPC.workspace_layout != 1) return;
+
+    // Auto-apply Debug preset on first entry into docked mode
+    if (s_first_dock) {
+        // Only apply if dockspace has no saved layout (no child nodes)
+        ImGuiDockNode* node = ImGui::DockBuilderGetNode(DOCKSPACE_ID);
+        if (!node || !node->ChildNodes[0]) {
+            workspace_apply_preset(WorkspacePreset::Debug);
+        }
+        s_first_dock = false;
+    }
+
+    ImGuiViewport* vp = ImGui::GetMainViewport();
+
+    // Get topbar height to offset below it
+    int topbar_h = video_get_topbar_height();
+    ImVec2 pos(vp->Pos.x, vp->Pos.y + topbar_h);
+    ImVec2 size(vp->Size.x, vp->Size.y - topbar_h);
+
+    ImGui::SetNextWindowPos(pos);
+    ImGui::SetNextWindowSize(size);
+    ImGui::SetNextWindowViewport(vp->ID);
+
+    ImGuiWindowFlags flags =
+        ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoCollapse |
+        ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove |
+        ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoNavFocus |
+        ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoDocking;
+
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 0.0f);
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0.0f);
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0.0f, 0.0f));
+
+    ImGui::Begin("##DockSpaceHost", nullptr, flags);
+    ImGui::PopStyleVar(3);
+
+    ImGui::DockSpace(DOCKSPACE_ID, ImVec2(0.0f, 0.0f),
+                     ImGuiDockNodeFlags_PassthruCentralNode);
+
+    ImGui::End();
+}
+
+// ─────────────────────────────────────────────────
+// CPC Screen window (docked mode)
+// ─────────────────────────────────────────────────
+
+void workspace_render_cpc_screen()
+{
+    if (CPC.workspace_layout != 1) return;
+
+    ImTextureID tex = static_cast<ImTextureID>(video_get_cpc_texture());
+    int tex_w, tex_h;
+    video_get_cpc_size(&tex_w, &tex_h);
+    if (!tex || tex_w <= 0 || tex_h <= 0) return;
+
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0.0f, 0.0f));
+    bool open = true;
+    if (ImGui::Begin("CPC Screen", &open, ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse)) {
+        ImVec2 avail = ImGui::GetContentRegionAvail();
+
+        // CPC aspect ratio
+        float src_aspect = static_cast<float>(tex_w) / static_cast<float>(tex_h);
+
+        float draw_w, draw_h;
+        if (CPC.cpc_screen_scale == 0) {
+            // Fit: scale to fill available space preserving aspect ratio
+            float dst_aspect = avail.x / avail.y;
+            if (dst_aspect > src_aspect) {
+                draw_h = avail.y;
+                draw_w = draw_h * src_aspect;
+            } else {
+                draw_w = avail.x;
+                draw_h = draw_w / src_aspect;
+            }
+        } else {
+            // Fixed 1x/2x/3x
+            draw_w = static_cast<float>(tex_w * CPC.cpc_screen_scale);
+            draw_h = static_cast<float>(tex_h * CPC.cpc_screen_scale);
+        }
+
+        // Center in available space
+        float offset_x = (avail.x - draw_w) * 0.5f;
+        float offset_y = (avail.y - draw_h) * 0.5f;
+        if (offset_x < 0.0f) offset_x = 0.0f;
+        if (offset_y < 0.0f) offset_y = 0.0f;
+
+        // Black background behind the image (for letterboxing)
+        ImVec2 p0 = ImGui::GetCursorScreenPos();
+        ImGui::GetWindowDrawList()->AddRectFilled(
+            p0, ImVec2(p0.x + avail.x, p0.y + avail.y),
+            IM_COL32(0, 0, 0, 255));
+
+        ImGui::SetCursorPos(ImVec2(
+            ImGui::GetCursorPos().x + offset_x,
+            ImGui::GetCursorPos().y + offset_y));
+        ImGui::Image(tex, ImVec2(draw_w, draw_h));
+
+        // Right-click context menu for scale mode
+        if (ImGui::BeginPopupContextWindow("##CPCScreenCtx")) {
+            ImGui::TextUnformatted("Scale Mode");
+            ImGui::Separator();
+            if (ImGui::RadioButton("Fit",  CPC.cpc_screen_scale == 0)) CPC.cpc_screen_scale = 0;
+            if (ImGui::RadioButton("1x",   CPC.cpc_screen_scale == 1)) CPC.cpc_screen_scale = 1;
+            if (ImGui::RadioButton("2x",   CPC.cpc_screen_scale == 2)) CPC.cpc_screen_scale = 2;
+            if (ImGui::RadioButton("3x",   CPC.cpc_screen_scale == 3)) CPC.cpc_screen_scale = 3;
+            ImGui::EndPopup();
+        }
+    }
+    ImGui::End();
+    ImGui::PopStyleVar();
+
+    // If user closed the CPC Screen window, switch back to classic mode
+    if (!open) {
+        CPC.workspace_layout = 0;
+    }
+}
+
+// ─────────────────────────────────────────────────
+// Preset layouts via DockBuilder
+// ─────────────────────────────────────────────────
+
+// Helper: ensure a DevToolsUI window is open by name
+static void ensure_window_open(const char* name) {
+    if (!g_devtools_ui.is_window_open(name)) {
+        g_devtools_ui.toggle_window(name);
+    }
+}
+
+void workspace_apply_preset(WorkspacePreset preset)
+{
+    // Clear existing dockspace layout
+    ImGui::DockBuilderRemoveNode(DOCKSPACE_ID);
+    ImGui::DockBuilderAddNode(DOCKSPACE_ID, ImGuiDockNodeFlags_DockSpace);
+
+    // Size the dockspace to match the main viewport (minus topbar)
+    ImGuiViewport* vp = ImGui::GetMainViewport();
+    int topbar_h = video_get_topbar_height();
+    ImGui::DockBuilderSetNodeSize(DOCKSPACE_ID,
+        ImVec2(vp->Size.x, vp->Size.y - topbar_h));
+    ImGui::DockBuilderSetNodePos(DOCKSPACE_ID,
+        ImVec2(vp->Pos.x, vp->Pos.y + topbar_h));
+
+    ImGuiID center = DOCKSPACE_ID;
+    ImGuiID left, right, bottom;
+
+    switch (preset) {
+    case WorkspacePreset::Debug:
+        // Split: left 25% | center | right 25%, bottom 30%
+        ImGui::DockBuilderSplitNode(center, ImGuiDir_Left, 0.25f, &left, &center);
+        ImGui::DockBuilderSplitNode(center, ImGuiDir_Right, 0.33f, &right, &center);
+        ImGui::DockBuilderSplitNode(center, ImGuiDir_Down, 0.30f, &bottom, &center);
+
+        ImGui::DockBuilderDockWindow("CPC Screen", center);
+        ImGui::DockBuilderDockWindow("DevTools", center);  // tabs with CPC Screen
+
+        ImGui::DockBuilderDockWindow("Disassembly", left);
+        ImGui::DockBuilderDockWindow("Breakpoints/WP/IO", left);
+
+        ImGui::DockBuilderDockWindow("Registers", right);
+        ImGui::DockBuilderDockWindow("Stack", right);
+
+        ImGui::DockBuilderDockWindow("Memory Hex", bottom);
+
+        ensure_window_open("registers");
+        ensure_window_open("disassembly");
+        ensure_window_open("stack");
+        ensure_window_open("breakpoints");
+        ensure_window_open("memory_hex");
+        break;
+
+    case WorkspacePreset::IDE:
+        // Split: left 20% | center | right 25%
+        ImGui::DockBuilderSplitNode(center, ImGuiDir_Left, 0.20f, &left, &center);
+        ImGui::DockBuilderSplitNode(center, ImGuiDir_Right, 0.25f, &right, &center);
+
+        ImGui::DockBuilderDockWindow("CPC Screen", center);
+        ImGui::DockBuilderDockWindow("DevTools", center);
+
+        ImGui::DockBuilderDockWindow("Disassembly", left);
+
+        ImGui::DockBuilderDockWindow("Symbols", right);
+        ImGui::DockBuilderDockWindow("Breakpoints/WP/IO", right);
+
+        ensure_window_open("disassembly");
+        ensure_window_open("symbols");
+        ensure_window_open("breakpoints");
+        break;
+
+    case WorkspacePreset::Hardware:
+        // Split: center | right 30%, bottom 30%
+        ImGui::DockBuilderSplitNode(center, ImGuiDir_Right, 0.30f, &right, &center);
+        ImGui::DockBuilderSplitNode(center, ImGuiDir_Down, 0.30f, &bottom, &center);
+
+        ImGui::DockBuilderDockWindow("CPC Screen", center);
+        ImGui::DockBuilderDockWindow("DevTools", center);
+
+        ImGui::DockBuilderDockWindow("Video State", right);
+        ImGui::DockBuilderDockWindow("Audio State", right);
+        ImGui::DockBuilderDockWindow("ASIC Registers", right);
+
+        ImGui::DockBuilderDockWindow("Disc Tools", bottom);
+        ImGui::DockBuilderDockWindow("Silicon Disc", bottom);
+
+        ensure_window_open("video_state");
+        ensure_window_open("audio_state");
+        ensure_window_open("asic");
+        ensure_window_open("disc_tools");
+        ensure_window_open("silicon_disc");
+        break;
+    }
+
+    // Ensure DevTools toolbar is visible so windowed panels render
+    imgui_state.show_devtools = true;
+
+    ImGui::DockBuilderFinish(DOCKSPACE_ID);
+}

--- a/src/workspace_layout.h
+++ b/src/workspace_layout.h
@@ -1,0 +1,18 @@
+#ifndef WORKSPACE_LAYOUT_H
+#define WORKSPACE_LAYOUT_H
+
+enum class WorkspacePreset { Debug, IDE, Hardware };
+
+// Render the fullscreen dockspace host window (call before other windows).
+// Only active when CPC.workspace_layout == 1.
+void workspace_render_dockspace();
+
+// Render the CPC Screen as a dockable ImGui window.
+// Only active when CPC.workspace_layout == 1.
+void workspace_render_cpc_screen();
+
+// Apply a preset layout using DockBuilder.
+// Resets dockspace splits and docks windows by title.
+void workspace_apply_preset(WorkspacePreset preset);
+
+#endif // WORKSPACE_LAYOUT_H

--- a/src/workspace_layout.h
+++ b/src/workspace_layout.h
@@ -1,6 +1,9 @@
 #ifndef WORKSPACE_LAYOUT_H
 #define WORKSPACE_LAYOUT_H
 
+#include <string>
+#include <vector>
+
 enum class WorkspacePreset { Debug, IDE, Hardware };
 
 // Render the fullscreen dockspace host window (call before other windows).
@@ -14,5 +17,17 @@ void workspace_render_cpc_screen();
 // Apply a preset layout using DockBuilder.
 // Resets dockspace splits and docks windows by title.
 void workspace_apply_preset(WorkspacePreset preset);
+
+// Save current window arrangement as a named layout.
+bool workspace_save_layout(const std::string& name);
+
+// Load a previously saved layout by name.
+bool workspace_load_layout(const std::string& name);
+
+// Delete a saved layout by name.
+bool workspace_delete_layout(const std::string& name);
+
+// Return sorted list of saved layout names (stems only, no extension).
+std::vector<std::string> workspace_list_layouts();
 
 #endif // WORKSPACE_LAYOUT_H


### PR DESCRIPTION
## Summary

- Adds a **Docked workspace mode** where the CPC screen renders inside an ImGui window within a fullscreen dockspace, and all DevTools panels dock alongside it in a single managed layout
- **Classic mode** (default) preserves the existing floating multi-viewport behavior — zero behavioral change
- Three **DockBuilder presets** (Debug, IDE, Hardware) arrange panels into predefined split layouts that users can then customize by dragging
- CPC Screen window supports **Fit/1x/2x/3x scale modes** via right-click context menu or Layout menu
- Layout persists automatically via `imgui.ini`; config persists `workspace_layout` and `cpc_screen_scale` in `[ui]` section

## Files Changed

| File | Change |
|------|--------|
| `src/workspace_layout.h` | **NEW** — WorkspacePreset enum, render/apply functions |
| `src/workspace_layout.cpp` | **NEW** — DockBuilder preset implementations, dockspace host, CPC Screen window |
| `src/video.h/cpp` | Added `video_get_cpc_texture()` and `video_get_cpc_size()` getters; guarded background `AddImage()` for docked mode |
| `src/koncepcja.h` | Added `workspace_layout`, `cpc_screen_scale` to `t_CPC` |
| `src/kon_cpc_ja.cpp` | Config load/save for `[ui]` section |
| `src/imgui_ui.cpp` | Updated Layout menu with mode toggle + presets; calls workspace render functions |

## Test plan

- [x] `make ARCH=macos` — clean build (0 errors)
- [x] `make debug` — 646 tests pass (644 passed, 2 skipped)
- [ ] Launch in classic mode — verify identical to before (no dockspace)
- [ ] DevTools > Layout > "Docked Mode" — dockspace appears, CPC Screen shows emulator output
- [ ] CPC Screen renders correctly with aspect ratio preservation
- [ ] Right-click CPC Screen — test Fit/1x/2x/3x scale modes
- [ ] "Apply Debug Layout" — Disasm left, Screen center, Registers right, Memory bottom
- [ ] Drag a window to different dock node — restart — layout persists
- [ ] "Apply Hardware Layout" — resets to hardware template
- [ ] Switch back to Classic mode — floating windows resume, background draw restored
- [ ] Test with a game loaded — emulation runs in both modes