### PR TITLE
Introduce CpcMachine aggregate for core globals

### DIFF
--- a/src/cpc_machine.h
+++ b/src/cpc_machine.h
@@ -1,0 +1,28 @@
+// Core CPC machine aggregate — non-owning view of global emulator state.
+// Phase 1: wrapper only, no behavior change. Globals remain the source of truth.
+
+#ifndef CPC_MACHINE_H
+#define CPC_MACHINE_H
+
+#include "koncepcja.h"
+
+class t_z80regs;
+
+struct CpcMachine {
+  t_CPC*       cpc        = nullptr;
+  t_CRTC*      crtc       = nullptr;
+  t_GateArray* gate_array = nullptr;
+  t_FDC*       fdc        = nullptr;
+  t_PPI*       ppi        = nullptr;
+  t_PSG*       psg        = nullptr;
+  t_VDU*       vdu        = nullptr;
+  t_drive*     driveA     = nullptr;
+  t_drive*     driveB     = nullptr;
+  t_z80regs*   z80        = nullptr;
+};
+
+extern CpcMachine g_machine;
+
+#endif // CPC_MACHINE_H
+
+

--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -60,6 +60,7 @@ static inline Uint32 MapRGBSurface(SDL_Surface* surface, Uint8 r, Uint8 g, Uint8
 #include "ym_recorder.h"
 #include "avi_recorder.h"
 #include "macos_menu.h"
+#include "cpc_machine.h"
 
 #include "imgui.h"
 #include "imgui_impl_sdl3.h"
@@ -276,6 +277,21 @@ t_VDU VDU;
 
 t_drive driveA;
 t_drive driveB;
+
+// Phase 1: non-owning aggregate of core globals. Behavior is unchanged;
+// this simply provides a structured view for future refactors.
+CpcMachine g_machine{
+  &CPC,
+  &CRTC,
+  &GateArray,
+  &FDC,
+  &PPI,
+  &PSG,
+  &VDU,
+  &driveA,
+  &driveB,
+  &z80,
+};
 
 #define psg_write \
 { \


### PR DESCRIPTION
Small prep change: add a non-owning CpcMachine wrapper aggregating pointers to existing core globals, and instantiate g_machine in kon_cpc_ja.cpp without changing any behavior. Tests: make -j24 unit_test (all green).

Made with [Cursor](https://cursor.com)