### PR TITLE
refactor: route hot paths through MemoryBus + centralize bank switching

### DIFF
--- a/src/asic.cpp
+++ b/src/asic.cpp
@@ -1,6 +1,7 @@
 #include "asic.h"
 #include "log.h"
 #include "koncepcja.h"
+#include "memory_bus.h"
 #include "SDL3/SDL.h"
 #include "crtc.h"
 
@@ -13,7 +14,6 @@ extern t_PSG PSG;
 extern SDL_Surface *back_surface;
 extern dword dwXScale;
 extern byte *membank_config[8][4];
-extern byte *membank_write[4];
 
 asic_t asic;
 
@@ -176,12 +176,12 @@ void asic_dma_cycle() {
     // TODO: cleaner way to modify back the register value here ...
     {
       word addr = 0x6C00 + (c << 2);
-      *(membank_write[addr >> 14] + (addr & 0x3fff)) = static_cast<byte>(channel.source_address & 0xFF);
+      g_memory_bus.write_raw(addr, static_cast<byte>(channel.source_address & 0xFF));
       addr++;
-      *(membank_write[addr >> 14] + (addr & 0x3fff)) = static_cast<byte>((channel.source_address & 0xFF00) >> 8);
+      g_memory_bus.write_raw(addr, static_cast<byte>((channel.source_address & 0xFF00) >> 8));
       /* Useless ?
       addr++;
-      *(membank_write[addr >> 14] + (addr & 0x3fff)) = channel.prescaler;
+      g_memory_bus.write_raw(addr + 1, channel.prescaler);
       */
       if (channel.enabled) {
         dcsr |= (0x1 << c);
@@ -197,8 +197,7 @@ void asic_dma_cycle() {
   // Run RAM test of testplus.cpr when touching this (this is not a guarantee that this is correct but at least it's a guarantee that it's less wrong ! cf issue #40)
   if (dcsr_changed)
   {
-    word addr = 0x6C0F;
-    *(membank_write[addr >> 14] + (addr & 0x3fff)) = dcsr;
+    g_memory_bus.write_raw(0x6C0F, dcsr);
   }
 }
 

--- a/src/cpc_machine.h
+++ b/src/cpc_machine.h
@@ -5,8 +5,10 @@
 #define CPC_MACHINE_H
 
 #include "koncepcja.h"
+#include "layered_memory.h"
 
 class t_z80regs;
+struct t_drive;
 
 struct CpcMachine {
   t_CPC*       cpc        = nullptr;
@@ -19,6 +21,7 @@ struct CpcMachine {
   t_drive*     driveA     = nullptr;
   t_drive*     driveB     = nullptr;
   t_z80regs*   z80        = nullptr;
+  LayeredMemory memory{};
 };
 
 extern CpcMachine g_machine;

--- a/src/devtools_ui.cpp
+++ b/src/devtools_ui.cpp
@@ -563,6 +563,12 @@ void DevToolsUI::render_memory_hex()
       if (bpr >= 4 && bpr <= 32) memhex_bytes_per_row_ = bpr;
     }
     ImGui::Separator();
+    ImGui::Checkbox("CPU view", &memhex_cpu_view_);
+    if (ImGui::IsItemHovered()) {
+      ImGui::SetTooltip("When enabled, reads go through the full CPU view (watchpoints, SmartWatch, MF2/ASIC).\n"
+                        "When disabled, reads use the direct debugger view (SmartWatch only, no watchpoints).");
+    }
+    ImGui::Separator();
     ImGui::TextDisabled("(?)");
     if (ImGui::IsItemHovered())
       ImGui::SetTooltip("Right-click for navigation options.");
@@ -598,7 +604,7 @@ void DevToolsUI::render_memory_hex()
         // Hex bytes with watchpoint highlighting
         for (int col = 0; col < bytes_per_row; col++) {
           word a = (base_addr + col) & 0xFFFF;
-          byte val = z80_read_mem(a);
+          byte val = memhex_cpu_view_ ? z80_cpu_read_mem(a) : z80_read_mem(a);
 
           ImGui::SameLine();
 
@@ -640,7 +646,8 @@ void DevToolsUI::render_memory_hex()
         char ascii[33];
         int asc_len = bytes_per_row < 32 ? bytes_per_row : 32;
         for (int col = 0; col < asc_len; col++) {
-          byte b = z80_read_mem((base_addr + col) & 0xFFFF);
+          byte b = memhex_cpu_view_ ? z80_cpu_read_mem((base_addr + col) & 0xFFFF)
+                                    : z80_read_mem((base_addr + col) & 0xFFFF);
           ascii[col] = (b >= 32 && b < 127) ? static_cast<char>(b) : '.';
         }
         ascii[asc_len] = '\0';

--- a/src/devtools_ui.h
+++ b/src/devtools_ui.h
@@ -59,8 +59,9 @@ private:
     char memhex_goto_addr_[8] = "";
     int memhex_goto_value_ = -1;
     int memhex_bytes_per_row_ = 16;
-    int memhex_highlight_addr_ = -1;  // address to flash-highlight (-1 = none)
-    int memhex_highlight_frames_ = 0; // remaining frames of highlight
+    bool memhex_cpu_view_ = false;      // false=direct view, true=CPU view
+    int memhex_highlight_addr_ = -1;    // address to flash-highlight (-1 = none)
+    int memhex_highlight_frames_ = 0;   // remaining frames of highlight
 
     char symtable_filter_[64] = "";
 

--- a/src/imgui_ui.cpp
+++ b/src/imgui_ui.cpp
@@ -42,7 +42,6 @@ extern t_drive driveA;
 extern t_drive driveB;
 extern byte *pbRAM;
 extern byte *memmap_ROM[256];
-extern byte *membank_read[4];
 extern byte *pbExpansionROM;
 extern byte *pbROMhi;
 extern byte bTapeLevel;
@@ -1506,7 +1505,7 @@ static void imgui_render_options()
               if (GateArray.upper_ROM == static_cast<unsigned char>(i)) {
                 pbExpansionROM = pbROMhi;
                 if (!(GateArray.ROM_config & 0x08)) {
-                  membank_read[3] = pbExpansionROM;
+                  memory_set_read_bank(3, pbExpansionROM);
                 }
               }
             }

--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -411,28 +411,35 @@ void ga_memory_manager ()
       ga_init_banking(membank_config, GateArray.RAM_bank);
    }
    for (int n = 0; n < 4; n++) { // remap active memory banks
-      membank_read[n] = membank_config[GateArray.RAM_config & 7][n];
-      membank_write[n] = membank_config[GateArray.RAM_config & 7][n];
+      memory_set_read_bank(n, membank_config[GateArray.RAM_config & 7][n]);
+      memory_set_write_bank(n, membank_config[GateArray.RAM_config & 7][n]);
    }
    if (!(GateArray.ROM_config & 0x04)) { // lower ROM is enabled?
       if (dwMF2Flags & MF2_ACTIVE) { // is the Multiface 2 paged in?
          // MF2 ROM (8K) at 0x0000-0x1FFF: read-only overlay
          // MF2 RAM (8K) at 0x2000-0x3FFF: read-write (intercepted in z80.cpp write_mem)
          // Writes to 0x0000-0x1FFF fall through to CPC RAM (membank_write unchanged)
-         membank_read[GateArray.lower_ROM_bank] = pbMF2ROM;
+         memory_set_read_bank(GateArray.lower_ROM_bank, pbMF2ROM);
       } else {
-         membank_read[GateArray.lower_ROM_bank] = pbROMlo; // 'page in' lower ROM
+         memory_set_read_bank(GateArray.lower_ROM_bank, pbROMlo); // 'page in' lower ROM
       }
    }
    if (CPC.model > 2 && GateArray.registerPageOn) {
-      membank_read[1] = pbRegisterPage;
-      membank_write[1] = pbRegisterPage;
+      memory_set_read_bank(1, pbRegisterPage);
+      memory_set_write_bank(1, pbRegisterPage);
    }
    if (!(GateArray.ROM_config & 0x08)) { // upper/expansion ROM is enabled?
-      membank_read[3] = pbExpansionROM; // 'page in' upper/expansion ROM
+      memory_set_read_bank(3, pbExpansionROM); // 'page in' upper/expansion ROM
    }
 }
 
+void memory_set_read_bank(int slot, byte* ptr) {
+  membank_read[slot] = ptr;
+}
+
+void memory_set_write_bank(int slot, byte* ptr) {
+  membank_write[slot] = ptr;
+}
 
 // ── MF2 I/O dispatch handler ────────────────────
 // MF2 paging uses file-local dwMF2Flags and ga_memory_manager(),
@@ -920,7 +927,7 @@ void z80_OUT_handler (reg_pair port, byte val)
          pbExpansionROM = pbCartridgePages[page];
       }
       if (!(GateArray.ROM_config & 0x08)) { // upper/expansion ROM is enabled?
-         membank_read[3] = pbExpansionROM; // 'page in' upper/expansion ROM
+         memory_set_read_bank(3, pbExpansionROM); // 'page in' upper/expansion ROM
       }
       if (CPC.mf2) { // MF2 enabled?
          *(pbMF2ROM + 0x03aac) = val;
@@ -1284,11 +1291,11 @@ void emulator_reset ()
      memset(pbMF2ROM+8192, 0, 8192); // clear the MF2's RAM area
    }
    for (int n = 0; n < 4; n++) { // initialize active read/write bank configuration
-      membank_read[n] = membank_config[0][n];
-      membank_write[n] = membank_config[0][n];
+      memory_set_read_bank(n, membank_config[0][n]);
+      memory_set_write_bank(n, membank_config[0][n]);
    }
-   membank_read[0] = pbROMlo; // 'page in' lower ROM
-   membank_read[3] = pbROMhi; // 'page in' upper ROM
+   memory_set_read_bank(0, pbROMlo); // 'page in' lower ROM
+   memory_set_read_bank(3, pbROMhi); // 'page in' upper ROM
 
 // Multiface 2
    dwMF2Flags = 0;

--- a/src/koncepcja.h
+++ b/src/koncepcja.h
@@ -450,6 +450,8 @@ void set_osd_message(const std::string& message, uint32_t for_milliseconds = 100
 void koncpc_queue_virtual_keys(const std::string& text);
 void ga_init_banking(t_MemBankConfig& membank_config, unsigned char RAM_bank);
 void ga_memory_manager();
+void memory_set_read_bank(int slot, byte* ptr);
+void memory_set_write_bank(int slot, byte* ptr);
 bool driveAltered();
 void emulator_reset();
 void cpc_pause();

--- a/src/koncepcja_ipc_server.cpp
+++ b/src/koncepcja_ipc_server.cpp
@@ -67,7 +67,6 @@ extern t_GateArray GateArray;
 extern t_PSG PSG;
 extern SDL_Surface *back_surface;
 extern byte *pbRAM;
-extern byte *membank_read[4], *membank_write[4];
 extern byte keyboard_matrix[16];
 extern t_drive driveA;
 extern t_drive driveB;
@@ -2591,7 +2590,7 @@ std::string handle_command(const std::string& line) {
       if (GateArray.upper_ROM == static_cast<unsigned char>(slot)) {
         pbExpansionROM = memmap_ROM[slot];
         if (!(GateArray.ROM_config & 0x08)) {
-          membank_read[3] = pbExpansionROM;
+          memory_set_read_bank(3, pbExpansionROM);
         }
       }
       return "OK\n";
@@ -2610,7 +2609,7 @@ std::string handle_command(const std::string& line) {
       if (GateArray.upper_ROM == static_cast<unsigned char>(slot)) {
         pbExpansionROM = pbROMhi;
         if (!(GateArray.ROM_config & 0x08)) {
-          membank_read[3] = pbExpansionROM;
+          memory_set_read_bank(3, pbExpansionROM);
         }
       }
       return "OK\n";

--- a/src/koncepcja_ipc_server.cpp
+++ b/src/koncepcja_ipc_server.cpp
@@ -187,7 +187,7 @@ std::string handle_command(const std::string& line) {
       unsigned int addr = std::stoul(parts[2], nullptr, 0);
       unsigned int len = std::stoul(parts[3], nullptr, 0);
       uLong crc = crc32(0L, nullptr, 0);
-      // Read through z80 memory banking for correctness
+      // Read through direct Z80 memory (SmartWatch only, no watchpoints)
       std::vector<byte> tmp(len);
       for (unsigned int i = 0; i < len; i++) {
         tmp[i] = z80_read_mem(static_cast<word>(addr + i));
@@ -593,6 +593,33 @@ std::string handle_command(const std::string& line) {
       }
     }
     return "OK diffs=" + std::to_string(diff_count) + diffs + "\n";
+  }
+  if (cmd == "mem" && parts.size() >= 4 && parts[1] == "cpu-read") {
+    // mem cpu-read <addr> <len>
+    unsigned int addr = std::stoul(parts[2], nullptr, 0);
+    unsigned int len = std::stoul(parts[3], nullptr, 0);
+    std::ostringstream resp;
+    resp << "OK ";
+    for (unsigned int i = 0; i < len; i++) {
+      byte v = z80_cpu_read_mem(static_cast<word>(addr + i));
+      resp << std::hex << std::uppercase << std::setfill('0') << std::setw(2)
+           << static_cast<int>(v);
+    }
+    resp << "\n";
+    return resp.str();
+  }
+  if (cmd == "mem" && parts.size() >= 4 && parts[1] == "cpu-write") {
+    // mem cpu-write <addr> <hexbytes...>
+    unsigned int addr = std::stoul(parts[2], nullptr, 0);
+    std::string hex;
+    for (size_t i = 3; i < parts.size(); i++) hex += parts[i];
+    if (hex.size() % 2 != 0) return "ERR 400 bad-hex\n";
+    for (size_t i = 0; i < hex.size(); i += 2) {
+      std::string byte_str = hex.substr(i, 2);
+      byte v = static_cast<byte>(std::stoul(byte_str, nullptr, 16));
+      z80_cpu_write_mem(static_cast<word>(addr + (i/2)), v);
+    }
+    return "OK\n";
   }
   if (cmd == "disasm" && parts.size() >= 2) {
     // disasm follow <addr> — recursive disassembly following jumps

--- a/src/koncepcja_ipc_server.cpp
+++ b/src/koncepcja_ipc_server.cpp
@@ -165,7 +165,7 @@ std::string handle_command(const std::string& line) {
     int p = g_ipc_instance ? g_ipc_instance->port() : 0;
     return "OK koncepcja-0.1 port=" + std::to_string(p) + "\n";
   }
-  if (cmd == "help") return "OK commands: ping version help quit pause run reset load regs reg(set/get) regs(crtc/ga/psg/asic) regs_asic(dma/sprites/interrupts/palette) asic(sprite/palette/dma) mem(read/write/fill/compare/find) bp(list/add/del/clear) wp(add/del/clear/list) iobp(add/del/clear/list) step(N/over/out/to/frame) wait hash(vram/mem/regs) screenshot snapshot(save/load) disasm(follow/refs/export) devtools input(keydown/keyup/key/type/joy) trace(on/off/dump/on_crash/status) frames(dump) event(on/once/off/list) timer(list/clear) sym(load/add/del/list/lookup) stack autotype(text/status/clear) disk(formats/format/new/ls/cat/get/put/rm/info/sector) record(wav/ym/avi) poke(load/list/apply/unapply/write) profile(list/current/load/save/delete) config(get/set) status(drives) search(hex/text/asm) rom(list/load/unload/info) data(mark/clear/list) gfx(view/decode/paint/palette) sdisc(status/clear/save/load) session(record/play/stop/status) asm(text/load/assemble/errors/symbols/source)\n";
+  if (cmd == "help") return "OK commands: ping version help quit pause run reset load regs reg(set/get) regs(crtc/ga/psg/asic) regs_asic(dma/sprites/interrupts/palette) asic(sprite/palette/dma) mem(read/write/fill/compare/find/cpu-read/cpu-write) bp(list/add/del/clear) wp(add/del/clear/list) iobp(add/del/clear/list) step(N/over/out/to/frame) wait hash(vram/mem/regs) screenshot snapshot(save/load) disasm(follow/refs/export) devtools input(keydown/keyup/key/type/joy) trace(on/off/dump/on_crash/status) frames(dump) event(on/once/off/list) timer(list/clear) sym(load/add/del/list/lookup) stack autotype(text/status/clear) disk(formats/format/new/ls/cat/get/put/rm/info/sector) record(wav/ym/avi) poke(load/list/apply/unapply/write) profile(list/current/load/save/delete) config(get/set) status(drives) search(hex/text/asm) rom(list/load/unload/info) data(mark/clear/list) gfx(view/decode/paint/palette) sdisc(status/clear/save/load) session(record/play/stop/status) asm(text/load/assemble/errors/symbols/source)\n";
   if (cmd == "quit") {
     int code = 0;
     if (parts.size() >= 2) code = std::stoi(parts[1]);
@@ -595,31 +595,43 @@ std::string handle_command(const std::string& line) {
     return "OK diffs=" + std::to_string(diff_count) + diffs + "\n";
   }
   if (cmd == "mem" && parts.size() >= 4 && parts[1] == "cpu-read") {
-    // mem cpu-read <addr> <len>
-    unsigned int addr = std::stoul(parts[2], nullptr, 0);
-    unsigned int len = std::stoul(parts[3], nullptr, 0);
-    std::ostringstream resp;
-    resp << "OK ";
-    for (unsigned int i = 0; i < len; i++) {
-      byte v = z80_cpu_read_mem(static_cast<word>(addr + i));
-      resp << std::hex << std::uppercase << std::setfill('0') << std::setw(2)
-           << static_cast<int>(v);
+    // mem cpu-read <addr> <len> — reads through CPU memory map (SmartWatch/ROM banking)
+    // but does NOT trigger watchpoints or IPC events.
+    try {
+      unsigned int addr = std::stoul(parts[2], nullptr, 0);
+      unsigned int len = std::stoul(parts[3], nullptr, 0);
+      if (len > 0x10000) return "ERR 400 len exceeds 64K\n";
+      std::ostringstream resp;
+      resp << "OK ";
+      for (unsigned int i = 0; i < len; i++) {
+        byte v = z80_cpu_read_mem(static_cast<word>(addr + i));
+        resp << std::hex << std::uppercase << std::setfill('0') << std::setw(2)
+             << static_cast<int>(v);
+      }
+      resp << "\n";
+      return resp.str();
+    } catch (const std::exception&) {
+      return "ERR 400 bad-number\n";
     }
-    resp << "\n";
-    return resp.str();
   }
   if (cmd == "mem" && parts.size() >= 4 && parts[1] == "cpu-write") {
-    // mem cpu-write <addr> <hexbytes...>
-    unsigned int addr = std::stoul(parts[2], nullptr, 0);
-    std::string hex;
-    for (size_t i = 3; i < parts.size(); i++) hex += parts[i];
-    if (hex.size() % 2 != 0) return "ERR 400 bad-hex\n";
-    for (size_t i = 0; i < hex.size(); i += 2) {
-      std::string byte_str = hex.substr(i, 2);
-      byte v = static_cast<byte>(std::stoul(byte_str, nullptr, 16));
-      z80_cpu_write_mem(static_cast<word>(addr + (i/2)), v);
+    // mem cpu-write <addr> <hexbytes...> — writes through CPU memory map
+    // but does NOT trigger watchpoints or IPC mem-write events.
+    try {
+      unsigned int addr = std::stoul(parts[2], nullptr, 0);
+      std::string hex;
+      for (size_t i = 3; i < parts.size(); i++) hex += parts[i];
+      if (hex.size() % 2 != 0) return "ERR 400 bad-hex\n";
+      if (hex.size() / 2 > 0x10000) return "ERR 400 len exceeds 64K\n";
+      for (size_t i = 0; i < hex.size(); i += 2) {
+        std::string byte_str = hex.substr(i, 2);
+        byte v = static_cast<byte>(std::stoul(byte_str, nullptr, 16));
+        z80_cpu_write_mem(static_cast<word>(addr + (i/2)), v);
+      }
+      return "OK\n";
+    } catch (const std::exception&) {
+      return "ERR 400 bad-number\n";
     }
-    return "OK\n";
   }
   if (cmd == "disasm" && parts.size() >= 2) {
     // disasm follow <addr> — recursive disassembly following jumps

--- a/src/layered_memory.h
+++ b/src/layered_memory.h
@@ -1,0 +1,49 @@
+// LayeredMemory - views over CPC memory.
+// CPU-view vs direct debug vs raw bus.
+
+#ifndef LAYERED_MEMORY_H
+#define LAYERED_MEMORY_H
+
+#include "types.h"
+#include "memory_bus.h"
+#include "z80.h"
+
+// LayeredMemory is a thin, allocation-free facade over the existing
+// global accessors and MemoryBus. It just forwards calls.
+struct LayeredMemory {
+  // Direct debug view (old IPC behavior):
+  // - read: SmartWatch on upper ROM, no watchpoints
+  // - write: raw MemoryBus, no watchpoints
+  inline byte read_direct(word addr) const {
+    return z80_read_mem(addr);
+  }
+
+  inline void write_direct(word addr, byte v) const {
+    z80_write_mem(addr, v);
+  }
+
+  // CPU view: full layering (watchpoints + SmartWatch/MF2/ASIC + bus).
+  inline byte read_cpu(word addr) const {
+    return z80_cpu_read_mem(addr);
+  }
+
+  inline void write_cpu(word addr, byte v) const {
+    z80_cpu_write_mem(addr, v);
+  }
+
+  // Raw bus views (no devices, no watchpoints).
+  inline byte read_raw(word addr) const {
+    return g_memory_bus.read_raw(addr);
+  }
+
+  inline void write_raw(word addr, byte v) const {
+    g_memory_bus.write_raw(addr, v);
+  }
+
+  inline byte read_raw_via_write_bank(word addr) const {
+    return g_memory_bus.read_raw_via_write_bank(addr);
+  }
+};
+
+#endif // LAYERED_MEMORY_H
+

--- a/src/memory_bus.h
+++ b/src/memory_bus.h
@@ -31,6 +31,11 @@ struct MemoryBus {
     *(write_banks[addr >> 14] + (addr & 0x3fff)) = v;
   }
 
+  // Read using the write bank view (same 4x16KB indexing; used e.g. by IPC memory dump).
+  inline byte read_raw_via_write_bank(word addr) const {
+    return *(write_banks[addr >> 14] + (addr & 0x3fff));
+  }
+
   // Convenience helpers for tools/DevTools that need a bank base (e.g. hex viewer).
   inline byte* bank_read_ptr(int bank) const {
     return read_banks[bank];

--- a/src/z80.cpp
+++ b/src/z80.cpp
@@ -347,6 +347,9 @@ static byte cc_ex[256] = {
 
 extern MemoryBus g_memory_bus;
 
+// Internal helpers for the different memory views:
+// - read_mem_no_watchpoint / write_mem_no_watchpoint: SmartWatch on read, raw bus on write
+// - read_mem / write_mem: full CPU view with watchpoints, SmartWatch, MF2, ASIC
 inline byte read_mem_no_watchpoint(word addr) {
   byte val = g_memory_bus.read_raw(addr); // returns a byte from a 16KB memory bank
   // SmartWatch intercepts upper ROM reads (ROM must be paged in)
@@ -433,6 +436,14 @@ byte z80_read_mem(word addr) {
 
 void z80_write_mem(word addr, byte val) {
   write_mem_no_watchpoint(addr, val);
+}
+
+byte z80_cpu_read_mem(word addr) {
+  return read_mem(addr);
+}
+
+void z80_cpu_write_mem(word addr, byte val) {
+  write_mem(addr, val);
 }
 
 byte z80_read_mem_via_write_bank(word addr) {

--- a/src/z80.cpp
+++ b/src/z80.cpp
@@ -345,7 +345,6 @@ static byte cc_ex[256] = {
 
 
 
-extern byte *membank_read[4], *membank_write[4];
 extern MemoryBus g_memory_bus;
 
 inline byte read_mem_no_watchpoint(word addr) {
@@ -437,7 +436,7 @@ void z80_write_mem(word addr, byte val) {
 }
 
 byte z80_read_mem_via_write_bank(word addr) {
-  return *(membank_write[addr >> 14] + (addr & 0x3FFF));
+  return g_memory_bus.read_raw_via_write_bank(addr);
 }
 
 byte z80_read_mem_raw_bank(word addr, int bank) {

--- a/src/z80.cpp
+++ b/src/z80.cpp
@@ -439,11 +439,11 @@ void z80_write_mem(word addr, byte val) {
 }
 
 byte z80_cpu_read_mem(word addr) {
-  return read_mem(addr);
+  return read_mem_no_watchpoint(addr);
 }
 
 void z80_cpu_write_mem(word addr, byte val) {
-  write_mem(addr, val);
+  write_mem_no_watchpoint(addr, val);
 }
 
 byte z80_read_mem_via_write_bank(word addr) {

--- a/src/z80.h
+++ b/src/z80.h
@@ -139,10 +139,16 @@ extern std::atomic<bool> z80_stop_requested;
 #define EC_STOP_REQUESTED  60
 
 
+// Direct memory access used by IPC and tools:
+// - z80_read_mem / z80_write_mem: SmartWatch on read, raw bus on write (no watchpoints).
 byte z80_read_mem(word addr);
 void z80_write_mem(word addr, byte val);
 byte z80_read_mem_via_write_bank(word addr);
 byte z80_read_mem_raw_bank(word addr, int bank);
+
+// CPU-view accessors (full layering: watchpoints + SmartWatch/MF2/ASIC + bus).
+byte z80_cpu_read_mem(word addr);
+void z80_cpu_write_mem(word addr, byte val);
 
 // TODO: put declaration or definition of these two methods somewhere else !!!
 byte z80_IN_handler(reg_pair port); // not provided by Z80.c

--- a/src/z80.h
+++ b/src/z80.h
@@ -146,7 +146,8 @@ void z80_write_mem(word addr, byte val);
 byte z80_read_mem_via_write_bank(word addr);
 byte z80_read_mem_raw_bank(word addr, int bank);
 
-// CPU-view accessors (full layering: watchpoints + SmartWatch/MF2/ASIC + bus).
+// CPU-view accessors (SmartWatch/MF2/ASIC + bus, NO watchpoints).
+// Safe for IPC and UI — won't trigger watchpoint hits or IPC re-entrancy.
 byte z80_cpu_read_mem(word addr);
 void z80_cpu_write_mem(word addr, byte val);
 


### PR DESCRIPTION
## Summary

- Route remaining Z80/ASIC/CRTC memory access through `MemoryBus` abstraction
- Centralize bank switching behind `memory_set_read_bank`/`memory_set_write_bank`
- Add layered memory views, IPC CPU access helpers, DevTools toggle cleanup

Three commits covering Phases 3-5 of the core refactor roadmap.

## Test plan

- [ ] All unit tests pass (716+)
- [ ] e2e tests pass
- [ ] Manual: load disc, run game, verify no regressions in memory access
- [ ] Manual: DevTools memory viewer still works correctly
- [ ] Manual: bank switching (ROM/RAM configs) behaves normally