### PR TITLE
fix: topbar buttons unresponsive when ImGui viewports active on macOS

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -27,6 +27,12 @@ jobs:
           libx11-dev libxext-dev libxrandr-dev libxcursor-dev libxfixes-dev libxi-dev libxss-dev
           libwayland-dev libxkbcommon-dev libdrm-dev libgbm-dev libdecor-0-dev
 
+      - name: Apply SDL patches
+        run: |
+          for p in vendor/sdl-patches/*.patch; do
+            [ -f "$p" ] && git -C vendor/SDL apply "../../$p"
+          done
+
       - name: Cache vendored SDL3
         id: cache-sdl
         uses: actions/cache@v4

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -23,6 +23,12 @@ jobs:
       - run: brew update
       - run: brew install freetype zlib libpng gnu-sed cmake
 
+      - name: Apply SDL patches
+        run: |
+          for p in vendor/sdl-patches/*.patch; do
+            [ -f "$p" ] && git -C vendor/SDL apply "../../$p"
+          done
+
       - name: Cache vendored SDL3
         id: cache-sdl
         uses: actions/cache@v4

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    timeout-minutes: 10
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -41,6 +41,13 @@ jobs:
             ${{matrix.mingw}}/mingw-w64-${{matrix.env}}-toolchain
             ${{matrix.mingw}}/mingw-w64-${{matrix.env}}-zlib
             ${{matrix.mingw}}/mingw-w64-${{matrix.env}}-7zip
+
+      - name: Apply SDL patches
+        shell: msys2 {0}
+        run: |
+          for p in vendor/sdl-patches/*.patch; do
+            [ -f "$p" ] && git -C vendor/SDL apply "../../$p"
+          done
 
       - name: Install SDL3 from MSYS2
         if: ${{ !matrix.sdl_from_source }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -255,6 +255,27 @@ Press **F12** or send `devtools` via IPC to open the developer tools:
 | Shift+F1 | Virtual keyboard |
 | Shift+F3 | Save snapshot |
 
+### SDL3 macOS Mouse Events & ImGui Viewports
+
+When `ImGuiConfigFlags_ViewportsEnable` is active, ImGui creates separate OS windows (viewports) for floating devtools. On macOS this triggers a chain of issues:
+
+**Root cause chain:**
+1. `SDL_CaptureMouse()` is a permanent no-op in the Cocoa implementation (`Cocoa_CaptureMouse()` in `SDL_cocoamouse.m`) — just returns `true`.
+2. `koncpc_order_viewports_above_main()` keeps viewport windows above the main window via `orderWindow:NSWindowAbove`. This confuses macOS mouse-up delivery during drags.
+3. macOS may deliver `mouseUp:` to a different NSWindow or lose it entirely.
+4. SDL's internal `source->buttonstate` gets stuck at "pressed".
+5. `SDL_PrivateSendMouseButton()` has duplicate suppression (`if (buttonstate == source->buttonstate) return`) — once stuck, ALL future button events for that button are silently dropped at the SDL level.
+
+**The fix** (three layers):
+- **SDL Cocoa backend** (`vendor/SDL/src/video/cocoa/SDL_cocoamouse.m`): `Cocoa_ReconcileMouseButtons()` polls `[NSEvent pressedMouseButtons]` (OS-reported hardware state) once per frame in `Cocoa_PumpEvents()`. Calls `SDL_SendMouseButton(RELEASED)` through SDL's full pipeline for any stuck buttons.
+- **ImGui SDL3 backend** (`vendor/imgui/backends/imgui_impl_sdl3.cpp`): Viewport windowID check removed for mouse button and MOUSE_ENTER events. Button state is global — the GLFW and Win32 backends never had this check.
+- **Application** (`src/kon_cpc_ja.cpp`): No legacy `showGui()` click handler — topbar clicks are handled purely by ImGui's `Button("Menu (F1)")`.
+
+**Key pitfalls when debugging mouse issues:**
+- `SDL_GetMouseState()` reads SDL's **event-derived cache** — if the button-up event was lost, this cache is stuck too. Use `SDL_GetGlobalMouseState()` which queries OS-reported state via `[NSEvent pressedMouseButtons]`.
+- SDL and ImGui use **different button-to-bit mappings**: SDL has Left=bit0, Middle=bit1, Right=bit2; ImGui's `MouseButtonsDown` has Left=bit0, Right=bit1, Middle=bit2. Always use an explicit mapping table, not `(1 << button_n)` for both.
+- SDL is a pre-built submodule. Edits to `vendor/SDL/src/` require rebuilding: `cd vendor/SDL/build && make -j$(sysctl -n hw.ncpu)` then `cmake --install . --prefix ../install`.
+
 ## Configuration
 
 Config file locations (in order of precedence):

--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -3550,13 +3550,8 @@ int koncpc_main (int argc, char **argv)
 
             case SDL_EVENT_MOUSE_BUTTON_DOWN:
             {
-              SDL_WindowID main_wid = mainSDLWindow ? SDL_GetWindowID(mainSDLWindow) : 0;
-              if (event.button.windowID == main_wid && event.button.y < topbar_height_px) {
-                if (!CPC.scr_gui_is_currently_on) {
-                  showGui();
-                }
-                break;
-              }
+              // Topbar clicks (Menu button, drive LEDs, etc.) are handled by ImGui's
+              // imgui_render_topbar(). No legacy showGui() handler needed here.
               if (CPC.phazer_emulation) {
                 // Trojan Light Phazer uses Joystick Fire for the trigger button:
                 // https://www.cpcwiki.eu/index.php/Trojan_Light_Phazer

--- a/vendor/sdl-patches/0001-cocoa-reconcile-mouse-buttons.patch
+++ b/vendor/sdl-patches/0001-cocoa-reconcile-mouse-buttons.patch
@@ -1,0 +1,80 @@
+diff --git a/src/video/cocoa/SDL_cocoaevents.m b/src/video/cocoa/SDL_cocoaevents.m
+index 58cae9955..1a9c6589f 100644
+--- a/src/video/cocoa/SDL_cocoaevents.m
++++ b/src/video/cocoa/SDL_cocoaevents.m
+@@ -23,6 +23,7 @@
+ #ifdef SDL_VIDEO_DRIVER_COCOA
+ 
+ #include "SDL_cocoavideo.h"
++#include "SDL_cocoamouse.h"
+ #include "../../events/SDL_events_c.h"
+ 
+ static SDL_Window *FindSDLWindowForNSWindow(NSWindow *win)
+@@ -629,6 +630,7 @@ void Cocoa_PumpEvents(SDL_VideoDevice *_this)
+ {
+     @autoreleasepool {
+         Cocoa_PumpEventsUntilDate(_this, [NSDate distantPast], true);
++        Cocoa_ReconcileMouseButtons();
+     }
+ }
+ 
+diff --git a/src/video/cocoa/SDL_cocoamouse.h b/src/video/cocoa/SDL_cocoamouse.h
+index 70282be9f..1d5d74f68 100644
+--- a/src/video/cocoa/SDL_cocoamouse.h
++++ b/src/video/cocoa/SDL_cocoamouse.h
+@@ -31,6 +31,7 @@ extern void Cocoa_HandleMouseEvent(SDL_VideoDevice *_this, NSEvent *event);
+ extern void Cocoa_HandleMouseWheel(SDL_Window *window, NSEvent *event);
+ extern void Cocoa_HandleMouseWarp(CGFloat x, CGFloat y);
+ extern void Cocoa_QuitMouse(SDL_VideoDevice *_this);
++extern void Cocoa_ReconcileMouseButtons(void);
+ 
+ typedef struct
+ {
+diff --git a/src/video/cocoa/SDL_cocoamouse.m b/src/video/cocoa/SDL_cocoamouse.m
+index 77ebf109d..7121fce96 100644
+--- a/src/video/cocoa/SDL_cocoamouse.m
++++ b/src/video/cocoa/SDL_cocoamouse.m
+@@ -369,6 +369,43 @@ static SDL_MouseButtonFlags Cocoa_GetGlobalMouseState(float *x, float *y)
+     return result;
+ }
+ 
++/* Cocoa_CaptureMouse() is a no-op, so mouse-up events can be lost when
++   windows are reordered (orderWindow:) during a drag. SDL's internal
++   buttonstate then gets permanently stuck, and duplicate suppression in
++   SDL_PrivateSendMouseButton() blocks all future button events.
++   This function polls [NSEvent pressedMouseButtons] (hardware truth) and
++   synthesizes releases for any buttons SDL thinks are pressed but aren't. */
++void Cocoa_ReconcileMouseButtons(void)
++{
++    SDL_Mouse *mouse = SDL_GetMouse();
++    if (!mouse) {
++        return;
++    }
++
++    const NSUInteger cocoaButtons = [NSEvent pressedMouseButtons];
++
++    /* Map: Cocoa bit → SDL button constant.
++       Cocoa: bit 0 = Left, bit 1 = Right, bit 2 = Middle
++       SDL:   SDL_BUTTON_LEFT=1, SDL_BUTTON_MIDDLE=2, SDL_BUTTON_RIGHT=3 */
++    static const struct { int cocoa_bit; Uint8 sdl_button; } map[] = {
++        { 0, SDL_BUTTON_LEFT },
++        { 1, SDL_BUTTON_RIGHT },
++        { 2, SDL_BUTTON_MIDDLE },
++    };
++
++    for (int i = 0; i < 3; i++) {
++        bool hw_pressed = (cocoaButtons & (1 << map[i].cocoa_bit)) != 0;
++        if (!hw_pressed) {
++            /* Hardware says released — send a release through SDL's normal
++               pipeline so buttonstate gets updated and an event is posted.
++               If SDL already considers it released, SDL_PrivateSendMouseButton's
++               duplicate suppression will no-op safely. */
++            SDL_SendMouseButton(0, mouse->focus, SDL_GLOBAL_MOUSE_ID,
++                                map[i].sdl_button, false);
++        }
++    }
++}
++
+ bool Cocoa_InitMouse(SDL_VideoDevice *_this)
+ {
+     NSPoint location;


### PR DESCRIPTION
## Summary

- Fix topbar buttons (Menu, drive LEDs) becoming permanently unresponsive after interacting with DevTools viewport windows on macOS
- Root cause: SDL3's `Cocoa_CaptureMouse()` is a no-op, so mouse-up events get lost when viewport windows overlap the main window. SDL's internal `buttonstate` gets permanently stuck, and duplicate suppression blocks all future button events.

### Three-layer fix:
- **SDL Cocoa backend** (`vendor/sdl-patches/`): `Cocoa_ReconcileMouseButtons()` polls `[NSEvent pressedMouseButtons]` (hardware truth) once per frame and synthesizes releases for stuck buttons through SDL's full pipeline
- **ImGui SDL3 backend**: Remove viewport `windowID` check for mouse button and `MOUSE_ENTER` events (GLFW/Win32 backends never had this check)
- **Application**: Remove legacy `showGui()` click handler; topbar clicks handled purely by ImGui buttons
- **CI**: All workflows apply SDL patches before building vendored SDL3

## Test plan

- [ ] Launch emulator, click Menu button — works (baseline)
- [ ] Open devtools (F12), click Menu button — still works
- [ ] Click between main window and viewport windows — no stuck state
- [ ] Right-click on topbar — no stuck state
- [ ] Drag devtools windows outside main window — buttons still work
- [ ] Close devtools — buttons still work
- [ ] Linux/Windows CI builds pass (patch is macOS-only Cocoa code, no-op on other platforms)