### PR TITLE
fix: address Gemini review comments from PRs #23-42

### DIFF
--- a/src/koncepcja_ipc_server.cpp
+++ b/src/koncepcja_ipc_server.cpp
@@ -12,6 +12,7 @@
 #include <chrono>
 #include <cctype>
 #include <sstream>
+#include <stdexcept>
 #include <iomanip>
 #include <fstream>
 #include <filesystem>
@@ -146,6 +147,8 @@ std::string handle_command(const std::string& line) {
   if (line.empty()) return "OK\n";
   auto parts = split_ws(line);
   if (parts.empty()) return "OK\n";
+
+  try {
 
   const auto& cmd = parts[0];
   if (cmd == "ping") return "OK pong\n";
@@ -2810,6 +2813,12 @@ std::string handle_command(const std::string& line) {
   }
 
   return "ERR 501 not-implemented\n";
+
+  } catch (const std::invalid_argument&) {
+    return "ERR 400 bad-number\n";
+  } catch (const std::out_of_range&) {
+    return "ERR 400 number-out-of-range\n";
+  }
 }
 }
 

--- a/src/symbiface.cpp
+++ b/src/symbiface.cpp
@@ -37,13 +37,12 @@ static void ide_set_string(uint16_t* buf, int word_start, int word_count, const 
 {
    // ATA strings are byte-swapped within each word.
    // Track string length to avoid reading past the null terminator.
-   int slen = 0;
-   while (str[slen]) slen++;
+   int slen = str ? static_cast<int>(strlen(str)) : 0;
 
    for (int w = 0; w < word_count; w++) {
       int si = w * 2;
-      char c0 = (si < slen) ? str[si] : ' ';
-      char c1 = (si + 1 < slen) ? str[si + 1] : ' ';
+      uint8_t c0 = (si < slen) ? static_cast<uint8_t>(str[si]) : 0x20;
+      uint8_t c1 = (si + 1 < slen) ? static_cast<uint8_t>(str[si + 1]) : 0x20;
       buf[word_start + w] = (static_cast<uint16_t>(c0) << 8) | c1;
       if (si + 1 >= slen) {
          // Pad rest with spaces

--- a/src/symbiface.cpp
+++ b/src/symbiface.cpp
@@ -35,13 +35,17 @@ static uint32_t ide_lba(const IDE_Device& dev)
 
 static void ide_set_string(uint16_t* buf, int word_start, int word_count, const char* str)
 {
-   // ATA strings are byte-swapped within each word
+   // ATA strings are byte-swapped within each word.
+   // Track string length to avoid reading past the null terminator.
+   int slen = 0;
+   while (str[slen]) slen++;
+
    for (int w = 0; w < word_count; w++) {
       int si = w * 2;
-      char c0 = str[si] ? str[si] : ' ';
-      char c1 = (str[si] && str[si + 1]) ? str[si + 1] : ' ';
+      char c0 = (si < slen) ? str[si] : ' ';
+      char c1 = (si + 1 < slen) ? str[si + 1] : ' ';
       buf[word_start + w] = (static_cast<uint16_t>(c0) << 8) | c1;
-      if (!str[si] || !str[si + 1]) {
+      if (si + 1 >= slen) {
          // Pad rest with spaces
          for (int w2 = w + 1; w2 < word_count; w2++) {
             buf[word_start + w2] = 0x2020;


### PR DESCRIPTION
## Summary

- **IPC server**: Added top-level `try/catch` in `handle_command()` that catches `std::invalid_argument` and `std::out_of_range`. This guards ~100 unprotected `std::stoi`/`std::stoul` calls across the command dispatcher — bad numeric input now returns `ERR 400 bad-number` instead of crashing.
- **Symbiface IDE**: Rewrote `ide_set_string` to compute string length once and bounds-check per-character access, rather than relying on null-terminator proximity in fixed-width ATA IDENTIFY fields.
- **AGENTS.md**: Documented recurring review themes (enum class over magic ints, exception safety, I/O return checking, render-loop caching, reference out-params) to prevent repeat issues in future PRs.

Triage of 68 unresolved Gemini comments across PRs #23-42 found that most were already addressed by later PRs. These two source fixes are the only remaining actionable items.

## Test plan

- [x] `make -j ARCH=macos` — clean build
- [x] 644/646 tests pass (2 skipped as expected)
- [ ] Manual: send `mem read abc 10` via IPC — should return `ERR 400 bad-number`
- [ ] Manual: verify AGENTS.md loads correctly via `CLAUDE.md` symlink