### PR TITLE
Route core memory/IO via MemoryBus/IoBus

### DIFF
--- a/src/io_bus.h
+++ b/src/io_bus.h
@@ -1,0 +1,26 @@
+// IoBus - thin wrapper around IO dispatch.
+// Phase 2: helper only, Z80 still calls z80_IN/OUT handlers directly.
+//
+// This provides a place to hang IO abstractions without changing how
+// io_dispatch works today.
+
+#ifndef IO_BUS_H
+#define IO_BUS_H
+
+#include "z80.h"
+#include "io_dispatch.h"
+
+struct IoBus {
+  inline byte in(reg_pair port, byte current_val) const {
+    return io_dispatch_in(port, current_val);
+  }
+
+  inline void out(reg_pair port, byte val) const {
+    io_dispatch_out(port, val);
+  }
+};
+
+extern IoBus g_io_bus;
+
+#endif // IO_BUS_H
+

--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -61,6 +61,8 @@ static inline Uint32 MapRGBSurface(SDL_Surface* surface, Uint8 r, Uint8 g, Uint8
 #include "avi_recorder.h"
 #include "macos_menu.h"
 #include "cpc_machine.h"
+#include "memory_bus.h"
+#include "io_bus.h"
 
 #include "imgui.h"
 #include "imgui_impl_sdl3.h"
@@ -292,6 +294,11 @@ CpcMachine g_machine{
   &driveB,
   &z80,
 };
+
+// Phase 2: non-owning bus views over existing banking / IO dispatch.
+// These are helpers only; core hot paths still use the original globals.
+MemoryBus g_memory_bus{ membank_read, membank_write };
+IoBus g_io_bus{};
 
 #define psg_write \
 { \

--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -615,7 +615,7 @@ byte z80_IN_handler (reg_pair port)
       }
    }
 // Peripheral dispatch (Symbiface II, etc.) ------------------------------------
-   ret_val = io_dispatch_in(port, ret_val);
+   ret_val = g_io_bus.in(port, ret_val);
    LOG_DEBUG("IN on port " << std::hex << static_cast<int>(port.w.l) << ", ret_val=" << static_cast<int>(ret_val) << std::dec);
    return ret_val;
 }
@@ -1018,7 +1018,7 @@ void z80_OUT_handler (reg_pair port, byte val)
       fdc_write_data(val);
    }
 // Peripheral dispatch (M4 Board, MF2, Symbiface II, AmDrum, Phazer) -----------
-   io_dispatch_out(port, val);
+   g_io_bus.out(port, val);
 }
 
 

--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -296,7 +296,7 @@ CpcMachine g_machine{
 };
 
 // Phase 2: non-owning bus views over existing banking / IO dispatch.
-// These are helpers only; core hot paths still use the original globals.
+// Memory hot paths use g_memory_bus (wrapping membank_*); IO still goes via the same dispatch.
 MemoryBus g_memory_bus{ membank_read, membank_write };
 IoBus g_io_bus{};
 

--- a/src/memory_bus.h
+++ b/src/memory_bus.h
@@ -1,5 +1,5 @@
 // MemoryBus - thin, non-owning view over CPC memory banking.
-// Phase 2: helper only, not yet wired into hot paths.
+// Used by the core (including hot-path memory accesses) as a simple bus view.
 //
 // Design notes for humans:
 // - This is intentionally just a pair of pointers to the existing
@@ -31,7 +31,7 @@ struct MemoryBus {
     *(write_banks[addr >> 14] + (addr & 0x3fff)) = v;
   }
 
-  // Convenience helpers to get the base pointer for a 16KB bank.
+  // Convenience helpers for tools/DevTools that need a bank base (e.g. hex viewer).
   inline byte* bank_read_ptr(int bank) const {
     return read_banks[bank];
   }

--- a/src/memory_bus.h
+++ b/src/memory_bus.h
@@ -1,0 +1,47 @@
+// MemoryBus - thin, non-owning view over CPC memory banking.
+// Phase 2: helper only, not yet wired into hot paths.
+//
+// Design notes for humans:
+// - This is intentionally just a pair of pointers to the existing
+//   membank_read/membank_write arrays (4 x 16KB banks selected by addr>>14).
+// - It does NOT know about SmartWatch, ASIC, or watchpoints; those stay
+//   in the higher-level accessors in z80.cpp for now.
+// - The goal is to make it easy to thread a single "bus" object through
+//   helpers and tools without changing the memory layout or timing.
+
+#ifndef MEMORY_BUS_H
+#define MEMORY_BUS_H
+
+#include "types.h"
+
+struct MemoryBus {
+  // Pointers to the 16KB bank tables used by the core:
+  //   read_banks [0..3]  -> base of each readable bank
+  //   write_banks[0..3]  -> base of each writable bank
+  byte* const* read_banks  = nullptr;
+  byte* const* write_banks = nullptr;
+
+  // Raw banked access using the existing 4x16KB scheme.
+  // Callers are expected to layer any device/watchpoint logic on top.
+  inline byte read_raw(word addr) const {
+    return *(read_banks[addr >> 14] + (addr & 0x3fff));
+  }
+
+  inline void write_raw(word addr, byte v) const {
+    *(write_banks[addr >> 14] + (addr & 0x3fff)) = v;
+  }
+
+  // Convenience helpers to get the base pointer for a 16KB bank.
+  inline byte* bank_read_ptr(int bank) const {
+    return read_banks[bank];
+  }
+
+  inline byte* bank_write_ptr(int bank) const {
+    return write_banks[bank];
+  }
+};
+
+extern MemoryBus g_memory_bus;
+
+#endif // MEMORY_BUS_H
+

--- a/src/z80.cpp
+++ b/src/z80.cpp
@@ -36,6 +36,7 @@
 #include "expr_parser.h"
 #include "smartwatch.h"
 #include "log.h"
+#include "memory_bus.h"
 #include <algorithm>
 #include <vector>
 #include <iomanip>
@@ -345,9 +346,10 @@ static byte cc_ex[256] = {
 
 
 extern byte *membank_read[4], *membank_write[4];
+extern MemoryBus g_memory_bus;
 
 inline byte read_mem_no_watchpoint(word addr) {
-  byte val = *(membank_read[addr >> 14] + (addr & 0x3fff)); // returns a byte from a 16KB memory bank
+  byte val = g_memory_bus.read_raw(addr); // returns a byte from a 16KB memory bank
   // SmartWatch intercepts upper ROM reads (ROM must be paged in)
   if (g_smartwatch.enabled && (addr >= 0xC000) && !(GateArray.ROM_config & 0x08)) {
     val = smartwatch_rom_read(addr, val);
@@ -383,7 +385,7 @@ inline byte read_mem(word addr) {
 }
 
 inline void write_mem_no_watchpoint(word addr, byte val) {
-  *(membank_write[addr >> 14] + (addr & 0x3fff)) = val; // writes a byte to a 16KB memory bank
+  g_memory_bus.write_raw(addr, val); // writes a byte to a 16KB memory bank
 }
 
 inline void write_mem(word addr, byte val) {


### PR DESCRIPTION
Small refactor: add non-owning MemoryBus/IoBus helpers wired to existing membank_read/membank_write and io_dispatch, and route Z80 raw memory helpers and peripheral IO dispatch through them without changing behavior. Tests: make -j24 unit_test (all green).

Made with [Cursor](https://cursor.com)