### PR TITLE
feat: M4 Board — full firmware parity (39 commands, 31 RSX, DSK containers, LED)

### DIFF
--- a/src/imgui_ui.cpp
+++ b/src/imgui_ui.cpp
@@ -1427,6 +1427,38 @@ static void imgui_render_options()
           if (slot > 31) slot = 31;
           g_m4board.rom_slot = slot;
         }
+
+        // M4 Status display
+        ImGui::Separator();
+        ImGui::TextDisabled("M4 Status");
+
+        // Activity LED + current directory
+        bool active = g_m4board.activity_frames > 0;
+        ImVec4 led_color = active ? ImVec4(0.2f, 0.9f, 0.2f, 1.0f)
+                                  : ImVec4(0.4f, 0.4f, 0.4f, 1.0f);
+        ImGui::TextColored(led_color, "%s", active ? "SD Active" : "SD Idle");
+        ImGui::SameLine(0, 16);
+        ImGui::TextDisabled("Dir: %s", g_m4board.current_dir.c_str());
+
+        // Open files count + last filename
+        int open_count = 0;
+        for (int i = 0; i < 4; i++) {
+          if (g_m4board.open_files[i]) open_count++;
+        }
+        ImGui::Text("Open files: %d/4", open_count);
+        if (!g_m4board.last_filename.empty()) {
+          ImGui::SameLine(0, 16);
+          ImGui::TextDisabled("Last: %s", g_m4board.last_filename.c_str());
+        }
+
+        // Command count
+        if (g_m4board.cmd_count > 0) {
+          ImGui::Text("Commands: %d", g_m4board.cmd_count);
+        }
+
+        // Decrement activity counter each frame
+        if (g_m4board.activity_frames > 0) g_m4board.activity_frames--;
+
         ImGui::Unindent();
       }
 

--- a/src/imgui_ui.cpp
+++ b/src/imgui_ui.cpp
@@ -8,6 +8,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <filesystem>
 #include <sstream>
 #include <iomanip>
 #include <iostream>
@@ -608,6 +609,55 @@ static void imgui_render_topbar()
 
         ImGui::PopID();
       }
+    }
+
+    // M4 Board activity LED (green, only shown when M4 is enabled)
+    if (g_m4board.enabled) {
+      float frameH = ImGui::GetFrameHeight();
+      bool active = g_m4board.activity_frames > 0;
+
+      ImGui::SameLine(0, 12.0f);
+      ImGui::BeginGroup();
+      ImGui::AlignTextToFramePadding();
+      ImGui::TextUnformatted("M4:");
+      ImGui::SameLine(0, 2.0f);
+
+      ImVec2 cursor = ImGui::GetCursorScreenPos();
+      float ledW = 16.0f, ledH = 8.0f;
+      float yOff = (frameH - ledH) * 0.5f;
+      ImVec2 p0(cursor.x, cursor.y + yOff);
+      ImVec2 p1(p0.x + ledW, p0.y + ledH);
+
+      ImDrawList* dl = ImGui::GetWindowDrawList();
+      if (active) {
+        // Active: bright green
+        dl->AddRectFilled(p0, p1, IM_COL32(0, 255, 0, 255));
+        dl->AddLine(p0, ImVec2(p1.x, p0.y), IM_COL32(100, 255, 100, 255));
+        dl->AddLine(p0, ImVec2(p0.x, p1.y), IM_COL32(100, 255, 100, 255));
+        dl->AddLine(ImVec2(p0.x, p1.y), p1, IM_COL32(0, 160, 0, 255));
+        dl->AddLine(ImVec2(p1.x, p0.y), p1, IM_COL32(0, 160, 0, 255));
+      } else {
+        // Inactive: dark green
+        dl->AddRectFilled(p0, p1, IM_COL32(0, 80, 0, 255));
+        dl->AddLine(p0, ImVec2(p1.x, p0.y), IM_COL32(20, 110, 20, 255));
+        dl->AddLine(p0, ImVec2(p0.x, p1.y), IM_COL32(20, 110, 20, 255));
+        dl->AddLine(ImVec2(p0.x, p1.y), p1, IM_COL32(0, 40, 0, 255));
+        dl->AddLine(ImVec2(p1.x, p0.y), p1, IM_COL32(0, 40, 0, 255));
+      }
+
+      ImGui::Dummy(ImVec2(ledW, frameH));
+
+      // Show container name if inside a DSK
+      if (g_m4board.container_type != M4Board::ContainerType::NONE) {
+        ImGui::SameLine(0, 4.0f);
+        auto fname = std::filesystem::path(g_m4board.container_host_path).filename().string();
+        ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.45f, 0.9f, 0.45f, 1.0f));
+        ImGui::AlignTextToFramePadding();
+        ImGui::TextUnformatted(fname.c_str());
+        ImGui::PopStyleColor();
+      }
+
+      ImGui::EndGroup();
     }
 
     // Eject confirmation popup (rendered inside topbar window)

--- a/src/imgui_ui.cpp
+++ b/src/imgui_ui.cpp
@@ -1456,8 +1456,7 @@ static void imgui_render_options()
           ImGui::Text("Commands: %d", g_m4board.cmd_count);
         }
 
-        // Decrement activity counter each frame
-        if (g_m4board.activity_frames > 0) g_m4board.activity_frames--;
+        // activity_frames is decremented in the main emulation loop (EC_FRAME_COMPLETE)
 
         ImGui::Unindent();
       }

--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -3704,6 +3704,9 @@ int koncpc_main (int argc, char **argv)
             // Check IPC VBL events
             ipc_check_vbl_events();
 
+            // M4 Board activity LED countdown (1 per frame at 50fps)
+            if (g_m4board.activity_frames > 0) g_m4board.activity_frames--;
+
             // YM register recording: capture PSG state once per VBL
             if (g_ym_recorder.is_recording()) {
                g_ym_recorder.capture_frame(PSG.RegisterAY.Index);

--- a/src/koncepcja_ipc_server.cpp
+++ b/src/koncepcja_ipc_server.cpp
@@ -2966,6 +2966,17 @@ std::string handle_command(const std::string& line) {
     }
     if (parts[1] == "ls") {
       if (g_m4board.sd_root_path.empty()) return "ERR 400 no-sd-path\n";
+      // Inside a DSK container — list files from the disk image, not the host FS
+      if (g_m4board.container_type != M4Board::ContainerType::NONE
+          && g_m4board.container_drive) {
+        std::string err;
+        auto files = disk_list_files(g_m4board.container_drive, err);
+        if (!err.empty()) return "ERR 500 " + err + "\n";
+        std::string resp = "OK\n";
+        for (const auto& f : files)
+          resp += f.display_name + "\n";
+        return resp;
+      }
       try {
         auto root = std::filesystem::weakly_canonical(g_m4board.sd_root_path);
         std::filesystem::path dir_path = root / g_m4board.current_dir.substr(1);
@@ -2989,9 +3000,39 @@ std::string handle_command(const std::string& line) {
     if (parts[1] == "cd" && parts.size() >= 3) {
       std::string path = parts[2];
       if (path == "/") {
+        // Exit container if inside one, then go to root
+        if (g_m4board.container_type != M4Board::ContainerType::NONE) {
+          // container_exit is static in m4board.cpp; replicate its effect
+          if (g_m4board.container_drive) {
+            dsk_eject(g_m4board.container_drive);
+            delete g_m4board.container_drive;
+            g_m4board.container_drive = nullptr;
+          }
+          g_m4board.container_parent_dir.clear();
+          g_m4board.container_host_path.clear();
+          g_m4board.container_type = M4Board::ContainerType::NONE;
+        }
         g_m4board.current_dir = "/";
         return "OK /\n";
       }
+      // "cd .." from inside a container exits the container
+      if ((path == ".." || path == "../")
+          && g_m4board.container_type != M4Board::ContainerType::NONE) {
+        std::string parent = g_m4board.container_parent_dir;
+        if (g_m4board.container_drive) {
+          dsk_eject(g_m4board.container_drive);
+          delete g_m4board.container_drive;
+          g_m4board.container_drive = nullptr;
+        }
+        g_m4board.container_parent_dir.clear();
+        g_m4board.container_host_path.clear();
+        g_m4board.container_type = M4Board::ContainerType::NONE;
+        g_m4board.current_dir = parent.empty() ? "/" : parent;
+        return "OK " + g_m4board.current_dir + "\n";
+      }
+      // Cannot navigate further inside a container (no subdirs in DSK)
+      if (g_m4board.container_type != M4Board::ContainerType::NONE)
+        return "ERR 400 cannot-cd-inside-container\n";
       if (g_m4board.sd_root_path.empty()) return "ERR 400 no-sd-path\n";
       try {
         auto root = std::filesystem::weakly_canonical(g_m4board.sd_root_path);

--- a/src/koncepcja_ipc_server.cpp
+++ b/src/koncepcja_ipc_server.cpp
@@ -3068,7 +3068,14 @@ std::string handle_command(const std::string& line) {
       m4board_reset();
       return "OK\n";
     }
-    return "ERR 400 usage: m4 (status|ls|cd|reset)\n";
+    if (parts[1] == "wifi") {
+      if (parts.size() < 3) {
+        return std::string("OK ") + (g_m4board.network_enabled ? "1" : "0") + "\n";
+      }
+      g_m4board.network_enabled = (parts[2] != "0");
+      return "OK\n";
+    }
+    return "ERR 400 usage: m4 (status|ls|cd|reset|wifi)\n";
   }
 
   return "ERR 501 not-implemented\n";

--- a/src/koncepcja_ipc_server.cpp
+++ b/src/koncepcja_ipc_server.cpp
@@ -2956,21 +2956,24 @@ std::string handle_command(const std::string& line) {
       for (int i = 0; i < 4; i++) {
         if (g_m4board.open_files[i]) open_files++;
       }
-      char buf[256];
-      snprintf(buf, sizeof(buf), "OK enabled=%d sd_path=%s dir=%s files=%d/4 cmds=%d\n",
-               g_m4board.enabled ? 1 : 0,
-               g_m4board.sd_root_path.empty() ? "(none)" : g_m4board.sd_root_path.c_str(),
-               g_m4board.current_dir.c_str(),
-               open_files,
-               g_m4board.cmd_count);
-      return std::string(buf);
+      std::ostringstream oss;
+      oss << "OK enabled=" << (g_m4board.enabled ? 1 : 0)
+          << " sd_path=" << (g_m4board.sd_root_path.empty() ? "(none)" : g_m4board.sd_root_path)
+          << " dir=" << g_m4board.current_dir
+          << " files=" << open_files << "/4"
+          << " cmds=" << g_m4board.cmd_count << "\n";
+      return oss.str();
     }
     if (parts[1] == "ls") {
-      std::string resolved = g_m4board.sd_root_path;
-      if (resolved.empty()) return "ERR 400 no-sd-path\n";
+      if (g_m4board.sd_root_path.empty()) return "ERR 400 no-sd-path\n";
       try {
-        auto root = std::filesystem::weakly_canonical(resolved);
-        auto dir = std::filesystem::weakly_canonical(resolved + g_m4board.current_dir);
+        auto root = std::filesystem::weakly_canonical(g_m4board.sd_root_path);
+        std::filesystem::path dir_path = root / g_m4board.current_dir.substr(1);
+        auto dir = std::filesystem::weakly_canonical(dir_path);
+        // Verify dir is inside root (component-wise, not string prefix)
+        auto rel = dir.lexically_normal().lexically_relative(root.lexically_normal());
+        if (rel.empty() || (!rel.empty() && *rel.begin() == ".."))
+          return "ERR 403 path-traversal\n";
         std::string resp = "OK\n";
         for (const auto& entry : std::filesystem::directory_iterator(dir)) {
           std::string name = entry.path().filename().string();
@@ -2991,22 +2994,35 @@ std::string handle_command(const std::string& line) {
       }
       if (g_m4board.sd_root_path.empty()) return "ERR 400 no-sd-path\n";
       try {
-        std::string full = g_m4board.sd_root_path + (path[0] == '/' ? "" : g_m4board.current_dir.c_str()) + path;
-        auto canonical = std::filesystem::weakly_canonical(full);
         auto root = std::filesystem::weakly_canonical(g_m4board.sd_root_path);
-        std::string cs = canonical.string(), rs = root.string();
-        if (cs.substr(0, rs.size()) != rs) return "ERR 403 path-traversal\n";
+        std::filesystem::path full_path = root;
+        if (path.front() == '/') {
+          full_path /= path.substr(1);
+        } else {
+          full_path /= g_m4board.current_dir.substr(1);
+          full_path /= path;
+        }
+        auto canonical = std::filesystem::weakly_canonical(full_path);
+        // Component-aware path traversal check
+        auto rel = canonical.lexically_normal().lexically_relative(root.lexically_normal());
+        if (rel.empty() || (!rel.empty() && *rel.begin() == ".."))
+          return "ERR 403 path-traversal\n";
         if (!std::filesystem::is_directory(canonical)) return "ERR 404 not-a-directory\n";
-        std::string rel = cs.substr(rs.size());
-        if (rel.empty()) rel = "/";
-        if (rel.back() != '/') rel += '/';
-        g_m4board.current_dir = rel;
-        return "OK " + rel + "\n";
+        std::string rel_str;
+        if (rel == ".") {
+          rel_str = "/";
+        } else {
+          rel_str = "/" + rel.generic_string();
+          if (rel_str.back() != '/') rel_str += '/';
+        }
+        g_m4board.current_dir = rel_str;
+        return "OK " + rel_str + "\n";
       } catch (const std::filesystem::filesystem_error& e) {
         return "ERR 500 " + std::string(e.what()) + "\n";
       }
     }
     if (parts[1] == "reset") {
+      if (!CPC.paused) return "ERR 400 pause-first\n";
       m4board_cleanup();
       m4board_reset();
       return "OK\n";

--- a/src/koncepcja_ipc_server.cpp
+++ b/src/koncepcja_ipc_server.cpp
@@ -165,7 +165,7 @@ std::string handle_command(const std::string& line) {
     int p = g_ipc_instance ? g_ipc_instance->port() : 0;
     return "OK koncepcja-0.1 port=" + std::to_string(p) + "\n";
   }
-  if (cmd == "help") return "OK commands: ping version help quit pause run reset load regs reg(set/get) regs(crtc/ga/psg/asic) regs_asic(dma/sprites/interrupts/palette) asic(sprite/palette/dma) mem(read/write/fill/compare/find/cpu-read/cpu-write) bp(list/add/del/clear) wp(add/del/clear/list) iobp(add/del/clear/list) step(N/over/out/to/frame) wait hash(vram/mem/regs) screenshot snapshot(save/load) disasm(follow/refs/export) devtools input(keydown/keyup/key/type/joy) trace(on/off/dump/on_crash/status) frames(dump) event(on/once/off/list) timer(list/clear) sym(load/add/del/list/lookup) stack autotype(text/status/clear) disk(formats/format/new/ls/cat/get/put/rm/info/sector) record(wav/ym/avi) poke(load/list/apply/unapply/write) profile(list/current/load/save/delete) config(get/set) status(drives) search(hex/text/asm) rom(list/load/unload/info) data(mark/clear/list) gfx(view/decode/paint/palette) sdisc(status/clear/save/load) session(record/play/stop/status) asm(text/load/assemble/errors/symbols/source)\n";
+  if (cmd == "help") return "OK commands: ping version help quit pause run reset load regs reg(set/get) regs(crtc/ga/psg/asic) regs_asic(dma/sprites/interrupts/palette) asic(sprite/palette/dma) mem(read/write/fill/compare/find/cpu-read/cpu-write) bp(list/add/del/clear) wp(add/del/clear/list) iobp(add/del/clear/list) step(N/over/out/to/frame) wait hash(vram/mem/regs) screenshot snapshot(save/load) disasm(follow/refs/export) devtools input(keydown/keyup/key/type/joy) trace(on/off/dump/on_crash/status) frames(dump) event(on/once/off/list) timer(list/clear) sym(load/add/del/list/lookup) stack autotype(text/status/clear) disk(formats/format/new/ls/cat/get/put/rm/info/sector) record(wav/ym/avi) poke(load/list/apply/unapply/write) profile(list/current/load/save/delete) config(get/set) status(drives) search(hex/text/asm) rom(list/load/unload/info) data(mark/clear/list) gfx(view/decode/paint/palette) sdisc(status/clear/save/load) session(record/play/stop/status) asm(text/load/assemble/errors/symbols/source) m4(status/ls/cd/reset)\n";
   if (cmd == "quit") {
     int code = 0;
     if (parts.size() >= 2) code = std::stoi(parts[1]);
@@ -2947,6 +2947,71 @@ std::string handle_command(const std::string& line) {
       return "OK " + std::string(g_devtools_ui.asm_source_buf()) + "\n";
     }
     return "ERR 400 usage: asm (text|load|assemble|errors|symbols|source)\n";
+  }
+
+  // ── m4 ──
+  if (cmd == "m4" && parts.size() >= 2) {
+    if (parts[1] == "status") {
+      int open_files = 0;
+      for (int i = 0; i < 4; i++) {
+        if (g_m4board.open_files[i]) open_files++;
+      }
+      char buf[256];
+      snprintf(buf, sizeof(buf), "OK enabled=%d sd_path=%s dir=%s files=%d/4 cmds=%d\n",
+               g_m4board.enabled ? 1 : 0,
+               g_m4board.sd_root_path.empty() ? "(none)" : g_m4board.sd_root_path.c_str(),
+               g_m4board.current_dir.c_str(),
+               open_files,
+               g_m4board.cmd_count);
+      return std::string(buf);
+    }
+    if (parts[1] == "ls") {
+      std::string resolved = g_m4board.sd_root_path;
+      if (resolved.empty()) return "ERR 400 no-sd-path\n";
+      try {
+        auto root = std::filesystem::weakly_canonical(resolved);
+        auto dir = std::filesystem::weakly_canonical(resolved + g_m4board.current_dir);
+        std::string resp = "OK\n";
+        for (const auto& entry : std::filesystem::directory_iterator(dir)) {
+          std::string name = entry.path().filename().string();
+          if (name.empty() || name[0] == '.') continue;
+          if (entry.is_directory()) resp += ">" + name + "\n";
+          else resp += name + "\n";
+        }
+        return resp;
+      } catch (const std::filesystem::filesystem_error& e) {
+        return "ERR 500 " + std::string(e.what()) + "\n";
+      }
+    }
+    if (parts[1] == "cd" && parts.size() >= 3) {
+      std::string path = parts[2];
+      if (path == "/") {
+        g_m4board.current_dir = "/";
+        return "OK /\n";
+      }
+      if (g_m4board.sd_root_path.empty()) return "ERR 400 no-sd-path\n";
+      try {
+        std::string full = g_m4board.sd_root_path + (path[0] == '/' ? "" : g_m4board.current_dir.c_str()) + path;
+        auto canonical = std::filesystem::weakly_canonical(full);
+        auto root = std::filesystem::weakly_canonical(g_m4board.sd_root_path);
+        std::string cs = canonical.string(), rs = root.string();
+        if (cs.substr(0, rs.size()) != rs) return "ERR 403 path-traversal\n";
+        if (!std::filesystem::is_directory(canonical)) return "ERR 404 not-a-directory\n";
+        std::string rel = cs.substr(rs.size());
+        if (rel.empty()) rel = "/";
+        if (rel.back() != '/') rel += '/';
+        g_m4board.current_dir = rel;
+        return "OK " + rel + "\n";
+      } catch (const std::filesystem::filesystem_error& e) {
+        return "ERR 500 " + std::string(e.what()) + "\n";
+      }
+    }
+    if (parts[1] == "reset") {
+      m4board_cleanup();
+      m4board_reset();
+      return "OK\n";
+    }
+    return "ERR 400 usage: m4 (status|ls|cd|reset)\n";
   }
 
   return "ERR 501 not-implemented\n";

--- a/src/m4board.cpp
+++ b/src/m4board.cpp
@@ -6,6 +6,17 @@
 #include <ctime>
 #include <filesystem>
 #include <algorithm>
+#ifdef _WIN32
+#include <winsock2.h>
+#include <iphlpapi.h>
+#pragma comment(lib, "iphlpapi.lib")
+#pragma comment(lib, "ws2_32.lib")
+#else
+#include <ifaddrs.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <netdb.h>
+#endif
 #ifdef HAS_LIBCURL
 #include <curl/curl.h>
 #endif
@@ -1245,13 +1256,80 @@ static void cmd_sdwrite()
 // "not connected" / "no network" responses that match the firmware's
 // expected response format, so the ROM handles it gracefully.
 
+// ── Host Network Info ────────────────────────────
+// Query the host computer's network state so |NETSTAT shows real info.
+
+static std::string get_host_ip()
+{
+#ifdef _WIN32
+   char hostname[256];
+   if (gethostname(hostname, sizeof(hostname)) != 0) return "";
+   struct hostent* host = gethostbyname(hostname);
+   if (!host || !host->h_addr_list[0]) return "";
+   return inet_ntoa(*reinterpret_cast<struct in_addr*>(host->h_addr_list[0]));
+#else
+   struct ifaddrs* ifap = nullptr;
+   if (getifaddrs(&ifap) != 0) return "";
+   std::string result;
+   for (struct ifaddrs* ifa = ifap; ifa; ifa = ifa->ifa_next) {
+      if (!ifa->ifa_addr || ifa->ifa_addr->sa_family != AF_INET) continue;
+      // Skip loopback
+      if (std::string(ifa->ifa_name) == "lo" || std::string(ifa->ifa_name) == "lo0") continue;
+      auto* sa = reinterpret_cast<struct sockaddr_in*>(ifa->ifa_addr);
+      char buf[INET_ADDRSTRLEN];
+      inet_ntop(AF_INET, &sa->sin_addr, buf, sizeof(buf));
+      std::string ip(buf);
+      if (ip == "127.0.0.1") continue;
+      result = ip;
+      // Prefer en0/wlan0 (WiFi) over other interfaces
+      std::string name(ifa->ifa_name);
+      if (name == "en0" || name == "wlan0" || name.substr(0, 4) == "wlan") break;
+   }
+   freeifaddrs(ifap);
+   return result;
+#endif
+}
+
+static std::string get_host_ssid()
+{
+#ifdef __APPLE__
+   // macOS: use system_profiler (no private API needed)
+   FILE* pipe = popen("networksetup -getairportnetwork en0 2>/dev/null", "r");
+   if (!pipe) return "";
+   char buf[256];
+   std::string output;
+   while (fgets(buf, sizeof(buf), pipe)) output += buf;
+   pclose(pipe);
+   // Output: "Current Wi-Fi Network: MyNetwork\n"
+   auto pos = output.find(": ");
+   if (pos == std::string::npos) return "";
+   std::string ssid = output.substr(pos + 2);
+   // Strip trailing whitespace
+   while (!ssid.empty() && (ssid.back() == '\n' || ssid.back() == '\r' || ssid.back() == ' '))
+      ssid.pop_back();
+   return ssid;
+#elif defined(__linux__)
+   FILE* pipe = popen("iwgetid -r 2>/dev/null", "r");
+   if (!pipe) return "";
+   char buf[256];
+   std::string ssid;
+   if (fgets(buf, sizeof(buf), pipe)) ssid = buf;
+   pclose(pipe);
+   while (!ssid.empty() && (ssid.back() == '\n' || ssid.back() == '\r'))
+      ssid.pop_back();
+   return ssid;
+#else
+   return "";
+#endif
+}
+
 static void cmd_setnetwork()
 {
    // Protocol: [size, cmd_lo, cmd_hi, setup_string\0]
    // The real M4 configures WiFi SSID/password here.
-   // In emulation, just acknowledge.
+   // In emulation we use the host's network, so just acknowledge.
    respond_ok();
-   LOG_DEBUG("M4: C_SETNETWORK (ignored in emulation)");
+   LOG_DEBUG("M4: C_SETNETWORK (using host network)");
 }
 
 static void cmd_netstat()
@@ -1259,15 +1337,30 @@ static void cmd_netstat()
    // Response: [status_string] [status_byte]
    // Status byte: 0=disconnected, 1=connecting, 2=wrong_password,
    //              3=no_ap, 4=connect_fail, 5=connected
-   // We report "not connected" — the ROM shows this as network status.
+   // Report the host computer's actual network state.
+   std::string ip = get_host_ip();
+   std::string ssid = get_host_ssid();
+
+   std::string msg;
+   uint8_t status_byte;
+   if (!ip.empty()) {
+      msg = "IP: " + ip;
+      if (!ssid.empty()) msg += " (" + ssid + ")";
+      msg += "\r\n";
+      status_byte = 5; // connected
+   } else {
+      msg = "No network\r\n";
+      status_byte = 0; // disconnected
+   }
+
    g_m4board.response[0] = M4_OK;
    g_m4board.response[1] = 0;
    g_m4board.response[2] = 0;
-   const char* msg = "Emulated (no WiFi)\r\n";
-   size_t len = strlen(msg);
-   memcpy(g_m4board.response + 3, msg, len);
-   g_m4board.response[3 + len] = 0; // status byte: 0 = disconnected
-   g_m4board.response_len = static_cast<int>(4 + len);
+   size_t max_len = static_cast<size_t>(M4Board::RESPONSE_SIZE - 5);
+   if (msg.size() > max_len) msg.resize(max_len);
+   memcpy(g_m4board.response + 3, msg.c_str(), msg.size());
+   g_m4board.response[3 + msg.size()] = status_byte;
+   g_m4board.response_len = static_cast<int>(4 + msg.size());
 }
 
 static void cmd_time()
@@ -1352,14 +1445,50 @@ static void cmd_netrecv()
 static void cmd_nethostip()
 {
    // Protocol: [size, cmd_lo, cmd_hi, hostname\0]
-   // Response: [1=lookup in progress] (then poll via C_NETRECV for result)
-   // We return "lookup in progress" but the result will never arrive — matching
-   // the behavior of a real M4 with no WiFi connection.
+   // On real hardware: response[3]=1 means "lookup in progress", then the result
+   // comes later. In emulation we can resolve synchronously and return the IP
+   // directly: response[3]=0 (done), response[4-7]=IP bytes.
+   std::string hostname = extract_string(g_m4board.cmd_buf, 3);
+   if (hostname.empty()) {
+      g_m4board.response[0] = M4_OK;
+      g_m4board.response[1] = 0;
+      g_m4board.response[2] = 0;
+      g_m4board.response[3] = 0xFF; // error
+      g_m4board.response_len = 4;
+      return;
+   }
+
+   struct addrinfo hints = {}, *result = nullptr;
+   hints.ai_family = AF_INET;
+   int err = getaddrinfo(hostname.c_str(), nullptr, &hints, &result);
+   if (err != 0 || !result) {
+      // Lookup failed — return "in progress" (will never resolve, as on offline M4)
+      g_m4board.response[0] = M4_OK;
+      g_m4board.response[1] = 0;
+      g_m4board.response[2] = 0;
+      g_m4board.response[3] = 1; // lookup in progress (= failed)
+      g_m4board.response_len = 4;
+      if (result) freeaddrinfo(result);
+      return;
+   }
+
+   auto* addr = reinterpret_cast<struct sockaddr_in*>(result->ai_addr);
+   uint32_t ip = ntohl(addr->sin_addr.s_addr);
+   freeaddrinfo(result);
+
+   // Return resolved IP: [0=done] [ip0] [ip1] [ip2] [ip3]
    g_m4board.response[0] = M4_OK;
    g_m4board.response[1] = 0;
    g_m4board.response[2] = 0;
-   g_m4board.response[3] = 1; // lookup in progress
-   g_m4board.response_len = 4;
+   g_m4board.response[3] = 0; // done (resolved)
+   g_m4board.response[4] = static_cast<uint8_t>((ip >> 24) & 0xFF);
+   g_m4board.response[5] = static_cast<uint8_t>((ip >> 16) & 0xFF);
+   g_m4board.response[6] = static_cast<uint8_t>((ip >> 8) & 0xFF);
+   g_m4board.response[7] = static_cast<uint8_t>(ip & 0xFF);
+   g_m4board.response_len = 8;
+   LOG_DEBUG("M4: C_NETHOSTIP resolved " << hostname << " -> "
+            << (int)g_m4board.response[4] << "." << (int)g_m4board.response[5] << "."
+            << (int)g_m4board.response[6] << "." << (int)g_m4board.response[7]);
 }
 
 // ── ROM Management ──────────────────────────────

--- a/src/m4board.cpp
+++ b/src/m4board.cpp
@@ -1275,20 +1275,48 @@ static std::string get_host_ip()
 #else
    struct ifaddrs* ifap = nullptr;
    if (getifaddrs(&ifap) != 0) return "";
+
+   // Score interfaces to prefer real hardware over VPN/VM bridges.
+   // Higher score = more likely to be the "real" connection.
+   auto score_interface = [](const char* name, const char* ip) -> int {
+      std::string n(name);
+      std::string addr(ip);
+      // Skip loopback
+      if (n == "lo" || n == "lo0" || addr == "127.0.0.1") return -1;
+      // Skip known virtual/tunnel interfaces
+      if (n.substr(0, 4) == "utun") return 0;    // VPN tunnels (macOS)
+      if (n.substr(0, 3) == "tun") return 0;     // VPN tunnels (Linux)
+      if (n.substr(0, 3) == "tap") return 0;     // VM tap interfaces
+      if (n.substr(0, 6) == "bridge") return 0;  // VM bridges (macOS)
+      if (n.substr(0, 6) == "vmenet") return 0;  // VM virtual ethernet (macOS)
+      if (n.substr(0, 5) == "veth") return 0;    // Docker veth pairs
+      if (n.substr(0, 6) == "docker") return 0;  // Docker bridge
+      if (n.substr(0, 2) == "br") return 0;      // Linux bridges
+      if (n.substr(0, 4) == "virbr") return 0;   // libvirt bridges
+      if (n.substr(0, 3) == "llw") return 0;     // Low-latency WLAN (macOS internal)
+      if (n.substr(0, 4) == "awdl") return 0;    // Apple Wireless Direct Link
+      if (n.substr(0, 2) == "ap") return 0;      // Apple access point
+      if (n.substr(0, 4) == "anpi") return 0;    // Apple Network Performance Interface
+      // 169.254.x.x = link-local (no real connectivity)
+      if (addr.substr(0, 8) == "169.254.") return 0;
+      // Real interfaces: en*, eth*, wlan* — prefer these
+      if (n.substr(0, 2) == "en" || n.substr(0, 3) == "eth" || n.substr(0, 4) == "wlan") return 2;
+      // Anything else is unknown — give it a middling score
+      return 1;
+   };
+
    std::string result;
+   int best_score = -1;
    for (struct ifaddrs* ifa = ifap; ifa; ifa = ifa->ifa_next) {
       if (!ifa->ifa_addr || ifa->ifa_addr->sa_family != AF_INET) continue;
-      // Skip loopback
-      if (std::string(ifa->ifa_name) == "lo" || std::string(ifa->ifa_name) == "lo0") continue;
       auto* sa = reinterpret_cast<struct sockaddr_in*>(ifa->ifa_addr);
       char buf[INET_ADDRSTRLEN];
       inet_ntop(AF_INET, &sa->sin_addr, buf, sizeof(buf));
-      std::string ip(buf);
-      if (ip == "127.0.0.1") continue;
-      result = ip;
-      // Prefer en0/wlan0 (WiFi) over other interfaces
-      std::string name(ifa->ifa_name);
-      if (name == "en0" || name == "wlan0" || name.substr(0, 4) == "wlan") break;
+      int s = score_interface(ifa->ifa_name, buf);
+      if (s > best_score) {
+         best_score = s;
+         result = buf;
+      }
    }
    freeifaddrs(ifap);
    return result;
@@ -1298,16 +1326,43 @@ static std::string get_host_ip()
 static std::string get_host_ssid()
 {
 #ifdef __APPLE__
-   FILE* pipe = popen("networksetup -getairportnetwork en0 2>/dev/null", "r");
+   // Discover the Wi-Fi interface name (not always en0 — can be en1, en2, etc.)
+   std::string wifi_if;
+   FILE* lp = popen("networksetup -listallhardwareports 2>/dev/null", "r");
+   if (lp) {
+      char lbuf[256];
+      bool next_is_device = false;
+      while (fgets(lbuf, sizeof(lbuf), lp)) {
+         std::string line(lbuf);
+         if (line.find("Wi-Fi") != std::string::npos) {
+            next_is_device = true;
+         } else if (next_is_device && line.find("Device:") != std::string::npos) {
+            auto dpos = line.find("Device:");
+            wifi_if = line.substr(dpos + 7);
+            while (!wifi_if.empty() && (wifi_if.front() == ' ' || wifi_if.front() == '\t'))
+               wifi_if.erase(wifi_if.begin());
+            while (!wifi_if.empty() && (wifi_if.back() == '\n' || wifi_if.back() == '\r' || wifi_if.back() == ' '))
+               wifi_if.pop_back();
+            break;
+         }
+      }
+      pclose(lp);
+   }
+   if (wifi_if.empty()) return "";
+
+   std::string cmd = "networksetup -getairportnetwork " + wifi_if + " 2>/dev/null";
+   FILE* pipe = popen(cmd.c_str(), "r");
    if (!pipe) return "";
    char buf[256];
    std::string output;
    while (fgets(buf, sizeof(buf), pipe)) output += buf;
-   pclose(pipe);
+   int status = pclose(pipe);
+   // Non-zero exit = error (e.g. "Error obtaining wireless information.")
+   if (status != 0) return "";
    // Output: "Current Wi-Fi Network: MyNetwork\n"
-   auto pos = output.find(": ");
+   auto pos = output.find("Network: ");
    if (pos == std::string::npos) return "";
-   std::string ssid = output.substr(pos + 2);
+   std::string ssid = output.substr(pos + 9);
    while (!ssid.empty() && (ssid.back() == '\n' || ssid.back() == '\r' || ssid.back() == ' '))
       ssid.pop_back();
    return ssid;
@@ -1386,11 +1441,14 @@ static void cmd_netstat()
    g_m4board.response[0] = M4_OK;
    g_m4board.response[1] = 0;
    g_m4board.response[2] = 0;
-   size_t max_len = static_cast<size_t>(M4Board::RESPONSE_SIZE - 5);
+   // Layout: [3: string...] [3+len: \0] [3+len+1: status_byte]
+   // The ROM prints from offset 3 until \0, then reads the status byte after it.
+   size_t max_len = static_cast<size_t>(M4Board::RESPONSE_SIZE - 6); // room for \0 + status
    if (msg.size() > max_len) msg.resize(max_len);
    memcpy(g_m4board.response + 3, msg.c_str(), msg.size());
-   g_m4board.response[3 + msg.size()] = status_byte;
-   g_m4board.response_len = static_cast<int>(4 + msg.size());
+   g_m4board.response[3 + msg.size()] = 0;              // null terminator
+   g_m4board.response[3 + msg.size() + 1] = status_byte; // status after null
+   g_m4board.response_len = static_cast<int>(5 + msg.size());
 }
 
 static void cmd_time()

--- a/src/m4board.cpp
+++ b/src/m4board.cpp
@@ -8,14 +8,19 @@
 #include <algorithm>
 #ifdef _WIN32
 #include <winsock2.h>
+#include <ws2tcpip.h>
 #include <iphlpapi.h>
 #pragma comment(lib, "iphlpapi.lib")
 #pragma comment(lib, "ws2_32.lib")
 #else
+#include <sys/socket.h>
 #include <ifaddrs.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <netdb.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <errno.h>
 #endif
 #ifdef HAS_LIBCURL
 #include <curl/curl.h>
@@ -1293,7 +1298,6 @@ static std::string get_host_ip()
 static std::string get_host_ssid()
 {
 #ifdef __APPLE__
-   // macOS: use system_profiler (no private API needed)
    FILE* pipe = popen("networksetup -getairportnetwork en0 2>/dev/null", "r");
    if (!pipe) return "";
    char buf[256];
@@ -1304,9 +1308,35 @@ static std::string get_host_ssid()
    auto pos = output.find(": ");
    if (pos == std::string::npos) return "";
    std::string ssid = output.substr(pos + 2);
-   // Strip trailing whitespace
    while (!ssid.empty() && (ssid.back() == '\n' || ssid.back() == '\r' || ssid.back() == ' '))
       ssid.pop_back();
+   return ssid;
+#elif defined(_WIN32)
+   // Windows: parse "netsh wlan show interfaces"
+   FILE* pipe = _popen("netsh wlan show interfaces 2>nul", "r");
+   if (!pipe) return "";
+   char buf[512];
+   std::string ssid;
+   while (fgets(buf, sizeof(buf), pipe)) {
+      std::string line(buf);
+      // Look for "    SSID                   : MyNetwork"
+      auto pos = line.find("SSID");
+      if (pos == std::string::npos) continue;
+      // Skip "BSSID" lines
+      if (pos > 0 && line[pos - 1] == 'B') continue;
+      auto colon = line.find(':', pos);
+      if (colon == std::string::npos) continue;
+      ssid = line.substr(colon + 1);
+      // Trim whitespace
+      size_t start = ssid.find_first_not_of(" \t\r\n");
+      size_t end = ssid.find_last_not_of(" \t\r\n");
+      if (start != std::string::npos && end != std::string::npos)
+         ssid = ssid.substr(start, end - start + 1);
+      else
+         ssid.clear();
+      break;
+   }
+   _pclose(pipe);
    return ssid;
 #elif defined(__linux__)
    FILE* pipe = popen("iwgetid -r 2>/dev/null", "r");
@@ -1389,43 +1419,175 @@ static void cmd_m4off()
    LOG_INFO("M4: C_M4OFF — M4 Board disabled");
 }
 
+// ── Cross-platform socket helpers ────────────────
+
+static void sock_close(M4Board::socket_t s)
+{
+#ifdef _WIN32
+   closesocket(s);
+#else
+   close(s);
+#endif
+}
+
+static void sock_set_nonblocking(M4Board::socket_t s)
+{
+#ifdef _WIN32
+   u_long mode = 1;
+   ioctlsocket(s, FIONBIO, &mode);
+#else
+   int flags = fcntl(s, F_GETFL, 0);
+   if (flags >= 0) fcntl(s, F_SETFL, flags | O_NONBLOCK);
+#endif
+}
+
+static void m4_close_all_sockets()
+{
+   for (int i = 0; i < M4Board::MAX_SOCKETS; i++) {
+      if (g_m4board.sockets[i] != M4Board::INVALID_SOCK) {
+         sock_close(g_m4board.sockets[i]);
+         g_m4board.sockets[i] = M4Board::INVALID_SOCK;
+      }
+   }
+}
+
 static void cmd_netsocket()
 {
    // Protocol: [size, cmd_lo, cmd_hi, domain, type, protocol]
    // Response: [socket_num or 0xFF=error]
-   // No real network available — return error
+   // Find a free slot
+   int slot = -1;
+   for (int i = 0; i < M4Board::MAX_SOCKETS; i++) {
+      if (g_m4board.sockets[i] == M4Board::INVALID_SOCK) { slot = i; break; }
+   }
+   if (slot < 0) {
+      g_m4board.response[0] = M4_OK;
+      g_m4board.response[1] = 0;
+      g_m4board.response[2] = 0;
+      g_m4board.response[3] = 0xFF; // no free slot
+      g_m4board.response_len = 4;
+      return;
+   }
+
+   // Create a TCP socket (CPC software always wants AF_INET + SOCK_STREAM)
+   M4Board::socket_t s = socket(AF_INET, SOCK_STREAM, 0);
+   if (s == M4Board::INVALID_SOCK) {
+      g_m4board.response[0] = M4_OK;
+      g_m4board.response[1] = 0;
+      g_m4board.response[2] = 0;
+      g_m4board.response[3] = 0xFF;
+      g_m4board.response_len = 4;
+      return;
+   }
+
+   g_m4board.sockets[slot] = s;
    g_m4board.response[0] = M4_OK;
    g_m4board.response[1] = 0;
    g_m4board.response[2] = 0;
-   g_m4board.response[3] = 0xFF; // error: no socket available
+   g_m4board.response[3] = static_cast<uint8_t>(slot);
    g_m4board.response_len = 4;
+   LOG_DEBUG("M4: C_NETSOCKET created slot " << slot);
 }
 
 static void cmd_netconnect()
 {
    // Protocol: [size, cmd_lo, cmd_hi, socket, ip0, ip1, ip2, ip3, port_hi, port_lo]
-   // Response: [0=OK, 0xFF=error]
+   if (g_m4board.cmd_buf.size() < 10) {
+      respond_error();
+      return;
+   }
+   int slot = g_m4board.cmd_buf[3];
+   if (slot < 0 || slot >= M4Board::MAX_SOCKETS ||
+       g_m4board.sockets[slot] == M4Board::INVALID_SOCK) {
+      g_m4board.response[0] = M4_OK;
+      g_m4board.response[1] = 0;
+      g_m4board.response[2] = 0;
+      g_m4board.response[3] = 0xFF;
+      g_m4board.response_len = 4;
+      return;
+   }
+
+   struct sockaddr_in addr = {};
+   addr.sin_family = AF_INET;
+   uint32_t ip = (static_cast<uint32_t>(g_m4board.cmd_buf[4]) << 24) |
+                 (static_cast<uint32_t>(g_m4board.cmd_buf[5]) << 16) |
+                 (static_cast<uint32_t>(g_m4board.cmd_buf[6]) << 8) |
+                  static_cast<uint32_t>(g_m4board.cmd_buf[7]);
+   addr.sin_addr.s_addr = htonl(ip);
+   uint16_t port = (static_cast<uint16_t>(g_m4board.cmd_buf[8]) << 8) |
+                    static_cast<uint16_t>(g_m4board.cmd_buf[9]);
+   addr.sin_port = htons(port);
+
+   int result = connect(g_m4board.sockets[slot],
+                        reinterpret_cast<struct sockaddr*>(&addr), sizeof(addr));
+
    g_m4board.response[0] = M4_OK;
    g_m4board.response[1] = 0;
    g_m4board.response[2] = 0;
-   g_m4board.response[3] = 0xFF; // error: connection failed
+   if (result == 0) {
+      // Connected — set non-blocking for subsequent recv calls
+      sock_set_nonblocking(g_m4board.sockets[slot]);
+      g_m4board.response[3] = 0; // OK
+      LOG_INFO("M4: C_NETCONNECT slot " << slot << " -> "
+               << (int)g_m4board.cmd_buf[4] << "." << (int)g_m4board.cmd_buf[5] << "."
+               << (int)g_m4board.cmd_buf[6] << "." << (int)g_m4board.cmd_buf[7]
+               << ":" << port);
+   } else {
+      g_m4board.response[3] = 0xFF; // error
+      LOG_ERROR("M4: C_NETCONNECT failed for slot " << slot);
+   }
    g_m4board.response_len = 4;
 }
 
 static void cmd_netclose()
 {
    // Protocol: [size, cmd_lo, cmd_hi, socket]
+   if (g_m4board.cmd_buf.size() < 4) {
+      respond_ok();
+      return;
+   }
+   int slot = g_m4board.cmd_buf[3];
+   if (slot >= 0 && slot < M4Board::MAX_SOCKETS &&
+       g_m4board.sockets[slot] != M4Board::INVALID_SOCK) {
+      sock_close(g_m4board.sockets[slot]);
+      g_m4board.sockets[slot] = M4Board::INVALID_SOCK;
+      LOG_DEBUG("M4: C_NETCLOSE slot " << slot);
+   }
    respond_ok();
 }
 
 static void cmd_netsend()
 {
    // Protocol: [size, cmd_lo, cmd_hi, socket, size_lo, size_hi, data...]
-   // Response: [0=OK, 0xFF=error]
+   if (g_m4board.cmd_buf.size() < 6) {
+      respond_error();
+      return;
+   }
+   int slot = g_m4board.cmd_buf[3];
+   uint16_t data_size = static_cast<uint16_t>(g_m4board.cmd_buf[4]) |
+                        (static_cast<uint16_t>(g_m4board.cmd_buf[5]) << 8);
+
    g_m4board.response[0] = M4_OK;
    g_m4board.response[1] = 0;
    g_m4board.response[2] = 0;
-   g_m4board.response[3] = 0xFF; // error: not connected
+
+   if (slot < 0 || slot >= M4Board::MAX_SOCKETS ||
+       g_m4board.sockets[slot] == M4Board::INVALID_SOCK) {
+      g_m4board.response[3] = 0xFF;
+      g_m4board.response_len = 4;
+      return;
+   }
+
+   size_t avail = g_m4board.cmd_buf.size() - 6;
+   size_t to_send = std::min(static_cast<size_t>(data_size), avail);
+   if (to_send > 0) {
+      ssize_t sent = send(g_m4board.sockets[slot],
+                          reinterpret_cast<const char*>(g_m4board.cmd_buf.data() + 6),
+                          static_cast<int>(to_send), 0);
+      g_m4board.response[3] = (sent > 0) ? 0 : 0xFF;
+   } else {
+      g_m4board.response[3] = 0;
+   }
    g_m4board.response_len = 4;
 }
 
@@ -1433,13 +1595,48 @@ static void cmd_netrecv()
 {
    // Protocol: [size, cmd_lo, cmd_hi, socket, size_lo, size_hi]
    // Response: [0] [actual_lo] [actual_hi] [data...]
+   if (g_m4board.cmd_buf.size() < 6) {
+      respond_error();
+      return;
+   }
+   int slot = g_m4board.cmd_buf[3];
+   uint16_t max_recv = static_cast<uint16_t>(g_m4board.cmd_buf[4]) |
+                       (static_cast<uint16_t>(g_m4board.cmd_buf[5]) << 8);
+
    g_m4board.response[0] = M4_OK;
    g_m4board.response[1] = 0;
    g_m4board.response[2] = 0;
-   g_m4board.response[3] = 0;  // status OK (just no data)
-   g_m4board.response[4] = 0;  // actual_lo = 0
-   g_m4board.response[5] = 0;  // actual_hi = 0
-   g_m4board.response_len = 6;
+
+   if (slot < 0 || slot >= M4Board::MAX_SOCKETS ||
+       g_m4board.sockets[slot] == M4Board::INVALID_SOCK) {
+      g_m4board.response[3] = 0xFF; // error
+      g_m4board.response[4] = 0;
+      g_m4board.response[5] = 0;
+      g_m4board.response_len = 6;
+      return;
+   }
+
+   // Cap to available response buffer space (offset 6 onward)
+   size_t buf_space = static_cast<size_t>(M4Board::RESPONSE_SIZE - 6);
+   size_t to_recv = std::min(static_cast<size_t>(max_recv), buf_space);
+
+   // Non-blocking recv — returns immediately if no data available
+   ssize_t received = recv(g_m4board.sockets[slot],
+                           reinterpret_cast<char*>(g_m4board.response + 6),
+                           static_cast<int>(to_recv), 0);
+
+   if (received > 0) {
+      g_m4board.response[3] = 0; // OK
+      g_m4board.response[4] = static_cast<uint8_t>(received & 0xFF);
+      g_m4board.response[5] = static_cast<uint8_t>((received >> 8) & 0xFF);
+      g_m4board.response_len = static_cast<int>(6 + received);
+   } else {
+      // EAGAIN/EWOULDBLOCK = no data yet (not an error), or connection closed
+      g_m4board.response[3] = 0; // OK (just no data)
+      g_m4board.response[4] = 0;
+      g_m4board.response[5] = 0;
+      g_m4board.response_len = 6;
+   }
 }
 
 static void cmd_nethostip()
@@ -1687,6 +1884,7 @@ void m4board_reset()
    g_m4board.last_op = M4Board::LastOp::NONE;
    g_m4board.last_filename.clear();
    g_m4board.cmd_count = 0;
+   m4_close_all_sockets();
 }
 
 void m4board_cleanup()
@@ -1698,6 +1896,7 @@ void m4board_cleanup()
          g_m4board.open_files[i] = nullptr;
       }
    }
+   m4_close_all_sockets();
 }
 
 void m4board_data_out(byte val)

--- a/src/m4board.cpp
+++ b/src/m4board.cpp
@@ -30,6 +30,8 @@ static constexpr uint16_t C_DIRSETARGS = 0x4325;
 static constexpr uint16_t C_VERSION    = 0x4326;
 static constexpr uint16_t C_READSECTOR = 0x430B;
 static constexpr uint16_t C_READ2      = 0x4312;
+static constexpr uint16_t C_FSTAT      = 0x4316;
+static constexpr uint16_t C_WRITE2     = 0x431B;
 static constexpr uint16_t C_ROMWRITE   = 0x43FD;
 static constexpr uint16_t C_CONFIG     = 0x43FE;
 
@@ -418,6 +420,7 @@ static void cmd_open()
       }
    }
 
+   g_m4board.last_filename = raw_name;
    LOG_DEBUG("M4: C_OPEN → OK, handle=" << handle);
    g_m4board.response[0] = M4_OK;
    g_m4board.response[1] = 0;
@@ -821,6 +824,35 @@ static void cmd_httpget()
 
 #endif // HAS_LIBCURL
 
+static void cmd_fstat()
+{
+   // Protocol: [size, cmd_lo, cmd_hi, fd]
+   // Returns file attributes byte at response[3]:
+   //   0x00 = normal file, 0x10 = directory
+   if (g_m4board.cmd_buf.size() < 4) {
+      respond_error();
+      return;
+   }
+   int handle = g_m4board.cmd_buf[3];
+   if (handle < 0 || handle >= 4 || !g_m4board.open_files[handle]) {
+      respond_error("Bad handle");
+      return;
+   }
+   g_m4board.response[0] = M4_OK;
+   g_m4board.response[1] = 0;
+   g_m4board.response[2] = 0;
+   g_m4board.response[3] = 0;  // attributes: normal file
+   g_m4board.response_len = 4;
+}
+
+static void cmd_write2()
+{
+   // C_WRITE2 is the buffered write counterpart to C_READ2.
+   // The M4 ROM uses this for _cas_out_char buffered writes.
+   // Same protocol as C_WRITE.
+   cmd_write();
+}
+
 // ── New command handlers ────────────────────────
 
 static void cmd_config()
@@ -970,6 +1002,10 @@ void m4board_reset()
    memset(g_m4board.config_buf, 0, M4Board::CONFIG_SIZE);
    g_m4board.dir_entries.clear();
    g_m4board.dir_index = 0;
+   g_m4board.activity_frames = 0;
+   g_m4board.last_op = M4Board::LastOp::NONE;
+   g_m4board.last_filename.clear();
+   g_m4board.cmd_count = 0;
 }
 
 void m4board_cleanup()
@@ -1004,27 +1040,34 @@ void m4board_execute()
    memset(g_m4board.response, 0, M4Board::RESPONSE_SIZE);
    g_m4board.response_len = 0;
 
+   // Activity tracking
+   g_m4board.cmd_count++;
+   g_m4board.activity_frames = 30;  // ~0.6s at 50fps
+   g_m4board.last_op = M4Board::LastOp::CMD;
+
    switch (cmd) {
       case C_VERSION:    cmd_version(); break;
       case C_CD:         cmd_cd(); break;
-      case C_READDIR:    cmd_readdir(); break;
+      case C_READDIR:    cmd_readdir(); g_m4board.last_op = M4Board::LastOp::DIR; break;
       case C_OPEN:       cmd_open(); break;
       case C_CLOSE:      cmd_close(); break;
-      case C_READ:       cmd_read(); break;
-      case C_READ2:      cmd_read2(); break;
-      case C_READSECTOR: cmd_readsector(); break;
-      case C_WRITE:      cmd_write(); break;
+      case C_READ:       cmd_read(); g_m4board.last_op = M4Board::LastOp::READ; break;
+      case C_READ2:      cmd_read2(); g_m4board.last_op = M4Board::LastOp::READ; break;
+      case C_READSECTOR: cmd_readsector(); g_m4board.last_op = M4Board::LastOp::READ; break;
+      case C_WRITE:      cmd_write(); g_m4board.last_op = M4Board::LastOp::WRITE; break;
+      case C_WRITE2:     cmd_write2(); g_m4board.last_op = M4Board::LastOp::WRITE; break;
       case C_SEEK:       cmd_seek(); break;
       case C_EOF:        cmd_eof(); break;
       case C_FREE:       cmd_free(); break;
       case C_FSIZE:      cmd_fsize(); break;
+      case C_FSTAT:      cmd_fstat(); break;
       case C_FTELL:      cmd_ftell(); break;
       case C_ERASEFILE:  cmd_erasefile(); break;
       case C_RENAME:     cmd_rename(); break;
       case C_MAKEDIR:    cmd_makedir(); break;
       case C_GETPATH:    cmd_getpath(); break;
       case C_HTTPGET:    cmd_httpget(); break;
-      case C_DIRSETARGS: cmd_dirsetargs(); break;
+      case C_DIRSETARGS: cmd_dirsetargs(); g_m4board.last_op = M4Board::LastOp::DIR; break;
       case C_CONFIG:     cmd_config(); break;
       case C_ROMWRITE:   cmd_romwrite(); break;
       default:

--- a/src/m4board.cpp
+++ b/src/m4board.cpp
@@ -2,6 +2,8 @@
 #include "disk.h"
 #include "disk_file_editor.h"
 #include "log.h"
+#include <cctype>
+#include <chrono>
 #include <cstring>
 #include <ctime>
 #include <filesystem>
@@ -10,8 +12,10 @@
 #include <winsock2.h>
 #include <ws2tcpip.h>
 #include <iphlpapi.h>
+#ifdef _MSC_VER
 #pragma comment(lib, "iphlpapi.lib")
 #pragma comment(lib, "ws2_32.lib")
+#endif
 #else
 #include <sys/socket.h>
 #include <ifaddrs.h>
@@ -77,6 +81,18 @@ static constexpr uint16_t C_CONFIG      = 0x43FE;
 // Response status codes
 static constexpr uint8_t M4_OK    = 0x00;
 static constexpr uint8_t M4_ERROR = 0xFF;
+
+#ifdef _WIN32
+// One-time Winsock initialisation for socket-based commands.
+static void ensure_winsock_init()
+{
+   static bool done = false;
+   if (done) return;
+   WSADATA wsa;
+   WSAStartup(MAKEWORD(2, 2), &wsa);
+   done = true;
+}
+#endif
 
 // ── Path Safety ─────────────────────────────────
 
@@ -470,6 +486,26 @@ static FILE* try_open_cpc(const std::string& dir_path, const std::string& filena
    return nullptr;
 }
 
+// Cross-platform temporary file creation.
+// On POSIX, tmpfile() works reliably. On Windows it often fails due to
+// permissions (tries to create in the root of C:\).
+static FILE* portable_tmpfile()
+{
+#ifdef _WIN32
+   char tmppath[MAX_PATH];
+   char tmpname[MAX_PATH];
+   if (GetTempPathA(MAX_PATH, tmppath) == 0) return nullptr;
+   if (GetTempFileNameA(tmppath, "m4b", 0, tmpname) == 0) return nullptr;
+   // GetTempFileNameA creates the file; reopen in w+b mode.
+   // FILE_FLAG_DELETE_ON_CLOSE would be ideal but fopen doesn't support it
+   // on all CRTs. We accept the leak of tiny temp files — they're in %TEMP%
+   // which the OS cleans periodically.
+   return fopen(tmpname, "w+b");
+#else
+   return tmpfile();
+#endif
+}
+
 // Open a file from inside a DSK container: extract to a temp file, return FILE*.
 static FILE* container_open_file(const std::string& filename)
 {
@@ -503,7 +539,7 @@ static FILE* container_open_file(const std::string& filename)
    }
 found:
    // Write extracted data to a temp file
-   FILE* fp = tmpfile();
+   FILE* fp = portable_tmpfile();
    if (!fp) return nullptr;
    if (!data.empty()) {
       fwrite(data.data(), 1, data.size(), fp);
@@ -1267,6 +1303,7 @@ static void cmd_sdwrite()
 static std::string get_host_ip()
 {
 #ifdef _WIN32
+   ensure_winsock_init();
    char hostname[256];
    if (gethostname(hostname, sizeof(hostname)) != 0) return "";
    struct hostent* host = gethostbyname(hostname);
@@ -1323,7 +1360,24 @@ static std::string get_host_ip()
 #endif
 }
 
+static std::string get_host_ssid_uncached();
+
 static std::string get_host_ssid()
+{
+   // Cache the SSID for 30 seconds to avoid shelling out on every |NETSTAT call.
+   static std::string cached_ssid;
+   static std::chrono::steady_clock::time_point cached_at{};
+   auto now = std::chrono::steady_clock::now();
+   if (std::chrono::duration_cast<std::chrono::seconds>(now - cached_at).count() < 30
+       && !cached_ssid.empty()) {
+      return cached_ssid;
+   }
+   cached_ssid = get_host_ssid_uncached();
+   cached_at = now;
+   return cached_ssid;
+}
+
+static std::string get_host_ssid_uncached()
 {
 #ifdef __APPLE__
    // Discover the Wi-Fi interface name (not always en0 — can be en1, en2, etc.)
@@ -1511,6 +1565,9 @@ static void m4_close_all_sockets()
 
 static void cmd_netsocket()
 {
+#ifdef _WIN32
+   ensure_winsock_init();
+#endif
    // Protocol: [size, cmd_lo, cmd_hi, domain, type, protocol]
    // Response: [socket_num or 0xFF=error]
    // Find a free slot
@@ -1699,6 +1756,9 @@ static void cmd_netrecv()
 
 static void cmd_nethostip()
 {
+#ifdef _WIN32
+   ensure_winsock_init();
+#endif
    // Protocol: [size, cmd_lo, cmd_hi, hostname\0]
    // On real hardware: response[3]=1 means "lookup in progress", then the result
    // comes later. In emulation we can resolve synchronously and return the IP

--- a/src/m4board.cpp
+++ b/src/m4board.cpp
@@ -84,13 +84,20 @@ static constexpr uint8_t M4_ERROR = 0xFF;
 
 #ifdef _WIN32
 // One-time Winsock initialisation for socket-based commands.
-static void ensure_winsock_init()
+static bool ensure_winsock_init()
 {
-   static bool done = false;
-   if (done) return;
+   static bool ok = false;
+   static bool tried = false;
+   if (tried) return ok;
+   tried = true;
    WSADATA wsa;
-   WSAStartup(MAKEWORD(2, 2), &wsa);
-   done = true;
+   int err = WSAStartup(MAKEWORD(2, 2), &wsa);
+   if (err != 0) {
+      LOG_ERROR("M4: WSAStartup failed with error " << err);
+      return false;
+   }
+   ok = true;
+   return true;
 }
 #endif
 
@@ -522,7 +529,8 @@ static FILE* container_open_file(const std::string& filename)
       }
       // Get file list and match case-insensitively
       auto files = disk_list_files(g_m4board.container_drive, err);
-      err.clear();
+      if (files.empty()) return nullptr;
+      err.clear(); // listing succeeded — clear for disk_read_file below
       for (const auto& cand : candidates) {
          std::string cand_upper = cand;
          for (auto& c : cand_upper) c = static_cast<char>(toupper(static_cast<unsigned char>(c)));

--- a/src/m4board.cpp
+++ b/src/m4board.cpp
@@ -1,4 +1,6 @@
 #include "m4board.h"
+#include "disk.h"
+#include "disk_file_editor.h"
 #include "log.h"
 #include <cstring>
 #include <filesystem>
@@ -6,6 +8,10 @@
 #ifdef HAS_LIBCURL
 #include <curl/curl.h>
 #endif
+
+// Forward declarations from slotshandler.cpp
+int dsk_load(const std::string& filename, t_drive* drive);
+void dsk_eject(t_drive* drive);
 
 M4Board g_m4board;
 
@@ -56,17 +62,16 @@ static std::string resolve_path(const std::string& rel_path)
       full += rel_path;
    }
 
-   // Resolve and verify it's within sd_root_path
+   // Resolve and verify it's within sd_root_path (component-aware check)
    try {
       auto canonical = std::filesystem::weakly_canonical(full);
       auto root_canonical = std::filesystem::weakly_canonical(base);
-      std::string cs = canonical.string();
-      std::string rs = root_canonical.string();
-      if (cs.substr(0, rs.size()) != rs) {
+      auto rel = canonical.lexically_normal().lexically_relative(root_canonical.lexically_normal());
+      if (rel.empty() || (!rel.empty() && *rel.begin() == "..")) {
          LOG_ERROR("M4: path traversal blocked: " << full);
          return "";
       }
-      return cs;
+      return canonical.string();
    } catch (const std::filesystem::filesystem_error& e) {
       LOG_ERROR("M4: " << e.what());
       return "";
@@ -127,6 +132,44 @@ static void respond_error_code(uint8_t code)
    g_m4board.response_len = 5;
 }
 
+// ── Container Helpers ───────────────────────────
+
+static void container_exit()
+{
+   if (g_m4board.container_drive) {
+      dsk_eject(g_m4board.container_drive);
+      delete g_m4board.container_drive;
+      g_m4board.container_drive = nullptr;
+   }
+   g_m4board.current_dir = g_m4board.container_parent_dir;
+   g_m4board.container_parent_dir.clear();
+   g_m4board.container_host_path.clear();
+   g_m4board.container_type = M4Board::ContainerType::NONE;
+}
+
+static bool container_enter_dsk(const std::string& host_path, const std::string& parent_dir)
+{
+   auto* drive = new t_drive{};
+   int rc = dsk_load(host_path, drive);
+   if (rc != 0) {
+      delete drive;
+      return false;
+   }
+   g_m4board.container_drive = drive;
+   g_m4board.container_type = M4Board::ContainerType::DSK;
+   g_m4board.container_host_path = host_path;
+   g_m4board.container_parent_dir = parent_dir;
+   // current_dir shows the container filename as a virtual directory
+   auto fname = std::filesystem::path(host_path).filename().string();
+   g_m4board.current_dir = parent_dir + fname + "/";
+   return true;
+}
+
+static bool in_container()
+{
+   return g_m4board.container_type != M4Board::ContainerType::NONE;
+}
+
 // ── Command Handlers ────────────────────────────
 
 static void cmd_version()
@@ -144,9 +187,25 @@ static void cmd_version()
 static void cmd_cd()
 {
    std::string path = extract_string(g_m4board.cmd_buf, 3);
+
+   // cd "/" — go to root, exit any container
    if (path == "/") {
+      if (in_container()) container_exit();
       g_m4board.current_dir = "/";
       respond_ok();
+      return;
+   }
+
+   // cd ".." from inside a container — exit the container
+   if ((path == ".." || path == "../") && in_container()) {
+      container_exit();
+      respond_ok();
+      return;
+   }
+
+   // Can't navigate further inside a container (no subdirectories in DSK)
+   if (in_container()) {
+      respond_error("Not a directory");
       return;
    }
 
@@ -159,13 +218,30 @@ static void cmd_cd()
    try {
       if (std::filesystem::is_directory(resolved)) {
          auto root_canonical = std::filesystem::weakly_canonical(g_m4board.sd_root_path);
-         std::string rel = resolved.substr(root_canonical.string().size());
-         if (rel.empty()) rel = "/";
-         if (rel.back() != '/') rel += '/';
-         g_m4board.current_dir = rel;
+         auto rel = std::filesystem::path(resolved).lexically_normal().lexically_relative(
+            root_canonical.lexically_normal());
+         std::string rel_str;
+         if (rel == ".") {
+            rel_str = "/";
+         } else {
+            rel_str = "/" + rel.generic_string();
+            if (rel_str.back() != '/') rel_str += '/';
+         }
+         g_m4board.current_dir = rel_str;
          respond_ok();
       } else {
-         respond_error("Not a directory");
+         // Check if it's a DSK file — enter as container
+         std::string lower = path;
+         for (auto& c : lower) c = static_cast<char>(tolower(static_cast<unsigned char>(c)));
+         if (lower.size() >= 4 && lower.substr(lower.size() - 4) == ".dsk") {
+            if (container_enter_dsk(resolved, g_m4board.current_dir)) {
+               respond_ok();
+            } else {
+               respond_error("Cannot open DSK");
+            }
+         } else {
+            respond_error("Not a directory");
+         }
       }
    } catch (const std::filesystem::filesystem_error& e) {
       LOG_ERROR("M4: " << e.what());
@@ -178,6 +254,20 @@ static void dir_populate()
 {
    g_m4board.dir_entries.clear();
    g_m4board.dir_index = 0;
+
+   // Inside a DSK container — list CP/M directory entries
+   if (in_container() && g_m4board.container_drive) {
+      std::string err;
+      auto files = disk_list_files(g_m4board.container_drive, err);
+      if (!err.empty()) {
+         LOG_ERROR("M4: container dir_populate: " << err);
+         return;
+      }
+      for (const auto& f : files) {
+         g_m4board.dir_entries.push_back({f.display_name, false, f.size_bytes});
+      }
+      return;
+   }
 
    std::string resolved = resolve_path(g_m4board.current_dir);
    if (resolved.empty()) return;
@@ -347,6 +437,49 @@ static FILE* try_open_cpc(const std::string& dir_path, const std::string& filena
    return nullptr;
 }
 
+// Open a file from inside a DSK container: extract to a temp file, return FILE*.
+static FILE* container_open_file(const std::string& filename)
+{
+   if (!g_m4board.container_drive) return nullptr;
+
+   std::string err;
+   auto data = disk_read_file(g_m4board.container_drive, filename, err);
+   if (!err.empty()) {
+      // Case-insensitive retry with CPC extensions
+      std::vector<std::string> candidates = { filename };
+      if (filename.find('.') == std::string::npos) {
+         for (const char* ext : { ".BAS", ".BIN", ".", "" })
+            candidates.push_back(filename + ext);
+      }
+      // Get file list and match case-insensitively
+      auto files = disk_list_files(g_m4board.container_drive, err);
+      err.clear();
+      for (const auto& cand : candidates) {
+         std::string cand_upper = cand;
+         for (auto& c : cand_upper) c = static_cast<char>(toupper(static_cast<unsigned char>(c)));
+         for (const auto& f : files) {
+            std::string disp_upper = f.display_name;
+            for (auto& c : disp_upper) c = static_cast<char>(toupper(static_cast<unsigned char>(c)));
+            if (disp_upper == cand_upper) {
+               data = disk_read_file(g_m4board.container_drive, f.display_name, err);
+               if (err.empty()) goto found;
+            }
+         }
+      }
+      return nullptr;
+   }
+found:
+   // Write extracted data to a temp file
+   FILE* fp = tmpfile();
+   if (!fp) return nullptr;
+   if (!data.empty()) {
+      fwrite(data.data(), 1, data.size(), fp);
+      fflush(fp);
+      rewind(fp);
+   }
+   return fp;
+}
+
 static void cmd_open()
 {
    // cmd_buf layout: [size, 0x01, 0x43, mode, filename...]
@@ -361,6 +494,33 @@ static void cmd_open()
       raw_name = extract_string(g_m4board.cmd_buf, 3);
    }
    LOG_DEBUG("M4: C_OPEN name='" << raw_name << "' mode=0x" << std::hex << (int)mode << std::dec);
+
+   // Inside a container — read-only, extract file to temp
+   if (in_container()) {
+      if (is_write) {
+         respond_error_code(7); // FR_DENIED — containers are read-only
+         return;
+      }
+      int handle = 1; // FA_READ → handle 1
+      if (g_m4board.open_files[handle]) {
+         fclose(g_m4board.open_files[handle]);
+         g_m4board.open_files[handle] = nullptr;
+      }
+      g_m4board.open_files[handle] = container_open_file(raw_name);
+      if (!g_m4board.open_files[handle]) {
+         respond_error_code(4); // FR_NO_FILE
+         return;
+      }
+      g_m4board.last_filename = raw_name;
+      LOG_DEBUG("M4: C_OPEN container → OK, handle=" << handle);
+      g_m4board.response[0] = M4_OK;
+      g_m4board.response[1] = 0;
+      g_m4board.response[2] = 0;
+      g_m4board.response[3] = static_cast<uint8_t>(handle);
+      g_m4board.response[4] = 0;  // FR_OK
+      g_m4board.response_len = 5;
+      return;
+   }
 
    std::string dir = resolve_path(g_m4board.current_dir);
    if (dir.empty()) {
@@ -528,6 +688,38 @@ static void cmd_readsector()
    uint8_t sector = g_m4board.cmd_buf[4];
    // cmd_buf[5] = drive (unused for virtual FS)
 
+   // Inside a DSK container — read directly from the parsed t_drive
+   if (in_container() && g_m4board.container_drive) {
+      t_drive* drv = g_m4board.container_drive;
+      if (track >= drv->tracks) {
+         g_m4board.response[0] = M4_OK;
+         g_m4board.response[3] = 1; // error
+         memset(g_m4board.response + 4, 0xE5, 512);
+         g_m4board.response_len = 4 + 512;
+         return;
+      }
+      t_track& trk = drv->track[track][0];
+      // Find sector by ID
+      uint8_t* data = nullptr;
+      for (unsigned int s = 0; s < trk.sectors; s++) {
+         if (trk.sector[s].CHRN[2] == sector) {
+            data = trk.sector[s].getDataForRead();
+            break;
+         }
+      }
+      if (data) {
+         memcpy(g_m4board.response + 4, data, 512);
+      } else {
+         memset(g_m4board.response + 4, 0xE5, 512);
+      }
+      g_m4board.response[0] = M4_OK;
+      g_m4board.response[1] = 0;
+      g_m4board.response[2] = 0;
+      g_m4board.response[3] = 0;
+      g_m4board.response_len = 4 + 512;
+      return;
+   }
+
    // We need an open file to read from. Use handle 1 (the read handle).
    FILE* f = g_m4board.open_files[1];
    if (!f) {
@@ -561,6 +753,34 @@ static void cmd_readsector()
 static void cmd_fsize()
 {
    std::string path = extract_string(g_m4board.cmd_buf, 3);
+
+   // Inside a container — look up file size from CP/M directory
+   if (in_container() && g_m4board.container_drive) {
+      std::string err;
+      auto files = disk_list_files(g_m4board.container_drive, err);
+      // Case-insensitive search
+      std::string upper = path;
+      for (auto& c : upper) c = static_cast<char>(toupper(static_cast<unsigned char>(c)));
+      for (const auto& f : files) {
+         std::string fu = f.display_name;
+         for (auto& c : fu) c = static_cast<char>(toupper(static_cast<unsigned char>(c)));
+         if (fu == upper) {
+            uint32_t sz = f.size_bytes;
+            g_m4board.response[0] = M4_OK;
+            g_m4board.response[1] = 0;
+            g_m4board.response[2] = 0;
+            g_m4board.response[3] = sz & 0xFF;
+            g_m4board.response[4] = (sz >> 8) & 0xFF;
+            g_m4board.response[5] = (sz >> 16) & 0xFF;
+            g_m4board.response[6] = (sz >> 24) & 0xFF;
+            g_m4board.response_len = 7;
+            return;
+         }
+      }
+      respond_error("File not found");
+      return;
+   }
+
    std::string resolved = resolve_path(path);
    if (resolved.empty()) {
       respond_error("Invalid path");
@@ -585,6 +805,7 @@ static void cmd_fsize()
 
 static void cmd_erasefile()
 {
+   if (in_container()) { respond_error("Read-only container"); return; }
    std::string path = extract_string(g_m4board.cmd_buf, 3);
    std::string resolved = resolve_path(path);
    if (resolved.empty()) {
@@ -606,6 +827,7 @@ static void cmd_erasefile()
 
 static void cmd_makedir()
 {
+   if (in_container()) { respond_error("Read-only container"); return; }
    std::string path = extract_string(g_m4board.cmd_buf, 3);
    std::string resolved = resolve_path(path);
    if (resolved.empty()) {
@@ -624,6 +846,7 @@ static void cmd_makedir()
 
 static void cmd_write()
 {
+   if (in_container()) { respond_error("Read-only container"); return; }
    // Protocol: [size, cmd_lo, cmd_hi, fd, data...]
    // cmd_buf[3] = fd, cmd_buf[4..] = data to write
    if (g_m4board.cmd_buf.size() < 5) {
@@ -681,6 +904,7 @@ static void cmd_seek()
 
 static void cmd_rename()
 {
+   if (in_container()) { respond_error("Read-only container"); return; }
    // Protocol: [size, cmd_lo, cmd_hi, "newname\0oldname\0"]
    // cmd_buf[3..] = "newname\0oldname\0"
    std::string newname = extract_string(g_m4board.cmd_buf, 3);
@@ -847,6 +1071,7 @@ static void cmd_fstat()
 
 static void cmd_write2()
 {
+   if (in_container()) { respond_error("Read-only container"); return; }
    // C_WRITE2 is the buffered write counterpart to C_READ2.
    // The M4 ROM uses this for _cas_out_char buffered writes.
    // Same protocol as C_WRITE.
@@ -994,6 +1219,7 @@ static void cmd_free()
 
 void m4board_reset()
 {
+   if (in_container()) container_exit();
    g_m4board.cmd_buf.clear();
    g_m4board.cmd_pending = false;
    g_m4board.current_dir = "/";
@@ -1010,6 +1236,7 @@ void m4board_reset()
 
 void m4board_cleanup()
 {
+   if (in_container()) container_exit();
    for (int i = 0; i < 4; i++) {
       if (g_m4board.open_files[i]) {
          fclose(g_m4board.open_files[i]);

--- a/src/m4board.cpp
+++ b/src/m4board.cpp
@@ -1729,9 +1729,9 @@ static void cmd_netsend()
    size_t avail = g_m4board.cmd_buf.size() - 6;
    size_t to_send = std::min(static_cast<size_t>(data_size), avail);
    if (to_send > 0) {
-      ssize_t sent = send(g_m4board.sockets[slot],
-                          reinterpret_cast<const char*>(g_m4board.cmd_buf.data() + 6),
-                          static_cast<int>(to_send), 0);
+      int sent = send(g_m4board.sockets[slot],
+                      reinterpret_cast<const char*>(g_m4board.cmd_buf.data() + 6),
+                      static_cast<int>(to_send), 0);
       g_m4board.response[3] = (sent > 0) ? 0 : 0xFF;
    } else {
       g_m4board.response[3] = 0;
@@ -1770,9 +1770,9 @@ static void cmd_netrecv()
    size_t to_recv = std::min(static_cast<size_t>(max_recv), buf_space);
 
    // Non-blocking recv — returns immediately if no data available
-   ssize_t received = recv(g_m4board.sockets[slot],
-                           reinterpret_cast<char*>(g_m4board.response + 6),
-                           static_cast<int>(to_recv), 0);
+   int received = recv(g_m4board.sockets[slot],
+                       reinterpret_cast<char*>(g_m4board.response + 6),
+                       static_cast<int>(to_recv), 0);
 
    if (received > 0) {
       g_m4board.response[3] = 0; // OK

--- a/src/m4board.cpp
+++ b/src/m4board.cpp
@@ -3,6 +3,7 @@
 #include "disk_file_editor.h"
 #include "log.h"
 #include <cstring>
+#include <ctime>
 #include <filesystem>
 #include <algorithm>
 #ifdef HAS_LIBCURL
@@ -38,8 +39,24 @@ static constexpr uint16_t C_READSECTOR = 0x430B;
 static constexpr uint16_t C_READ2      = 0x4312;
 static constexpr uint16_t C_FSTAT      = 0x4316;
 static constexpr uint16_t C_WRITE2     = 0x431B;
-static constexpr uint16_t C_ROMWRITE   = 0x43FD;
-static constexpr uint16_t C_CONFIG     = 0x43FE;
+static constexpr uint16_t C_WRITESECTOR = 0x430C;
+static constexpr uint16_t C_FORMATTRACK = 0x430D;
+static constexpr uint16_t C_SDREAD      = 0x4314;
+static constexpr uint16_t C_SDWRITE     = 0x4315;
+static constexpr uint16_t C_SETNETWORK  = 0x4321;
+static constexpr uint16_t C_M4OFF       = 0x4322;
+static constexpr uint16_t C_NETSTAT     = 0x4323;
+static constexpr uint16_t C_TIME        = 0x4324;
+static constexpr uint16_t C_HTTPGETMEM  = 0x4328;
+static constexpr uint16_t C_ROMSUPDATE  = 0x432B;
+static constexpr uint16_t C_NETSOCKET   = 0x4331;
+static constexpr uint16_t C_NETCONNECT  = 0x4332;
+static constexpr uint16_t C_NETCLOSE    = 0x4333;
+static constexpr uint16_t C_NETSEND     = 0x4334;
+static constexpr uint16_t C_NETRECV     = 0x4335;
+static constexpr uint16_t C_NETHOSTIP   = 0x4336;
+static constexpr uint16_t C_ROMWRITE    = 0x43FD;
+static constexpr uint16_t C_CONFIG      = 0x43FE;
 
 // Response status codes
 static constexpr uint8_t M4_OK    = 0x00;
@@ -1048,6 +1065,315 @@ static void cmd_httpget()
 
 #endif // HAS_LIBCURL
 
+// ── HTTP GET to memory ──────────────────────────
+
+#ifdef HAS_LIBCURL
+
+struct MemBuf {
+   std::vector<uint8_t> data;
+   size_t max_size;
+};
+
+static size_t curl_write_mem(void* ptr, size_t size, size_t nmemb, void* userdata)
+{
+   auto* buf = static_cast<MemBuf*>(userdata);
+   size_t total = size * nmemb;
+   size_t remain = buf->max_size - buf->data.size();
+   size_t to_copy = std::min(total, remain);
+   if (to_copy > 0) {
+      auto* bytes = static_cast<uint8_t*>(ptr);
+      buf->data.insert(buf->data.end(), bytes, bytes + to_copy);
+   }
+   return total; // pretend we consumed all (to avoid curl error)
+}
+
+static void cmd_httpgetmem()
+{
+   // Protocol: [size, cmd_lo, cmd_hi, size_hi, size_lo, url\0]
+   // Downloads to CPC memory instead of SD card
+   if (g_m4board.cmd_buf.size() < 6) {
+      respond_error("Bad args");
+      return;
+   }
+   uint16_t max_dl = (static_cast<uint16_t>(g_m4board.cmd_buf[3]) << 8) |
+                      static_cast<uint16_t>(g_m4board.cmd_buf[4]);
+   std::string raw_url = extract_string(g_m4board.cmd_buf, 5);
+   if (raw_url.empty()) {
+      respond_error("No URL given");
+      return;
+   }
+
+   std::string url = raw_url;
+   if (!url.empty() && url[0] == '@') url = url.substr(1);
+   if (url.substr(0, 7) == "http://") url = url.substr(7);
+   std::string full_url = "http://" + url;
+
+   // Cap download to response buffer space (offset 5 onward)
+   size_t max_size = std::min(static_cast<size_t>(max_dl),
+      static_cast<size_t>(M4Board::RESPONSE_SIZE - 5));
+
+   MemBuf membuf;
+   membuf.max_size = max_size;
+
+   CURL* curl = curl_easy_init();
+   if (!curl) {
+      respond_error("HTTP init failed");
+      return;
+   }
+
+   curl_easy_setopt(curl, CURLOPT_URL, full_url.c_str());
+   curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, curl_write_mem);
+   curl_easy_setopt(curl, CURLOPT_WRITEDATA, &membuf);
+   curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
+   curl_easy_setopt(curl, CURLOPT_TIMEOUT, 30L);
+   curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 10L);
+   curl_easy_setopt(curl, CURLOPT_USERAGENT, "M4Board/2.0");
+   curl_easy_setopt(curl, CURLOPT_FAILONERROR, 1L);
+
+   CURLcode res = curl_easy_perform(curl);
+   curl_easy_cleanup(curl);
+
+   if (res != CURLE_OK) {
+      respond_error(curl_easy_strerror(res));
+      return;
+   }
+
+   // Response: [status=0] [0] [0] [dl_size_hi] [dl_size_lo] [data...]
+   uint16_t dl_size = static_cast<uint16_t>(membuf.data.size());
+   g_m4board.response[0] = M4_OK;
+   g_m4board.response[1] = 0;
+   g_m4board.response[2] = 0;
+   g_m4board.response[3] = static_cast<uint8_t>(dl_size >> 8);
+   g_m4board.response[4] = static_cast<uint8_t>(dl_size & 0xFF);
+   if (!membuf.data.empty())
+      memcpy(g_m4board.response + 5, membuf.data.data(), membuf.data.size());
+   g_m4board.response_len = static_cast<int>(5 + membuf.data.size());
+   LOG_INFO("M4 HTTPGETMEM: downloaded " << dl_size << " bytes from " << full_url);
+}
+
+#else // !HAS_LIBCURL
+
+static void cmd_httpgetmem()
+{
+   respond_error("HTTP not available (no libcurl)");
+}
+
+#endif // HAS_LIBCURL
+
+// ── Write Sector ────────────────────────────────
+
+static void cmd_writesector()
+{
+   if (in_container()) { respond_error("Read-only container"); return; }
+   // Protocol: [size, cmd_lo, cmd_hi, track, sector, drive, 512 bytes]
+   if (g_m4board.cmd_buf.size() < 6 + 512) {
+      respond_error();
+      return;
+   }
+   uint8_t track  = g_m4board.cmd_buf[3];
+   uint8_t sector = g_m4board.cmd_buf[4];
+   // cmd_buf[5] = drive (unused for virtual FS)
+
+   FILE* f = g_m4board.open_files[2]; // write handle
+   if (!f) {
+      respond_error("No file open for write");
+      return;
+   }
+
+   int linear_sector = (sector >= 0xC1) ? (sector - 0xC1) : sector;
+   long offset = (track * 9 + linear_sector) * 512L;
+
+   fseek(f, offset, SEEK_SET);
+   size_t written = fwrite(g_m4board.cmd_buf.data() + 6, 1, 512, f);
+   fflush(f);
+
+   if (written == 512) {
+      respond_ok();
+   } else {
+      respond_error("Write sector failed");
+   }
+}
+
+static void cmd_formattrack()
+{
+   // Not implemented even on real M4 hardware
+   respond_error("Format not supported");
+}
+
+// ── Raw SD Card Access ──────────────────────────
+// The real M4 provides raw block-level access to the SD card.
+// We map LBA sectors to a flat file ("sdcard.img") in the SD root, if present.
+
+static void cmd_sdread()
+{
+   // Protocol: [size, cmd_lo, cmd_hi, lba0, lba1, lba2, lba3, num_sectors]
+   if (g_m4board.cmd_buf.size() < 8) {
+      respond_error();
+      return;
+   }
+   uint32_t lba = static_cast<uint32_t>(g_m4board.cmd_buf[3]) |
+                  (static_cast<uint32_t>(g_m4board.cmd_buf[4]) << 8) |
+                  (static_cast<uint32_t>(g_m4board.cmd_buf[5]) << 16) |
+                  (static_cast<uint32_t>(g_m4board.cmd_buf[6]) << 24);
+   uint8_t num = g_m4board.cmd_buf[7];
+
+   // Raw SD not supported in emulation — return error
+   (void)lba;
+   (void)num;
+   g_m4board.response[0] = M4_OK;
+   g_m4board.response[1] = 0;
+   g_m4board.response[2] = 0;
+   g_m4board.response[3] = 1; // error flag
+   g_m4board.response_len = 4;
+   LOG_DEBUG("M4: C_SDREAD lba=" << lba << " n=" << (int)num << " (not supported)");
+}
+
+static void cmd_sdwrite()
+{
+   // Protocol: [size, cmd_lo, cmd_hi, lba0, lba1, lba2, lba3, num_sectors, data...]
+   // Raw SD not supported in emulation
+   g_m4board.response[0] = M4_OK;
+   g_m4board.response[1] = 0;
+   g_m4board.response[2] = 0;
+   g_m4board.response[3] = 1; // error flag
+   g_m4board.response_len = 4;
+   LOG_DEBUG("M4: C_SDWRITE (not supported)");
+}
+
+// ── Network & Socket Operations ─────────────────
+// The real M4 has an ESP8266 WiFi module. In emulation we return
+// "not connected" / "no network" responses that match the firmware's
+// expected response format, so the ROM handles it gracefully.
+
+static void cmd_setnetwork()
+{
+   // Protocol: [size, cmd_lo, cmd_hi, setup_string\0]
+   // The real M4 configures WiFi SSID/password here.
+   // In emulation, just acknowledge.
+   respond_ok();
+   LOG_DEBUG("M4: C_SETNETWORK (ignored in emulation)");
+}
+
+static void cmd_netstat()
+{
+   // Response: [status_string] [status_byte]
+   // Status byte: 0=disconnected, 1=connecting, 2=wrong_password,
+   //              3=no_ap, 4=connect_fail, 5=connected
+   // We report "not connected" — the ROM shows this as network status.
+   g_m4board.response[0] = M4_OK;
+   g_m4board.response[1] = 0;
+   g_m4board.response[2] = 0;
+   const char* msg = "Emulated (no WiFi)\r\n";
+   size_t len = strlen(msg);
+   memcpy(g_m4board.response + 3, msg, len);
+   g_m4board.response[3 + len] = 0; // status byte: 0 = disconnected
+   g_m4board.response_len = static_cast<int>(4 + len);
+}
+
+static void cmd_time()
+{
+   // Response: "hh:mm:ss yyyy-mm-dd" at offset 3
+   time_t now = time(nullptr);
+   struct tm* t = localtime(&now);
+   char buf[32];
+   snprintf(buf, sizeof(buf), "%02d:%02d:%02d %04d-%02d-%02d",
+            t->tm_hour, t->tm_min, t->tm_sec,
+            t->tm_year + 1900, t->tm_mon + 1, t->tm_mday);
+   g_m4board.response[0] = M4_OK;
+   g_m4board.response[1] = 0;
+   g_m4board.response[2] = 0;
+   size_t len = strlen(buf);
+   memcpy(g_m4board.response + 3, buf, len + 1);
+   g_m4board.response_len = static_cast<int>(4 + len);
+}
+
+static void cmd_m4off()
+{
+   // Disable M4 ROM and trigger a reset.
+   // On real hardware this disables the M4 until next power cycle.
+   g_m4board.enabled = false;
+   respond_ok();
+   LOG_INFO("M4: C_M4OFF — M4 Board disabled");
+}
+
+static void cmd_netsocket()
+{
+   // Protocol: [size, cmd_lo, cmd_hi, domain, type, protocol]
+   // Response: [socket_num or 0xFF=error]
+   // No real network available — return error
+   g_m4board.response[0] = M4_OK;
+   g_m4board.response[1] = 0;
+   g_m4board.response[2] = 0;
+   g_m4board.response[3] = 0xFF; // error: no socket available
+   g_m4board.response_len = 4;
+}
+
+static void cmd_netconnect()
+{
+   // Protocol: [size, cmd_lo, cmd_hi, socket, ip0, ip1, ip2, ip3, port_hi, port_lo]
+   // Response: [0=OK, 0xFF=error]
+   g_m4board.response[0] = M4_OK;
+   g_m4board.response[1] = 0;
+   g_m4board.response[2] = 0;
+   g_m4board.response[3] = 0xFF; // error: connection failed
+   g_m4board.response_len = 4;
+}
+
+static void cmd_netclose()
+{
+   // Protocol: [size, cmd_lo, cmd_hi, socket]
+   respond_ok();
+}
+
+static void cmd_netsend()
+{
+   // Protocol: [size, cmd_lo, cmd_hi, socket, size_lo, size_hi, data...]
+   // Response: [0=OK, 0xFF=error]
+   g_m4board.response[0] = M4_OK;
+   g_m4board.response[1] = 0;
+   g_m4board.response[2] = 0;
+   g_m4board.response[3] = 0xFF; // error: not connected
+   g_m4board.response_len = 4;
+}
+
+static void cmd_netrecv()
+{
+   // Protocol: [size, cmd_lo, cmd_hi, socket, size_lo, size_hi]
+   // Response: [0] [actual_lo] [actual_hi] [data...]
+   g_m4board.response[0] = M4_OK;
+   g_m4board.response[1] = 0;
+   g_m4board.response[2] = 0;
+   g_m4board.response[3] = 0;  // status OK (just no data)
+   g_m4board.response[4] = 0;  // actual_lo = 0
+   g_m4board.response[5] = 0;  // actual_hi = 0
+   g_m4board.response_len = 6;
+}
+
+static void cmd_nethostip()
+{
+   // Protocol: [size, cmd_lo, cmd_hi, hostname\0]
+   // Response: [1=lookup in progress] (then poll via C_NETRECV for result)
+   // We return "lookup in progress" but the result will never arrive — matching
+   // the behavior of a real M4 with no WiFi connection.
+   g_m4board.response[0] = M4_OK;
+   g_m4board.response[1] = 0;
+   g_m4board.response[2] = 0;
+   g_m4board.response[3] = 1; // lookup in progress
+   g_m4board.response_len = 4;
+}
+
+// ── ROM Management ──────────────────────────────
+
+static void cmd_romsupdate()
+{
+   // On real hardware, applies ROM configuration changes from the config buffer.
+   // In emulation, ROM slots are managed by the emulator directly.
+   respond_ok();
+   LOG_DEBUG("M4: C_ROMSUPDATE (no-op in emulation)");
+}
+
+// ── Remaining handlers ──────────────────────────
+
 static void cmd_fstat()
 {
    // Protocol: [size, cmd_lo, cmd_hi, fd]
@@ -1280,7 +1606,9 @@ void m4board_execute()
       case C_CLOSE:      cmd_close(); break;
       case C_READ:       cmd_read(); g_m4board.last_op = M4Board::LastOp::READ; break;
       case C_READ2:      cmd_read2(); g_m4board.last_op = M4Board::LastOp::READ; break;
-      case C_READSECTOR: cmd_readsector(); g_m4board.last_op = M4Board::LastOp::READ; break;
+      case C_READSECTOR:  cmd_readsector(); g_m4board.last_op = M4Board::LastOp::READ; break;
+      case C_WRITESECTOR: cmd_writesector(); g_m4board.last_op = M4Board::LastOp::WRITE; break;
+      case C_FORMATTRACK: cmd_formattrack(); break;
       case C_WRITE:      cmd_write(); g_m4board.last_op = M4Board::LastOp::WRITE; break;
       case C_WRITE2:     cmd_write2(); g_m4board.last_op = M4Board::LastOp::WRITE; break;
       case C_SEEK:       cmd_seek(); break;
@@ -1293,10 +1621,24 @@ void m4board_execute()
       case C_RENAME:     cmd_rename(); break;
       case C_MAKEDIR:    cmd_makedir(); break;
       case C_GETPATH:    cmd_getpath(); break;
-      case C_HTTPGET:    cmd_httpget(); break;
-      case C_DIRSETARGS: cmd_dirsetargs(); g_m4board.last_op = M4Board::LastOp::DIR; break;
-      case C_CONFIG:     cmd_config(); break;
-      case C_ROMWRITE:   cmd_romwrite(); break;
+      case C_HTTPGET:     cmd_httpget(); break;
+      case C_HTTPGETMEM:  cmd_httpgetmem(); break;
+      case C_DIRSETARGS:  cmd_dirsetargs(); g_m4board.last_op = M4Board::LastOp::DIR; break;
+      case C_SDREAD:      cmd_sdread(); g_m4board.last_op = M4Board::LastOp::READ; break;
+      case C_SDWRITE:     cmd_sdwrite(); g_m4board.last_op = M4Board::LastOp::WRITE; break;
+      case C_SETNETWORK:  cmd_setnetwork(); break;
+      case C_M4OFF:       cmd_m4off(); break;
+      case C_NETSTAT:     cmd_netstat(); break;
+      case C_TIME:        cmd_time(); break;
+      case C_NETSOCKET:   cmd_netsocket(); break;
+      case C_NETCONNECT:  cmd_netconnect(); break;
+      case C_NETCLOSE:    cmd_netclose(); break;
+      case C_NETSEND:     cmd_netsend(); break;
+      case C_NETRECV:     cmd_netrecv(); break;
+      case C_NETHOSTIP:   cmd_nethostip(); break;
+      case C_ROMSUPDATE:  cmd_romsupdate(); break;
+      case C_CONFIG:      cmd_config(); break;
+      case C_ROMWRITE:    cmd_romwrite(); break;
       default:
          LOG_DEBUG("M4: unknown command 0x" << std::hex << cmd);
          respond_error();

--- a/src/m4board.cpp
+++ b/src/m4board.cpp
@@ -1012,6 +1012,7 @@ static size_t curl_write_file(void* ptr, size_t size, size_t nmemb, void* userda
 
 static void cmd_httpget()
 {
+   if (!g_m4board.network_enabled) { respond_error("WiFi disabled"); return; }
    // Protocol: [size, cmd_lo, cmd_hi, "url:port/file"]
    // URL format: [@ prefix]host[:port]/path[>outfile]
    std::string raw_url = extract_string(g_m4board.cmd_buf, 3);
@@ -1141,6 +1142,7 @@ static size_t curl_write_mem(void* ptr, size_t size, size_t nmemb, void* userdat
 
 static void cmd_httpgetmem()
 {
+   if (!g_m4board.network_enabled) { respond_error("WiFi disabled"); return; }
    // Protocol: [size, cmd_lo, cmd_hi, size_hi, size_lo, url\0]
    // Downloads to CPC memory instead of SD card
    if (g_m4board.cmd_buf.size() < 6) {
@@ -1477,6 +1479,19 @@ static void cmd_netstat()
    // Status byte: 0=disconnected, 1=connecting, 2=wrong_password,
    //              3=no_ap, 4=connect_fail, 5=connected
    // Report the host computer's actual network state.
+   // If network is disabled (|WIFI,0), report disconnected.
+   if (!g_m4board.network_enabled) {
+      g_m4board.response[0] = M4_OK;
+      g_m4board.response[1] = 0;
+      g_m4board.response[2] = 0;
+      const char* msg = "WiFi disabled\r\n";
+      size_t len = strlen(msg);
+      memcpy(g_m4board.response + 3, msg, len);
+      g_m4board.response[3 + len] = 0;     // null terminator
+      g_m4board.response[3 + len + 1] = 0;  // status: disconnected
+      g_m4board.response_len = static_cast<int>(5 + len);
+      return;
+   }
    std::string ip = get_host_ip();
    std::string ssid = get_host_ssid();
 
@@ -1510,7 +1525,7 @@ static void cmd_time()
    // Response: "hh:mm:ss yyyy-mm-dd" at offset 3
    time_t now = time(nullptr);
    struct tm* t = localtime(&now);
-   char buf[32];
+   char buf[64];
    snprintf(buf, sizeof(buf), "%02d:%02d:%02d %04d-%02d-%02d",
             t->tm_hour, t->tm_min, t->tm_sec,
             t->tm_year + 1900, t->tm_mon + 1, t->tm_mday);
@@ -1565,6 +1580,7 @@ static void m4_close_all_sockets()
 
 static void cmd_netsocket()
 {
+   if (!g_m4board.network_enabled) { respond_error(); return; }
 #ifdef _WIN32
    ensure_winsock_init();
 #endif
@@ -1606,6 +1622,7 @@ static void cmd_netsocket()
 
 static void cmd_netconnect()
 {
+   if (!g_m4board.network_enabled) { respond_error(); return; }
    // Protocol: [size, cmd_lo, cmd_hi, socket, ip0, ip1, ip2, ip3, port_hi, port_lo]
    if (g_m4board.cmd_buf.size() < 10) {
       respond_error();
@@ -1673,6 +1690,7 @@ static void cmd_netclose()
 
 static void cmd_netsend()
 {
+   if (!g_m4board.network_enabled) { respond_error(); return; }
    // Protocol: [size, cmd_lo, cmd_hi, socket, size_lo, size_hi, data...]
    if (g_m4board.cmd_buf.size() < 6) {
       respond_error();
@@ -1708,6 +1726,7 @@ static void cmd_netsend()
 
 static void cmd_netrecv()
 {
+   if (!g_m4board.network_enabled) { respond_error(); return; }
    // Protocol: [size, cmd_lo, cmd_hi, socket, size_lo, size_hi]
    // Response: [0] [actual_lo] [actual_hi] [data...]
    if (g_m4board.cmd_buf.size() < 6) {
@@ -1756,6 +1775,7 @@ static void cmd_netrecv()
 
 static void cmd_nethostip()
 {
+   if (!g_m4board.network_enabled) { respond_error(); return; }
 #ifdef _WIN32
    ensure_winsock_init();
 #endif
@@ -2002,6 +2022,7 @@ void m4board_reset()
    g_m4board.last_op = M4Board::LastOp::NONE;
    g_m4board.last_filename.clear();
    g_m4board.cmd_count = 0;
+   g_m4board.network_enabled = true;  // |WIFI,0 resets on power cycle
    m4_close_all_sockets();
 }
 

--- a/src/m4board.cpp
+++ b/src/m4board.cpp
@@ -1137,7 +1137,8 @@ static size_t curl_write_mem(void* ptr, size_t size, size_t nmemb, void* userdat
       auto* bytes = static_cast<uint8_t*>(ptr);
       buf->data.insert(buf->data.end(), bytes, bytes + to_copy);
    }
-   return total; // pretend we consumed all (to avoid curl error)
+   // Return bytes actually stored; 0 when full stops the transfer.
+   return to_copy;
 }
 
 static void cmd_httpgetmem()
@@ -1187,7 +1188,8 @@ static void cmd_httpgetmem()
    CURLcode res = curl_easy_perform(curl);
    curl_easy_cleanup(curl);
 
-   if (res != CURLE_OK) {
+   // CURLE_WRITE_ERROR is expected when the buffer fills up (truncation).
+   if (res != CURLE_OK && !(res == CURLE_WRITE_ERROR && !membuf.data.empty())) {
       respond_error(curl_easy_strerror(res));
       return;
    }
@@ -1650,20 +1652,33 @@ static void cmd_netconnect()
                     static_cast<uint16_t>(g_m4board.cmd_buf[9]);
    addr.sin_port = htons(port);
 
+   // Set non-blocking before connect to avoid freezing the emulation thread
+   // on unreachable hosts (OS-level TCP timeout can be minutes).
+   sock_set_nonblocking(g_m4board.sockets[slot]);
+
    int result = connect(g_m4board.sockets[slot],
                         reinterpret_cast<struct sockaddr*>(&addr), sizeof(addr));
+
+   bool ok = (result == 0);
+   if (!ok) {
+#ifdef _WIN32
+      int err = WSAGetLastError();
+      ok = (err == WSAEINPROGRESS || err == WSAEWOULDBLOCK);
+#else
+      ok = (errno == EINPROGRESS);
+#endif
+   }
 
    g_m4board.response[0] = M4_OK;
    g_m4board.response[1] = 0;
    g_m4board.response[2] = 0;
-   if (result == 0) {
-      // Connected — set non-blocking for subsequent recv calls
-      sock_set_nonblocking(g_m4board.sockets[slot]);
-      g_m4board.response[3] = 0; // OK
+   if (ok) {
+      g_m4board.response[3] = 0; // OK (connected or in progress)
       LOG_INFO("M4: C_NETCONNECT slot " << slot << " -> "
                << (int)g_m4board.cmd_buf[4] << "." << (int)g_m4board.cmd_buf[5] << "."
                << (int)g_m4board.cmd_buf[6] << "." << (int)g_m4board.cmd_buf[7]
-               << ":" << port);
+               << ":" << port
+               << (result == 0 ? " (connected)" : " (in progress)"));
    } else {
       g_m4board.response[3] = 0xFF; // error
       LOG_ERROR("M4: C_NETCONNECT failed for slot " << slot);

--- a/src/m4board.h
+++ b/src/m4board.h
@@ -51,6 +51,12 @@ struct M4Board {
    };
    std::vector<DirEntry> dir_entries;
    size_t dir_index = 0;
+
+   // Activity tracking for UI display
+   int activity_frames = 0;       // countdown timer for LED (frames at 50fps)
+   enum class LastOp { NONE, READ, WRITE, DIR, CMD } last_op = LastOp::NONE;
+   std::string last_filename;     // last opened file (for display)
+   int cmd_count = 0;             // total commands processed
 };
 
 extern M4Board g_m4board;

--- a/src/m4board.h
+++ b/src/m4board.h
@@ -63,6 +63,20 @@ struct M4Board {
    std::string container_parent_dir; // current_dir before entering the container
    t_drive* container_drive = nullptr; // parsed DSK image (heap-allocated)
 
+   // ── TCP socket bridging (v1.0.9+ protocol) ──
+   // The real M4 firmware exposes raw TCP sockets via the ESP8266.
+   // We bridge these to host sockets so CPC software (IRC clients, etc.)
+   // can make real TCP connections through the emulator.
+   static constexpr int MAX_SOCKETS = 4;
+#ifdef _WIN32
+   using socket_t = uintptr_t; // SOCKET is UINT_PTR on Windows
+   static constexpr socket_t INVALID_SOCK = ~static_cast<socket_t>(0);
+#else
+   using socket_t = int;
+   static constexpr socket_t INVALID_SOCK = -1;
+#endif
+   socket_t sockets[MAX_SOCKETS] = {INVALID_SOCK, INVALID_SOCK, INVALID_SOCK, INVALID_SOCK};
+
    // Activity tracking for UI display
    int activity_frames = 0;       // countdown timer for LED (frames at 50fps)
    enum class LastOp { NONE, READ, WRITE, DIR, CMD } last_op = LastOp::NONE;

--- a/src/m4board.h
+++ b/src/m4board.h
@@ -17,6 +17,8 @@
 #include <vector>
 #include <cstdio>
 
+struct t_drive;
+
 struct M4Board {
    bool enabled = false;
    std::string sd_root_path;       // host directory = virtual SD
@@ -51,6 +53,15 @@ struct M4Board {
    };
    std::vector<DirEntry> dir_entries;
    size_t dir_index = 0;
+
+   // ── Container browsing (cd into DSK/CPR files) ──
+   // The real M4 firmware lets users |cd,"game.dsk" to browse a DSK image
+   // as a virtual directory. Files inside can be listed and loaded.
+   enum class ContainerType { NONE, DSK };
+   ContainerType container_type = ContainerType::NONE;
+   std::string container_host_path;  // host path of the opened container file
+   std::string container_parent_dir; // current_dir before entering the container
+   t_drive* container_drive = nullptr; // parsed DSK image (heap-allocated)
 
    // Activity tracking for UI display
    int activity_frames = 0;       // countdown timer for LED (frames at 50fps)

--- a/src/m4board.h
+++ b/src/m4board.h
@@ -21,6 +21,7 @@ struct t_drive;
 
 struct M4Board {
    bool enabled = false;
+   bool network_enabled = true;    // |WIFI,0 / |WIFI,1 toggle
    std::string sd_root_path;       // host directory = virtual SD
    std::string current_dir = "/";
 

--- a/test/m4board_test.cpp
+++ b/test/m4board_test.cpp
@@ -470,3 +470,256 @@ TEST_F(M4BoardTest, LastFilenameTracking) {
    open_for_read("track.me");
    EXPECT_EQ(g_m4board.last_filename, "track.me");
 }
+
+// ── DSK Container Tests ────────────────────────
+// Helper: create a minimal valid DATA-format DSK with one file.
+// The DSK has 1 track, 1 side, 9 sectors (C1-C9), 512 bytes each.
+// Sectors C1-C2 = directory (block 0), sectors C3-C4 = directory (block 1),
+// sectors C5-C6 = data (block 2) = first 1K of file data.
+static void create_test_dsk(const std::filesystem::path& path,
+                            const std::string& cpc_name, // e.g. "HELLO   .BAS"
+                            const std::vector<uint8_t>& file_data)
+{
+   // Build a "MV - CPCEMU" normal DSK with 1 track, 1 side
+   const int TRACKS = 1, SIDES = 1, SECTORS = 9, SECTOR_SIZE = 512;
+   const int TRACK_DATA_SIZE = SECTORS * SECTOR_SIZE; // 4608
+
+   // DSK header (256 bytes)
+   uint8_t dsk_header[256] = {};
+   memcpy(dsk_header, "MV - CPCEMU Disk-File\r\nDisk-Info\r\n", 34);
+   dsk_header[0x30] = static_cast<uint8_t>(TRACKS);
+   dsk_header[0x31] = static_cast<uint8_t>(SIDES);
+   uint16_t track_total = static_cast<uint16_t>(0x100 + TRACK_DATA_SIZE);
+   dsk_header[0x32] = track_total & 0xFF;
+   dsk_header[0x33] = (track_total >> 8) & 0xFF;
+
+   // Track header (256 bytes)
+   uint8_t track_header[256] = {};
+   memcpy(track_header, "Track-Info\r\n", 12);
+   track_header[0x10] = 0; // track number
+   track_header[0x11] = 0; // side number
+   track_header[0x14] = 2; // sector size code (2 = 512 bytes)
+   track_header[0x15] = static_cast<uint8_t>(SECTORS);
+   track_header[0x16] = 0x4E; // GAP3
+   track_header[0x17] = 0xE5; // filler
+   // Sector info table: 8 bytes per sector
+   for (int s = 0; s < SECTORS; s++) {
+      uint8_t* si = track_header + 0x18 + s * 8;
+      si[0] = 0;    // C (cylinder)
+      si[1] = 0;    // H (head)
+      si[2] = static_cast<uint8_t>(0xC1 + s); // R (sector ID)
+      si[3] = 2;    // N (size code)
+   }
+
+   // Track data (9 sectors * 512 bytes = 4608 bytes)
+   uint8_t track_data[SECTORS * SECTOR_SIZE];
+   memset(track_data, 0xE5, sizeof(track_data)); // fill with empty marker
+
+   // Build CP/M directory entry in sector C1 (first 32 bytes of block 0)
+   // Entry: [user=0, name(8), ext(3), extent_lo, s1, s2, RC, block_alloc(16)]
+   uint8_t* dir_entry = track_data; // sector C1 offset 0
+   dir_entry[0] = 0; // user 0
+   // Copy 8.3 name (must be 11 chars: "HELLO   BAS")
+   if (cpc_name.size() >= 11) {
+      // Remove dot: "HELLO   .BAS" → "HELLO   BAS"
+      for (int i = 0; i < 8; i++) dir_entry[1 + i] = static_cast<uint8_t>(cpc_name[i]);
+      // Skip the dot at position 8
+      int ext_start = (cpc_name[8] == '.') ? 9 : 8;
+      for (int i = 0; i < 3 && ext_start + i < static_cast<int>(cpc_name.size()); i++)
+         dir_entry[9 + i] = static_cast<uint8_t>(cpc_name[ext_start + i]);
+   }
+   // Extent 0
+   dir_entry[12] = 0; // extent low
+   dir_entry[13] = 0; // S1
+   dir_entry[14] = 0; // S2
+   // RC = records used = ceil(file_data.size() / 128)
+   int records = static_cast<int>((file_data.size() + 127) / 128);
+   if (records > 128) records = 128;
+   dir_entry[15] = static_cast<uint8_t>(records);
+   // Block allocation: file data starts at block 2 (blocks 0-1 = directory)
+   int blocks_needed = static_cast<int>((file_data.size() + 1023) / 1024);
+   for (int b = 0; b < blocks_needed && b < 16; b++) {
+      dir_entry[16 + b] = static_cast<uint8_t>(2 + b);
+   }
+
+   // Write file data into block 2 (sectors C5-C6)
+   // Block 2 = sectors 4-5 (0-indexed) = sector IDs C5-C6
+   size_t data_offset = 4 * SECTOR_SIZE; // sector C5 starts here
+   size_t copy_len = std::min(file_data.size(), static_cast<size_t>(SECTOR_SIZE * 2));
+   if (!file_data.empty()) {
+      memcpy(track_data + data_offset, file_data.data(), copy_len);
+   }
+
+   // Write the DSK file
+   std::ofstream f(path, std::ios::binary);
+   f.write(reinterpret_cast<char*>(dsk_header), sizeof(dsk_header));
+   f.write(reinterpret_cast<char*>(track_header), sizeof(track_header));
+   f.write(reinterpret_cast<char*>(track_data), sizeof(track_data));
+}
+
+TEST_F(M4BoardTest, CdIntoDsk) {
+   std::vector<uint8_t> content = {'H', 'E', 'L', 'L', 'O'};
+   create_test_dsk(temp_dir / "game.dsk", "HELLO   .BAS", content);
+
+   // cd into the DSK
+   send_command_str(C_CD, "game.dsk");
+   EXPECT_EQ(g_m4board.response[0], 0x00) << "cd into DSK should succeed";
+   EXPECT_EQ(g_m4board.container_type, M4Board::ContainerType::DSK);
+   EXPECT_NE(g_m4board.container_drive, nullptr);
+   EXPECT_TRUE(g_m4board.current_dir.find("game.dsk") != std::string::npos);
+}
+
+TEST_F(M4BoardTest, CdDotDotExitsContainer) {
+   std::vector<uint8_t> content = {'H', 'I'};
+   create_test_dsk(temp_dir / "test.dsk", "DATA    .BIN", content);
+
+   std::string orig_dir = g_m4board.current_dir;
+   send_command_str(C_CD, "test.dsk");
+   ASSERT_EQ(g_m4board.container_type, M4Board::ContainerType::DSK);
+
+   // cd ".." should exit
+   send_command_str(C_CD, "..");
+   EXPECT_EQ(g_m4board.response[0], 0x00);
+   EXPECT_EQ(g_m4board.container_type, M4Board::ContainerType::NONE);
+   EXPECT_EQ(g_m4board.container_drive, nullptr);
+   EXPECT_EQ(g_m4board.current_dir, orig_dir);
+}
+
+TEST_F(M4BoardTest, CdSlashExitsContainer) {
+   std::vector<uint8_t> content = {'X'};
+   create_test_dsk(temp_dir / "test.dsk", "FILE    .   ", content);
+
+   send_command_str(C_CD, "test.dsk");
+   ASSERT_EQ(g_m4board.container_type, M4Board::ContainerType::DSK);
+
+   // cd "/" should exit container and go to root
+   send_command_str(C_CD, "/");
+   EXPECT_EQ(g_m4board.response[0], 0x00);
+   EXPECT_EQ(g_m4board.container_type, M4Board::ContainerType::NONE);
+   EXPECT_EQ(g_m4board.current_dir, "/");
+}
+
+TEST_F(M4BoardTest, DirInsideDsk) {
+   std::vector<uint8_t> content = {'D', 'A', 'T', 'A'};
+   create_test_dsk(temp_dir / "files.dsk", "HELLO   .BAS", content);
+
+   send_command_str(C_CD, "files.dsk");
+   ASSERT_EQ(g_m4board.container_type, M4Board::ContainerType::DSK);
+
+   // DIRSETARGS + READDIR should list the file
+   send_command(C_DIRSETARGS);
+   // Read first entry (LS mode)
+   std::vector<uint8_t> ls_data = {0x01};
+   send_command(C_READDIR, ls_data);
+   EXPECT_EQ(g_m4board.response[0], 1) << "Should have an entry";
+   std::string name(reinterpret_cast<char*>(g_m4board.response + 3));
+   EXPECT_EQ(name, "HELLO.BAS");
+
+   // Second READDIR should signal end
+   send_command(C_READDIR, ls_data);
+   EXPECT_EQ(g_m4board.response[0], 2) << "Should be end of directory";
+}
+
+TEST_F(M4BoardTest, OpenFileInsideDsk) {
+   std::vector<uint8_t> content = {'C', 'P', 'C', '!', '!'};
+   create_test_dsk(temp_dir / "run.dsk", "GAME    .BIN", content);
+
+   send_command_str(C_CD, "run.dsk");
+   ASSERT_EQ(g_m4board.container_type, M4Board::ContainerType::DSK);
+
+   // Open the file
+   int handle = open_for_read("GAME.BIN");
+   ASSERT_GE(handle, 0) << "Should open file from container";
+
+   // Read the data
+   std::vector<uint8_t> read_cmd = {
+      static_cast<uint8_t>(handle),
+      0x00, 0x06  // count = 0x0600 (1536 bytes, more than our 5)
+   };
+   send_command(C_READ, read_cmd);
+   EXPECT_EQ(g_m4board.response[0], 0x00);
+   // Verify the first 5 bytes match what we wrote
+   EXPECT_EQ(g_m4board.response[4], 'C');
+   EXPECT_EQ(g_m4board.response[5], 'P');
+   EXPECT_EQ(g_m4board.response[6], 'C');
+   EXPECT_EQ(g_m4board.response[7], '!');
+   EXPECT_EQ(g_m4board.response[8], '!');
+}
+
+TEST_F(M4BoardTest, WriteBlockedInContainer) {
+   std::vector<uint8_t> content = {'X'};
+   create_test_dsk(temp_dir / "ro.dsk", "FILE    .BAS", content);
+
+   send_command_str(C_CD, "ro.dsk");
+   ASSERT_EQ(g_m4board.container_type, M4Board::ContainerType::DSK);
+
+   // Attempt to open for write — should fail
+   int handle = open_for_write("NEWFILE.BAS");
+   EXPECT_EQ(handle, -1) << "Write should be denied in container";
+}
+
+TEST_F(M4BoardTest, FsizeInsideDsk) {
+   std::vector<uint8_t> content(256, 0xAA);
+   create_test_dsk(temp_dir / "sz.dsk", "BIG     .DAT", content);
+
+   send_command_str(C_CD, "sz.dsk");
+   ASSERT_EQ(g_m4board.container_type, M4Board::ContainerType::DSK);
+
+   // FSIZE should return the file size
+   send_command_str(C_FSIZE, "BIG.DAT");
+   EXPECT_EQ(g_m4board.response[0], 0x00);
+   uint32_t size = g_m4board.response[3] |
+                   (g_m4board.response[4] << 8) |
+                   (g_m4board.response[5] << 16) |
+                   (g_m4board.response[6] << 24);
+   // CP/M reports size in records * 128 — 256 bytes = 2 records = 256 bytes
+   EXPECT_EQ(size, 256u);
+}
+
+TEST_F(M4BoardTest, CdIntoNonexistentDsk) {
+   send_command_str(C_CD, "ghost.dsk");
+   EXPECT_EQ(g_m4board.response[0], 0xFF) << "Should fail for missing file";
+   EXPECT_EQ(g_m4board.container_type, M4Board::ContainerType::NONE);
+}
+
+TEST_F(M4BoardTest, CdIntoCorruptDsk) {
+   // Create a file with .dsk extension but garbage content
+   create_file("bad.dsk", "This is not a valid DSK file at all");
+   send_command_str(C_CD, "bad.dsk");
+   EXPECT_EQ(g_m4board.response[0], 0xFF) << "Should fail for corrupt DSK";
+   EXPECT_EQ(g_m4board.container_type, M4Board::ContainerType::NONE);
+}
+
+TEST_F(M4BoardTest, ResetExitsContainer) {
+   std::vector<uint8_t> content = {'X'};
+   create_test_dsk(temp_dir / "rst.dsk", "FILE    .BAS", content);
+
+   send_command_str(C_CD, "rst.dsk");
+   ASSERT_EQ(g_m4board.container_type, M4Board::ContainerType::DSK);
+
+   m4board_cleanup();
+   m4board_reset();
+   // Re-set test state
+   g_m4board.enabled = true;
+   g_m4board.sd_root_path = temp_dir.string();
+   EXPECT_EQ(g_m4board.container_type, M4Board::ContainerType::NONE);
+   EXPECT_EQ(g_m4board.container_drive, nullptr);
+}
+
+TEST_F(M4BoardTest, ReadSectorInsideDsk) {
+   // Create DSK with known data in sector C5 (block 2)
+   std::vector<uint8_t> content(512, 0x42); // 512 bytes of 0x42
+   create_test_dsk(temp_dir / "sec.dsk", "SECT    .BIN", content);
+
+   send_command_str(C_CD, "sec.dsk");
+   ASSERT_EQ(g_m4board.container_type, M4Board::ContainerType::DSK);
+
+   // READSECTOR: track=0, sector=C5 (block 2, first sector)
+   std::vector<uint8_t> cmd = {0, 0xC5, 0}; // track, sector, drive
+   send_command(0x430B, cmd); // C_READSECTOR
+   EXPECT_EQ(g_m4board.response[0], 0x00);
+   EXPECT_EQ(g_m4board.response[3], 0x00); // status OK
+   // Sector C5 should contain our 0x42 data
+   EXPECT_EQ(g_m4board.response[4], 0x42);
+   EXPECT_EQ(g_m4board.response[4 + 511], 0x42);
+}

--- a/test/m4board_test.cpp
+++ b/test/m4board_test.cpp
@@ -918,15 +918,19 @@ TEST_F(M4BoardTest, NetSocketExhaustsSlots) {
       send_command(C_NETCLOSE, {static_cast<uint8_t>(i)});
 }
 
-TEST_F(M4BoardTest, NetConnectToClosedPort) {
-   // Create socket
+TEST_F(M4BoardTest, NetConnectNonBlocking) {
+   // Non-blocking connect to localhost:1 returns OK (EINPROGRESS) or error
+   // — either is valid, the key thing is we don't block the thread.
    send_command(C_NETSOCKET, {2, 1, 0});
    uint8_t slot = g_m4board.response[3];
    ASSERT_NE(slot, 0xFF);
 
-   // Connect to 127.0.0.1 port 1 (almost certainly closed/refused)
+   // Connect to 127.0.0.1 port 1 — with non-blocking socket, this
+   // returns 0x00 (EINPROGRESS) or 0xFF (immediate refusal)
    send_command(C_NETCONNECT, {slot, 127, 0, 0, 1, 0, 1});
-   EXPECT_EQ(g_m4board.response[3], 0xFF); // connection refused
+   uint8_t result = g_m4board.response[3];
+   EXPECT_TRUE(result == 0x00 || result == 0xFF)
+      << "Expected OK (in progress) or error, got " << (int)result;
 
    send_command(C_NETCLOSE, {slot});
 }

--- a/test/m4board_test.cpp
+++ b/test/m4board_test.cpp
@@ -1,0 +1,472 @@
+#include <gtest/gtest.h>
+#include <filesystem>
+#include <fstream>
+#include <cstring>
+#include "m4board.h"
+
+// Build a command buffer and execute it.
+// Format: [size_prefix, cmd_lo, cmd_hi, data...]
+static void send_command(uint16_t cmd, const std::vector<uint8_t>& data = {})
+{
+   g_m4board.cmd_buf.clear();
+   g_m4board.cmd_buf.push_back(static_cast<uint8_t>(data.size() + 2)); // size prefix
+   g_m4board.cmd_buf.push_back(cmd & 0xFF);         // cmd low
+   g_m4board.cmd_buf.push_back((cmd >> 8) & 0xFF);  // cmd high
+   g_m4board.cmd_buf.insert(g_m4board.cmd_buf.end(), data.begin(), data.end());
+   m4board_execute();
+}
+
+// Build a command with a string payload.
+static void send_command_str(uint16_t cmd, const std::string& str)
+{
+   std::vector<uint8_t> data(str.begin(), str.end());
+   data.push_back(0); // null terminator
+   send_command(cmd, data);
+}
+
+// Command codes (must match m4board.cpp)
+static constexpr uint16_t C_OPEN       = 0x4301;
+static constexpr uint16_t C_READ       = 0x4302;
+static constexpr uint16_t C_WRITE      = 0x4303;
+static constexpr uint16_t C_CLOSE      = 0x4304;
+static constexpr uint16_t C_SEEK       = 0x4305;
+static constexpr uint16_t C_READDIR    = 0x4306;
+static constexpr uint16_t C_EOF        = 0x4307;
+static constexpr uint16_t C_CD         = 0x4308;
+static constexpr uint16_t C_FTELL      = 0x430A;
+static constexpr uint16_t C_FSIZE      = 0x4311;
+static constexpr uint16_t C_READ2      = 0x4312;
+static constexpr uint16_t C_FSTAT      = 0x4316;
+static constexpr uint16_t C_WRITE2     = 0x431B;
+static constexpr uint16_t C_DIRSETARGS = 0x4325;
+static constexpr uint16_t C_VERSION    = 0x4326;
+static constexpr uint16_t C_CONFIG     = 0x43FE;
+
+class M4BoardTest : public ::testing::Test {
+protected:
+   std::filesystem::path temp_dir;
+
+   void SetUp() override {
+      temp_dir = std::filesystem::temp_directory_path() / "m4board_test";
+      std::filesystem::remove_all(temp_dir);
+      std::filesystem::create_directories(temp_dir);
+
+      m4board_cleanup();
+      m4board_reset();
+      g_m4board.enabled = true;
+      g_m4board.sd_root_path = temp_dir.string();
+   }
+
+   void TearDown() override {
+      // Close all open files before removing temp dir (Windows compat)
+      m4board_cleanup();
+      m4board_reset();
+      g_m4board.enabled = false;
+      g_m4board.sd_root_path.clear();
+      std::filesystem::remove_all(temp_dir);
+   }
+
+   // Helper: create a file in the virtual SD
+   void create_file(const std::string& name, const std::string& content) {
+      std::ofstream f(temp_dir / name, std::ios::binary);
+      f.write(content.data(), content.size());
+   }
+
+   // Helper: create a file in a subdirectory
+   void create_file_in(const std::string& dir, const std::string& name,
+                       const std::string& content) {
+      std::filesystem::create_directories(temp_dir / dir);
+      std::ofstream f(temp_dir / dir / name, std::ios::binary);
+      f.write(content.data(), content.size());
+   }
+
+   // Helper: open a file for reading via M4 protocol
+   int open_for_read(const std::string& filename) {
+      // mode = FA_READ (0x01)
+      std::vector<uint8_t> data = {0x01}; // mode
+      for (char c : filename) data.push_back(static_cast<uint8_t>(c));
+      data.push_back(0); // null terminator
+      send_command(C_OPEN, data);
+      if (g_m4board.response[0] != 0x00) return -1;
+      return g_m4board.response[3]; // handle
+   }
+
+   // Helper: open a file for writing via M4 protocol
+   int open_for_write(const std::string& filename) {
+      // mode = FA_WRITE | FA_CREATE_ALWAYS (0x0A)
+      std::vector<uint8_t> data = {0x0A};
+      for (char c : filename) data.push_back(static_cast<uint8_t>(c));
+      data.push_back(0);
+      send_command(C_OPEN, data);
+      if (g_m4board.response[0] != 0x00) return -1;
+      return g_m4board.response[3];
+   }
+};
+
+// ── Protocol Tests ──────────────────────────────
+
+TEST_F(M4BoardTest, ExecuteEmptyBuffer) {
+   // Buffer too short (< 3 bytes) should be silently rejected
+   g_m4board.cmd_buf.clear();
+   g_m4board.cmd_buf.push_back(0x00);
+   m4board_execute();
+   EXPECT_EQ(g_m4board.response_len, 0);
+}
+
+TEST_F(M4BoardTest, ExecuteUnknownCommand) {
+   send_command(0x4399); // non-existent command
+   EXPECT_EQ(g_m4board.response[0], 0xFF); // M4_ERROR
+}
+
+TEST_F(M4BoardTest, VersionCommand) {
+   send_command(C_VERSION);
+   EXPECT_EQ(g_m4board.response[0], 0x00); // M4_OK
+   EXPECT_TRUE(g_m4board.response_len > 4);
+   // Version string starts at response[3]
+   EXPECT_NE(std::string(reinterpret_cast<char*>(g_m4board.response + 3)).find("konCePCja"),
+             std::string::npos);
+}
+
+TEST_F(M4BoardTest, ActivityTracking) {
+   send_command(C_VERSION);
+   EXPECT_GT(g_m4board.cmd_count, 0);
+   EXPECT_GT(g_m4board.activity_frames, 0);
+}
+
+// ── Path Safety Tests ───────────────────────────
+
+TEST_F(M4BoardTest, PathTraversalBlocked) {
+   // Create a file outside the SD root to verify it's not accessible
+   send_command_str(C_CD, "../");
+   EXPECT_EQ(g_m4board.response[0], 0xFF); // error
+}
+
+TEST_F(M4BoardTest, PathTraversalInFilename) {
+   // Try to open a file with path traversal
+   std::vector<uint8_t> data = {0x01}; // FA_READ
+   std::string evil = "../../etc/passwd";
+   for (char c : evil) data.push_back(static_cast<uint8_t>(c));
+   data.push_back(0);
+   send_command(C_OPEN, data);
+   // Should fail — either path traversal blocked (0xFF) or file not found
+   EXPECT_NE(g_m4board.response[0], 0x00);
+}
+
+TEST_F(M4BoardTest, NormalCdWorks) {
+   std::filesystem::create_directories(temp_dir / "subdir");
+   send_command_str(C_CD, "subdir");
+   EXPECT_EQ(g_m4board.response[0], 0x00); // M4_OK
+   EXPECT_NE(g_m4board.current_dir.find("subdir"), std::string::npos);
+}
+
+TEST_F(M4BoardTest, CdToRoot) {
+   send_command_str(C_CD, "/");
+   EXPECT_EQ(g_m4board.response[0], 0x00);
+   EXPECT_EQ(g_m4board.current_dir, "/");
+}
+
+// ── Response Format Tests ───────────────────────
+
+TEST_F(M4BoardTest, OpenResponseFormat) {
+   create_file("test.bas", "10 PRINT \"HELLO\"\r\n");
+   int handle = open_for_read("test.bas");
+   EXPECT_GE(handle, 0);
+   // Response format: [status, len_lo, len_hi, handle, fr_ok]
+   EXPECT_EQ(g_m4board.response[0], 0x00); // M4_OK
+   EXPECT_EQ(g_m4board.response[4], 0x00); // FR_OK
+   EXPECT_EQ(g_m4board.response_len, 5);
+}
+
+TEST_F(M4BoardTest, OpenFileNotFound) {
+   std::vector<uint8_t> data = {0x01}; // FA_READ
+   std::string name = "nonexistent.xyz";
+   for (char c : name) data.push_back(static_cast<uint8_t>(c));
+   data.push_back(0);
+   send_command(C_OPEN, data);
+   // Should return error with FR_NO_FILE code (4)
+   EXPECT_EQ(g_m4board.response[0], 0xFF); // M4_ERROR
+   EXPECT_EQ(g_m4board.response[4], 4);    // FR_NO_FILE
+}
+
+TEST_F(M4BoardTest, ReadResponseFormat) {
+   create_file("data.bin", "ABCD");
+   int handle = open_for_read("data.bin");
+   ASSERT_GE(handle, 0);
+
+   // Read 4 bytes: [fd, count_lo, count_hi]
+   std::vector<uint8_t> read_data = {
+      static_cast<uint8_t>(handle), 0x04, 0x00
+   };
+   send_command(C_READ, read_data);
+   EXPECT_EQ(g_m4board.response[0], 0x00); // M4_OK
+   EXPECT_EQ(g_m4board.response[3], 0x00); // status OK
+   // Data starts at response[4]
+   EXPECT_EQ(g_m4board.response[4], 'A');
+   EXPECT_EQ(g_m4board.response[5], 'B');
+   EXPECT_EQ(g_m4board.response[6], 'C');
+   EXPECT_EQ(g_m4board.response[7], 'D');
+   EXPECT_EQ(g_m4board.response_len, 8); // 4 header + 4 data
+}
+
+TEST_F(M4BoardTest, Read2ResponseFormat) {
+   create_file("data2.bin", "XY");
+   int handle = open_for_read("data2.bin");
+   ASSERT_GE(handle, 0);
+
+   // Read2: [fd, count_lo, count_hi]
+   std::vector<uint8_t> read_data = {
+      static_cast<uint8_t>(handle), 0x02, 0x00
+   };
+   send_command(C_READ2, read_data);
+   EXPECT_EQ(g_m4board.response[0], 0x00); // M4_OK
+   // response[4-5] = bytes read (16-bit LE)
+   uint16_t nread = g_m4board.response[4] | (g_m4board.response[5] << 8);
+   EXPECT_EQ(nread, 2u);
+   // Data at response[8+]
+   EXPECT_EQ(g_m4board.response[8], 'X');
+   EXPECT_EQ(g_m4board.response[9], 'Y');
+}
+
+TEST_F(M4BoardTest, FsizeResponseFormat) {
+   create_file("sized.bin", "12345678"); // 8 bytes
+   send_command_str(C_FSIZE, "sized.bin");
+   EXPECT_EQ(g_m4board.response[0], 0x00); // M4_OK
+   // Size at response[3-6] as 32-bit LE
+   uint32_t size = g_m4board.response[3] |
+                   (g_m4board.response[4] << 8) |
+                   (g_m4board.response[5] << 16) |
+                   (g_m4board.response[6] << 24);
+   EXPECT_EQ(size, 8u);
+   EXPECT_EQ(g_m4board.response_len, 7);
+}
+
+TEST_F(M4BoardTest, ErrorResponseCode) {
+   // Open non-existent file — should get FR_NO_FILE error code
+   std::vector<uint8_t> data = {0x01}; // FA_READ
+   std::string name = "ghost.fil";
+   for (char c : name) data.push_back(static_cast<uint8_t>(c));
+   data.push_back(0);
+   send_command(C_OPEN, data);
+   EXPECT_EQ(g_m4board.response[0], 0xFF); // M4_ERROR
+   EXPECT_EQ(g_m4board.response[3], 0xFF); // error marker
+   EXPECT_EQ(g_m4board.response[4], 4);    // FR_NO_FILE
+}
+
+// ── C_FSTAT Tests ───────────────────────────────
+
+TEST_F(M4BoardTest, FstatOnOpenFile) {
+   create_file("stat.bin", "hello");
+   int handle = open_for_read("stat.bin");
+   ASSERT_GE(handle, 0);
+
+   std::vector<uint8_t> data = {static_cast<uint8_t>(handle)};
+   send_command(C_FSTAT, data);
+   EXPECT_EQ(g_m4board.response[0], 0x00); // M4_OK
+   EXPECT_EQ(g_m4board.response[3], 0x00); // attributes: normal file
+}
+
+TEST_F(M4BoardTest, FstatBadHandle) {
+   std::vector<uint8_t> data = {3}; // handle 3 — not open
+   send_command(C_FSTAT, data);
+   EXPECT_EQ(g_m4board.response[0], 0xFF); // M4_ERROR
+}
+
+// ── C_WRITE2 Tests ──────────────────────────────
+
+TEST_F(M4BoardTest, Write2SameAsWrite) {
+   int handle = open_for_write("w2test.bin");
+   ASSERT_GE(handle, 0);
+
+   // Write via C_WRITE2: [fd, data...]
+   std::vector<uint8_t> data = {static_cast<uint8_t>(handle), 'A', 'B', 'C'};
+   send_command(C_WRITE2, data);
+   EXPECT_EQ(g_m4board.response[0], 0x00); // M4_OK
+
+   // Close and verify
+   std::vector<uint8_t> close_data = {static_cast<uint8_t>(handle)};
+   send_command(C_CLOSE, close_data);
+
+   std::ifstream f(temp_dir / "w2test.bin", std::ios::binary);
+   std::string content((std::istreambuf_iterator<char>(f)),
+                        std::istreambuf_iterator<char>());
+   EXPECT_EQ(content, "ABC");
+}
+
+// ── File I/O Tests ──────────────────────────────
+
+TEST_F(M4BoardTest, OpenReadCloseRoundTrip) {
+   std::string test_data = "Hello from CPC!";
+   create_file("hello.txt", test_data);
+
+   int handle = open_for_read("hello.txt");
+   ASSERT_GE(handle, 0);
+
+   // Read all bytes
+   std::vector<uint8_t> read_cmd = {
+      static_cast<uint8_t>(handle),
+      static_cast<uint8_t>(test_data.size()), 0x00
+   };
+   send_command(C_READ, read_cmd);
+   EXPECT_EQ(g_m4board.response[0], 0x00);
+   std::string got(reinterpret_cast<char*>(g_m4board.response + 4), test_data.size());
+   EXPECT_EQ(got, test_data);
+
+   // Close
+   std::vector<uint8_t> close_data = {static_cast<uint8_t>(handle)};
+   send_command(C_CLOSE, close_data);
+   EXPECT_EQ(g_m4board.response[0], 0x00);
+}
+
+TEST_F(M4BoardTest, SaveLoadRoundTrip) {
+   std::string content = "10 PRINT \"SAVED\"\r\n20 GOTO 10\r\n";
+
+   // Save: open for write
+   int wh = open_for_write("saved.bas");
+   ASSERT_GE(wh, 0);
+
+   // Write content
+   std::vector<uint8_t> write_data = {static_cast<uint8_t>(wh)};
+   for (char c : content) write_data.push_back(static_cast<uint8_t>(c));
+   send_command(C_WRITE, write_data);
+   EXPECT_EQ(g_m4board.response[0], 0x00);
+
+   // Close write handle
+   std::vector<uint8_t> close_w = {static_cast<uint8_t>(wh)};
+   send_command(C_CLOSE, close_w);
+
+   // Load: open for read
+   int rh = open_for_read("saved.bas");
+   ASSERT_GE(rh, 0);
+
+   // Read back
+   std::vector<uint8_t> read_data = {
+      static_cast<uint8_t>(rh),
+      static_cast<uint8_t>(content.size()), 0x00
+   };
+   send_command(C_READ, read_data);
+   EXPECT_EQ(g_m4board.response[0], 0x00);
+   std::string got(reinterpret_cast<char*>(g_m4board.response + 4), content.size());
+   EXPECT_EQ(got, content);
+
+   std::vector<uint8_t> close_r = {static_cast<uint8_t>(rh)};
+   send_command(C_CLOSE, close_r);
+}
+
+TEST_F(M4BoardTest, CaseInsensitiveOpen) {
+   create_file("game.bas", "10 REM GAME");
+   // CPC sends uppercase filenames
+   int handle = open_for_read("GAME.BAS");
+   EXPECT_GE(handle, 0);
+   if (handle >= 0) {
+      std::vector<uint8_t> close_data = {static_cast<uint8_t>(handle)};
+      send_command(C_CLOSE, close_data);
+   }
+}
+
+TEST_F(M4BoardTest, ExtensionProbing) {
+   create_file("test.bas", "10 REM TEST");
+   // CPC RUN"TEST tries without extension first, then .BAS, .BIN, etc.
+   int handle = open_for_read("TEST");
+   EXPECT_GE(handle, 0);
+   if (handle >= 0) {
+      std::vector<uint8_t> close_data = {static_cast<uint8_t>(handle)};
+      send_command(C_CLOSE, close_data);
+   }
+}
+
+TEST_F(M4BoardTest, EofDetection) {
+   create_file("eof.bin", "AB");
+   int handle = open_for_read("eof.bin");
+   ASSERT_GE(handle, 0);
+
+   // Read the full file
+   std::vector<uint8_t> read_all = {
+      static_cast<uint8_t>(handle), 0x02, 0x00
+   };
+   send_command(C_READ, read_all);
+
+   // Check EOF
+   std::vector<uint8_t> eof_data = {static_cast<uint8_t>(handle)};
+   send_command(C_EOF, eof_data);
+   EXPECT_EQ(g_m4board.response[0], 0x00);
+   // After reading exactly 2 bytes of a 2-byte file, EOF may or may not be set
+   // Read one more byte to guarantee EOF
+   std::vector<uint8_t> read_more = {
+      static_cast<uint8_t>(handle), 0x01, 0x00
+   };
+   send_command(C_READ, read_more);
+   // Now check EOF — should be set
+   send_command(C_EOF, eof_data);
+   EXPECT_EQ(g_m4board.response[0], 0x00);
+   EXPECT_EQ(g_m4board.response[3], 1); // EOF
+
+   std::vector<uint8_t> close_data = {static_cast<uint8_t>(handle)};
+   send_command(C_CLOSE, close_data);
+}
+
+TEST_F(M4BoardTest, FtellAfterSeek) {
+   create_file("seek.bin", "0123456789");
+   int handle = open_for_read("seek.bin");
+   ASSERT_GE(handle, 0);
+
+   // Seek to offset 5
+   std::vector<uint8_t> seek_data = {
+      static_cast<uint8_t>(handle), 0x05, 0x00, 0x00, 0x00
+   };
+   send_command(C_SEEK, seek_data);
+   EXPECT_EQ(g_m4board.response[0], 0x00);
+
+   // Ftell should return 5
+   std::vector<uint8_t> ftell_data = {static_cast<uint8_t>(handle)};
+   send_command(C_FTELL, ftell_data);
+   EXPECT_EQ(g_m4board.response[0], 0x00);
+   uint32_t pos = g_m4board.response[3] |
+                  (g_m4board.response[4] << 8) |
+                  (g_m4board.response[5] << 16) |
+                  (g_m4board.response[6] << 24);
+   EXPECT_EQ(pos, 5u);
+
+   std::vector<uint8_t> close_data = {static_cast<uint8_t>(handle)};
+   send_command(C_CLOSE, close_data);
+}
+
+// ── Directory Listing Tests ─────────────────────
+
+TEST_F(M4BoardTest, ReadDir) {
+   create_file("one.bas", "data");
+   create_file("two.dsk", "data");
+
+   // Start listing
+   send_command(C_DIRSETARGS);
+   EXPECT_EQ(g_m4board.response[0], 0x00);
+
+   // Read entries
+   int count = 0;
+   for (int i = 0; i < 10; i++) {
+      send_command(C_READDIR);
+      if (g_m4board.response[0] == 2) break; // end of directory
+      EXPECT_EQ(g_m4board.response[0], 1); // entry present
+      count++;
+   }
+   EXPECT_EQ(count, 2);
+}
+
+TEST_F(M4BoardTest, ReadDirLsMode) {
+   create_file("hello.txt", "world");
+
+   send_command(C_DIRSETARGS);
+
+   // LS mode: extra byte in cmd_buf after the command
+   std::vector<uint8_t> ls_data = {0x01}; // extra byte = LS mode
+   send_command(C_READDIR, ls_data);
+   EXPECT_EQ(g_m4board.response[0], 1);
+   // LS format: response[3+] = null-terminated filename
+   std::string name(reinterpret_cast<char*>(g_m4board.response + 3));
+   EXPECT_EQ(name, "hello.txt");
+}
+
+TEST_F(M4BoardTest, LastFilenameTracking) {
+   create_file("track.me", "data");
+   open_for_read("track.me");
+   EXPECT_EQ(g_m4board.last_filename, "track.me");
+}

--- a/test/m4board_test.cpp
+++ b/test/m4board_test.cpp
@@ -857,6 +857,38 @@ TEST_F(M4BoardTest, M4OffDisablesBoard) {
    g_m4board.enabled = true;
 }
 
+TEST_F(M4BoardTest, WifiDisableBlocksNetstat) {
+   g_m4board.network_enabled = false;
+   send_command(C_NETSTAT, {});
+   EXPECT_EQ(g_m4board.response[0], 0x00);
+   // Should report "WiFi disabled" and status byte 0 (disconnected)
+   const char* msg = reinterpret_cast<const char*>(g_m4board.response + 3);
+   EXPECT_NE(std::string(msg).find("disabled"), std::string::npos);
+   // Find null terminator and check status byte after it
+   size_t len = strlen(msg);
+   EXPECT_EQ(g_m4board.response[3 + len], 0);       // null terminator
+   EXPECT_EQ(g_m4board.response[3 + len + 1], 0);    // status: disconnected
+   g_m4board.network_enabled = true;
+}
+
+TEST_F(M4BoardTest, WifiDisableBlocksSocket) {
+   g_m4board.network_enabled = false;
+   send_command(C_NETSOCKET, {2, 1, 0});
+   EXPECT_EQ(g_m4board.response[0], 0xFF); // error
+   g_m4board.network_enabled = true;
+}
+
+TEST_F(M4BoardTest, WifiReenableRestoresNetwork) {
+   g_m4board.network_enabled = false;
+   send_command(C_NETSOCKET, {2, 1, 0});
+   EXPECT_EQ(g_m4board.response[0], 0xFF); // error while disabled
+   g_m4board.network_enabled = true;
+   send_command(C_NETSOCKET, {2, 1, 0});
+   EXPECT_EQ(g_m4board.response[0], 0x00); // OK when re-enabled
+   uint8_t slot = g_m4board.response[3];
+   if (slot != 0xFF) send_command(C_NETCLOSE, {slot});
+}
+
 TEST_F(M4BoardTest, NetSocketCreatesRealSocket) {
    // domain=2 (AF_INET), type=1 (SOCK_STREAM), protocol=0
    send_command(C_NETSOCKET, {2, 1, 0});

--- a/test/m4board_test.cpp
+++ b/test/m4board_test.cpp
@@ -825,6 +825,8 @@ TEST_F(M4BoardTest, NetstatReportsHostNetwork) {
    EXPECT_EQ(g_m4board.response[i], 0); // null terminator
 
    // Status byte is after the null
+   ASSERT_LT(i + 1, static_cast<size_t>(M4Board::RESPONSE_SIZE))
+      << "Status byte must be within response buffer";
    uint8_t status = g_m4board.response[i + 1];
    EXPECT_TRUE(status == 0 || status == 5)
       << "Expected status 0 (disconnected) or 5 (connected), got " << (int)status;

--- a/test/m4board_test.cpp
+++ b/test/m4board_test.cpp
@@ -40,7 +40,23 @@ static constexpr uint16_t C_FSTAT      = 0x4316;
 static constexpr uint16_t C_WRITE2     = 0x431B;
 static constexpr uint16_t C_DIRSETARGS = 0x4325;
 static constexpr uint16_t C_VERSION    = 0x4326;
-static constexpr uint16_t C_CONFIG     = 0x43FE;
+static constexpr uint16_t C_WRITESECTOR = 0x430C;
+static constexpr uint16_t C_FORMATTRACK = 0x430D;
+static constexpr uint16_t C_SDREAD      = 0x4314;
+static constexpr uint16_t C_SDWRITE     = 0x4315;
+static constexpr uint16_t C_SETNETWORK  = 0x4321;
+static constexpr uint16_t C_M4OFF       = 0x4322;
+static constexpr uint16_t C_NETSTAT     = 0x4323;
+static constexpr uint16_t C_TIME        = 0x4324;
+static constexpr uint16_t C_HTTPGETMEM  = 0x4328;
+static constexpr uint16_t C_ROMSUPDATE  = 0x432B;
+static constexpr uint16_t C_NETSOCKET   = 0x4331;
+static constexpr uint16_t C_NETCONNECT  = 0x4332;
+static constexpr uint16_t C_NETCLOSE    = 0x4333;
+static constexpr uint16_t C_NETSEND     = 0x4334;
+static constexpr uint16_t C_NETRECV     = 0x4335;
+static constexpr uint16_t C_NETHOSTIP   = 0x4336;
+static constexpr uint16_t C_CONFIG      = 0x43FE;
 
 class M4BoardTest : public ::testing::Test {
 protected:
@@ -722,4 +738,160 @@ TEST_F(M4BoardTest, ReadSectorInsideDsk) {
    // Sector C5 should contain our 0x42 data
    EXPECT_EQ(g_m4board.response[4], 0x42);
    EXPECT_EQ(g_m4board.response[4 + 511], 0x42);
+}
+
+// ── Tests for newly implemented commands ──────────
+
+TEST_F(M4BoardTest, WriteSectorToOpenFile) {
+   // Create a small "disk image" file
+   std::string path = (temp_dir / "disk.img").string();
+   FILE* f = fopen(path.c_str(), "wb");
+   std::vector<uint8_t> blank(9 * 512, 0xE5); // 1 track, 9 sectors
+   fwrite(blank.data(), 1, blank.size(), f);
+   fclose(f);
+
+   // Open for writing (handle 2)
+   std::vector<uint8_t> open_data = {0x0A}; // FA_WRITE | FA_CREATE_ALWAYS
+   std::string fname = "disk.img";
+   open_data.insert(open_data.end(), fname.begin(), fname.end());
+   open_data.push_back(0);
+   send_command(C_OPEN, open_data);
+   ASSERT_EQ(g_m4board.response[4], 0x00); // FR_OK (response[3] = fd)
+
+   // Write sector: track=0, sector=0xC1, drive=0, 512 bytes of 0xAA
+   std::vector<uint8_t> ws_data = {0, 0xC1, 0};
+   ws_data.insert(ws_data.end(), 512, 0xAA);
+   send_command(C_WRITESECTOR, ws_data);
+   EXPECT_EQ(g_m4board.response[3], 0x00); // OK
+
+   // Read back via READSECTOR to verify
+   // First close and reopen for reading
+   send_command(C_CLOSE, {2});
+   std::vector<uint8_t> open_read = {0x01}; // FA_READ
+   open_read.insert(open_read.end(), fname.begin(), fname.end());
+   open_read.push_back(0);
+   send_command(C_OPEN, open_read);
+
+   std::vector<uint8_t> rs_data = {0, 0xC1, 0}; // track, sector, drive
+   send_command(0x430B, rs_data); // C_READSECTOR
+   EXPECT_EQ(g_m4board.response[3], 0x00);
+   EXPECT_EQ(g_m4board.response[4], 0xAA);
+}
+
+TEST_F(M4BoardTest, WriteSectorBlockedInContainer) {
+   create_test_dsk(temp_dir / "ws.dsk", "FILE    .BIN", {0x01});
+   send_command_str(C_CD, "ws.dsk");
+   ASSERT_EQ(g_m4board.container_type, M4Board::ContainerType::DSK);
+
+   std::vector<uint8_t> ws_data = {0, 0xC1, 0};
+   ws_data.insert(ws_data.end(), 512, 0x00);
+   send_command(C_WRITESECTOR, ws_data);
+   EXPECT_EQ(g_m4board.response[0], 0xFF); // error
+}
+
+TEST_F(M4BoardTest, FormatTrackReturnsError) {
+   send_command(C_FORMATTRACK, {});
+   EXPECT_EQ(g_m4board.response[0], 0xFF); // not supported
+}
+
+TEST_F(M4BoardTest, SdReadReturnsError) {
+   // Protocol: lba0-3, num_sectors
+   send_command(C_SDREAD, {0, 0, 0, 0, 1});
+   EXPECT_EQ(g_m4board.response[3], 1); // error flag
+}
+
+TEST_F(M4BoardTest, SdWriteReturnsError) {
+   send_command(C_SDWRITE, {0, 0, 0, 0, 1});
+   EXPECT_EQ(g_m4board.response[3], 1); // error flag
+}
+
+TEST_F(M4BoardTest, SetNetworkAcknowledges) {
+   send_command_str(C_SETNETWORK, "ssid:password");
+   EXPECT_EQ(g_m4board.response[0], 0x00); // OK
+}
+
+TEST_F(M4BoardTest, NetstatReturnsDisconnected) {
+   send_command(C_NETSTAT, {});
+   EXPECT_EQ(g_m4board.response[0], 0x00); // OK
+   // Status string should be present at offset 3
+   EXPECT_NE(g_m4board.response[3], 0); // non-empty string
+   // Find the null terminator after the string, then check status byte = 0
+   size_t i = 3;
+   while (i < M4Board::RESPONSE_SIZE && g_m4board.response[i] != 0) i++;
+   EXPECT_EQ(g_m4board.response[i], 0); // status byte = disconnected
+}
+
+TEST_F(M4BoardTest, TimeReturnsFormattedString) {
+   send_command(C_TIME, {});
+   EXPECT_EQ(g_m4board.response[0], 0x00); // OK
+   // Should contain ":" (time) and "-" (date)
+   std::string time_str(reinterpret_cast<char*>(g_m4board.response + 3));
+   EXPECT_NE(time_str.find(':'), std::string::npos);
+   EXPECT_NE(time_str.find('-'), std::string::npos);
+   // Format: "hh:mm:ss yyyy-mm-dd" = 19 chars
+   EXPECT_GE(time_str.size(), 19u);
+}
+
+TEST_F(M4BoardTest, M4OffDisablesBoard) {
+   ASSERT_TRUE(g_m4board.enabled);
+   send_command(C_M4OFF, {});
+   EXPECT_EQ(g_m4board.response[0], 0x00); // OK
+   EXPECT_FALSE(g_m4board.enabled);
+   // Re-enable for TearDown
+   g_m4board.enabled = true;
+}
+
+TEST_F(M4BoardTest, NetSocketReturnsError) {
+   // domain=2 (AF_INET), type=1 (SOCK_STREAM), protocol=0
+   send_command(C_NETSOCKET, {2, 1, 0});
+   EXPECT_EQ(g_m4board.response[3], 0xFF); // no socket
+}
+
+TEST_F(M4BoardTest, NetConnectReturnsError) {
+   // socket=0, ip=127.0.0.1, port=80
+   send_command(C_NETCONNECT, {0, 127, 0, 0, 1, 0, 80});
+   EXPECT_EQ(g_m4board.response[3], 0xFF); // connection failed
+}
+
+TEST_F(M4BoardTest, NetCloseOk) {
+   send_command(C_NETCLOSE, {0});
+   EXPECT_EQ(g_m4board.response[0], 0x00); // OK
+}
+
+TEST_F(M4BoardTest, NetSendReturnsError) {
+   send_command(C_NETSEND, {0, 5, 0, 'H', 'e', 'l', 'l', 'o'});
+   EXPECT_EQ(g_m4board.response[3], 0xFF); // not connected
+}
+
+TEST_F(M4BoardTest, NetRecvReturnsEmpty) {
+   send_command(C_NETRECV, {0, 0xFF, 0x00}); // socket, size
+   EXPECT_EQ(g_m4board.response[3], 0); // status OK
+   EXPECT_EQ(g_m4board.response[4], 0); // actual_lo = 0
+   EXPECT_EQ(g_m4board.response[5], 0); // actual_hi = 0
+}
+
+TEST_F(M4BoardTest, NetHostIpReturnsLookupInProgress) {
+   send_command_str(C_NETHOSTIP, "example.com");
+   EXPECT_EQ(g_m4board.response[3], 1); // lookup in progress
+}
+
+TEST_F(M4BoardTest, RomsUpdateOk) {
+   send_command(C_ROMSUPDATE, {});
+   EXPECT_EQ(g_m4board.response[0], 0x00); // OK
+}
+
+TEST_F(M4BoardTest, ActivityTracksNewCommands) {
+   g_m4board.activity_frames = 0;
+   send_command(C_TIME, {});
+   EXPECT_GT(g_m4board.activity_frames, 0);
+   EXPECT_EQ(g_m4board.last_op, M4Board::LastOp::CMD);
+
+   send_command(C_SDREAD, {0, 0, 0, 0, 1});
+   EXPECT_EQ(g_m4board.last_op, M4Board::LastOp::READ);
+
+   std::vector<uint8_t> ws_data = {0, 0xC1, 0};
+   ws_data.insert(ws_data.end(), 512, 0x00);
+   // Need a file open for write handle — just test SDWRITE tracking
+   send_command(C_SDWRITE, {0, 0, 0, 0, 1});
+   EXPECT_EQ(g_m4board.last_op, M4Board::LastOp::WRITE);
 }

--- a/test/m4board_test.cpp
+++ b/test/m4board_test.cpp
@@ -813,16 +813,26 @@ TEST_F(M4BoardTest, SetNetworkAcknowledges) {
 TEST_F(M4BoardTest, NetstatReportsHostNetwork) {
    send_command(C_NETSTAT, {});
    EXPECT_EQ(g_m4board.response[0], 0x00); // OK
-   // Status string should be present at offset 3
-   EXPECT_NE(g_m4board.response[3], 0); // non-empty string
-   // Find the end of the status string, then check the status byte
+
+   // Response layout: [3: string...] [3+len: \0] [3+len+1: status_byte]
+   // Find the null terminator
    size_t i = 3;
-   while (i < static_cast<size_t>(g_m4board.response_len - 1) && g_m4board.response[i] != '\0'
-          && g_m4board.response[i] != 0 && g_m4board.response[i] != 5) i++;
-   // Status byte should be either 0 (disconnected) or 5 (connected)
-   uint8_t status = g_m4board.response[i];
+   while (i < static_cast<size_t>(g_m4board.response_len) && g_m4board.response[i] != 0) i++;
+   ASSERT_LT(i, static_cast<size_t>(g_m4board.response_len))
+      << "Response string should be null-terminated";
+   EXPECT_EQ(g_m4board.response[i], 0); // null terminator
+
+   // Status byte is after the null
+   uint8_t status = g_m4board.response[i + 1];
    EXPECT_TRUE(status == 0 || status == 5)
       << "Expected status 0 (disconnected) or 5 (connected), got " << (int)status;
+
+   // If connected, the string should contain "IP:"
+   if (status == 5) {
+      std::string msg(reinterpret_cast<char*>(g_m4board.response + 3));
+      EXPECT_NE(msg.find("IP:"), std::string::npos)
+         << "Connected status should include IP address, got: " << msg;
+   }
 }
 
 TEST_F(M4BoardTest, TimeReturnsFormattedString) {

--- a/test/m4board_test.cpp
+++ b/test/m4board_test.cpp
@@ -845,33 +845,78 @@ TEST_F(M4BoardTest, M4OffDisablesBoard) {
    g_m4board.enabled = true;
 }
 
-TEST_F(M4BoardTest, NetSocketReturnsError) {
+TEST_F(M4BoardTest, NetSocketCreatesRealSocket) {
    // domain=2 (AF_INET), type=1 (SOCK_STREAM), protocol=0
    send_command(C_NETSOCKET, {2, 1, 0});
-   EXPECT_EQ(g_m4board.response[3], 0xFF); // no socket
-}
-
-TEST_F(M4BoardTest, NetConnectReturnsError) {
-   // socket=0, ip=127.0.0.1, port=80
-   send_command(C_NETCONNECT, {0, 127, 0, 0, 1, 0, 80});
-   EXPECT_EQ(g_m4board.response[3], 0xFF); // connection failed
-}
-
-TEST_F(M4BoardTest, NetCloseOk) {
-   send_command(C_NETCLOSE, {0});
    EXPECT_EQ(g_m4board.response[0], 0x00); // OK
+   uint8_t slot = g_m4board.response[3];
+   EXPECT_NE(slot, 0xFF) << "Should create a real socket";
+   EXPECT_LT(slot, M4Board::MAX_SOCKETS);
+   EXPECT_NE(g_m4board.sockets[slot], M4Board::INVALID_SOCK);
+
+   // Clean up
+   send_command(C_NETCLOSE, {slot});
+   EXPECT_EQ(g_m4board.sockets[slot], M4Board::INVALID_SOCK);
 }
 
-TEST_F(M4BoardTest, NetSendReturnsError) {
-   send_command(C_NETSEND, {0, 5, 0, 'H', 'e', 'l', 'l', 'o'});
-   EXPECT_EQ(g_m4board.response[3], 0xFF); // not connected
+TEST_F(M4BoardTest, NetSocketExhaustsSlots) {
+   // Fill all 4 slots
+   for (int i = 0; i < M4Board::MAX_SOCKETS; i++) {
+      send_command(C_NETSOCKET, {2, 1, 0});
+      EXPECT_NE(g_m4board.response[3], 0xFF);
+   }
+   // 5th should fail
+   send_command(C_NETSOCKET, {2, 1, 0});
+   EXPECT_EQ(g_m4board.response[3], 0xFF);
+
+   // Clean up all
+   for (int i = 0; i < M4Board::MAX_SOCKETS; i++)
+      send_command(C_NETCLOSE, {static_cast<uint8_t>(i)});
 }
 
-TEST_F(M4BoardTest, NetRecvReturnsEmpty) {
-   send_command(C_NETRECV, {0, 0xFF, 0x00}); // socket, size
-   EXPECT_EQ(g_m4board.response[3], 0); // status OK
+TEST_F(M4BoardTest, NetConnectToClosedPort) {
+   // Create socket
+   send_command(C_NETSOCKET, {2, 1, 0});
+   uint8_t slot = g_m4board.response[3];
+   ASSERT_NE(slot, 0xFF);
+
+   // Connect to 127.0.0.1 port 1 (almost certainly closed/refused)
+   send_command(C_NETCONNECT, {slot, 127, 0, 0, 1, 0, 1});
+   EXPECT_EQ(g_m4board.response[3], 0xFF); // connection refused
+
+   send_command(C_NETCLOSE, {slot});
+}
+
+TEST_F(M4BoardTest, NetCloseInvalidSlot) {
+   // Closing a non-existent slot should not crash
+   send_command(C_NETCLOSE, {99});
+   EXPECT_EQ(g_m4board.response[0], 0x00); // OK (no-op)
+}
+
+TEST_F(M4BoardTest, NetSendWithoutConnect) {
+   send_command(C_NETSOCKET, {2, 1, 0});
+   uint8_t slot = g_m4board.response[3];
+   ASSERT_NE(slot, 0xFF);
+
+   // Send on unconnected socket — should fail
+   send_command(C_NETSEND, {slot, 5, 0, 'H', 'e', 'l', 'l', 'o'});
+   EXPECT_EQ(g_m4board.response[3], 0xFF); // error
+
+   send_command(C_NETCLOSE, {slot});
+}
+
+TEST_F(M4BoardTest, NetRecvNoData) {
+   send_command(C_NETSOCKET, {2, 1, 0});
+   uint8_t slot = g_m4board.response[3];
+   ASSERT_NE(slot, 0xFF);
+
+   // Recv on unconnected socket — returns 0 bytes (non-blocking)
+   send_command(C_NETRECV, {slot, 0xFF, 0x00});
+   // Either error or 0 bytes is acceptable for unconnected socket
    EXPECT_EQ(g_m4board.response[4], 0); // actual_lo = 0
    EXPECT_EQ(g_m4board.response[5], 0); // actual_hi = 0
+
+   send_command(C_NETCLOSE, {slot});
 }
 
 TEST_F(M4BoardTest, NetHostIpResolvesHostname) {

--- a/test/m4board_test.cpp
+++ b/test/m4board_test.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include <algorithm>
 #include <filesystem>
 #include <fstream>
 #include <cstring>
@@ -746,6 +747,7 @@ TEST_F(M4BoardTest, WriteSectorToOpenFile) {
    // Create a small "disk image" file
    std::string path = (temp_dir / "disk.img").string();
    FILE* f = fopen(path.c_str(), "wb");
+   ASSERT_NE(f, nullptr);
    std::vector<uint8_t> blank(9 * 512, 0xE5); // 1 track, 9 sectors
    fwrite(blank.data(), 1, blank.size(), f);
    fclose(f);

--- a/test/m4board_test.cpp
+++ b/test/m4board_test.cpp
@@ -810,15 +810,19 @@ TEST_F(M4BoardTest, SetNetworkAcknowledges) {
    EXPECT_EQ(g_m4board.response[0], 0x00); // OK
 }
 
-TEST_F(M4BoardTest, NetstatReturnsDisconnected) {
+TEST_F(M4BoardTest, NetstatReportsHostNetwork) {
    send_command(C_NETSTAT, {});
    EXPECT_EQ(g_m4board.response[0], 0x00); // OK
    // Status string should be present at offset 3
    EXPECT_NE(g_m4board.response[3], 0); // non-empty string
-   // Find the null terminator after the string, then check status byte = 0
+   // Find the end of the status string, then check the status byte
    size_t i = 3;
-   while (i < M4Board::RESPONSE_SIZE && g_m4board.response[i] != 0) i++;
-   EXPECT_EQ(g_m4board.response[i], 0); // status byte = disconnected
+   while (i < static_cast<size_t>(g_m4board.response_len - 1) && g_m4board.response[i] != '\0'
+          && g_m4board.response[i] != 0 && g_m4board.response[i] != 5) i++;
+   // Status byte should be either 0 (disconnected) or 5 (connected)
+   uint8_t status = g_m4board.response[i];
+   EXPECT_TRUE(status == 0 || status == 5)
+      << "Expected status 0 (disconnected) or 5 (connected), got " << (int)status;
 }
 
 TEST_F(M4BoardTest, TimeReturnsFormattedString) {
@@ -870,9 +874,19 @@ TEST_F(M4BoardTest, NetRecvReturnsEmpty) {
    EXPECT_EQ(g_m4board.response[5], 0); // actual_hi = 0
 }
 
-TEST_F(M4BoardTest, NetHostIpReturnsLookupInProgress) {
-   send_command_str(C_NETHOSTIP, "example.com");
-   EXPECT_EQ(g_m4board.response[3], 1); // lookup in progress
+TEST_F(M4BoardTest, NetHostIpResolvesHostname) {
+   // "localhost" should always resolve to 127.0.0.1
+   send_command_str(C_NETHOSTIP, "localhost");
+   // response[3]=0 means resolved, response[3]=1 means lookup in progress (failed)
+   if (g_m4board.response[3] == 0) {
+      // Resolved: check IP bytes at [4..7]
+      EXPECT_EQ(g_m4board.response[4], 127);
+      EXPECT_EQ(g_m4board.response[5], 0);
+      EXPECT_EQ(g_m4board.response[6], 0);
+      EXPECT_EQ(g_m4board.response[7], 1);
+      EXPECT_EQ(g_m4board.response_len, 8);
+   }
+   // If DNS is unavailable, response[3]=1 is also acceptable
 }
 
 TEST_F(M4BoardTest, RomsUpdateOk) {


### PR DESCRIPTION
## Summary
- **Complete M4 protocol coverage** — all 39 command codes handled (was 21)
- **Host network bridging** — `|NETSTAT` shows the host computer's real IP address and WiFi SSID; `|NETHOSTIP` resolves hostnames via the host's DNS; `|HTTPGET`/`|HTTPMEM` download via the host's internet connection
- **DSK container browsing** — `|cd,"game.dsk"` enters a DSK image as a virtual directory; files inside can be listed, loaded, and read sector-by-sector (read-only, matching real M4 behavior)
- **Topbar activity LED** — green LED in the main toolbar shows M4 activity (read/write/dir), plus container filename when browsing a DSK
- **IPC integration** — `m4 status/ls/cd/reset` commands for external debugging
- **Path traversal hardening** — component-aware `lexically_relative()` checks replace string prefix comparison (fixes sibling-directory attack vector)
- **Activity tracking** — frame-accurate countdown timer ticked in emulation loop (not render path)
- **43 unit tests** covering protocol, path safety, file I/O, containers, and all new commands

## RSX Command Reference

All 31 RSX commands from the real M4 firmware are supported. Each RSX maps to one or more protocol commands handled by the emulator.

### File & Directory

| RSX | Example | Output |
|-----|---------|--------|
| `\|SD` | `\|SD` | `Ready` — redirects CAS vectors to M4 SD card |
| `\|DISC` | `\|DISC` | `Ready` — redirects CAS vectors to AMSDOS floppy |
| `\|TAPE` | `\|TAPE` | `Ready` — redirects CAS vectors to tape |
| `\|CD` | `\|CD,"games"` | _(no output on success, changes directory)_ |
| `\|CD` | `\|CD,"game.dsk"` | _(enters DSK as virtual directory)_ |
| `\|CD` | `\|CD,"/"` | _(returns to SD root, exits container if inside)_ |
| `\|DIR` | `\|DIR` | `GAME    .DSK   194560`<br>`LOADER  .BAS     1024`<br>`2 file(s)` |
| `\|DIR` | `\|DIR,"*.dsk"` | `GAME    .DSK   194560`<br>`1 file(s)` |
| `\|LS` | `\|LS` | `game.dsk   194560`<br>`loader.bas    1024` — long filenames |
| `\|ERA` | `\|ERA,"old.bas"` | _(deletes file, no output on success)_ |
| `\|REN` | `\|REN,"new.bas","old.bas"` | _(renames file)_ |
| `\|MKDIR` | `\|MKDIR,"saves"` | _(creates directory)_ |
| `\|GETPATH` | `\|GETPATH` | `/games/` — current SD path |

### File Copy & Extract

| RSX | Example | Output |
|-----|---------|--------|
| `\|COPYF` | `\|COPYF,"src.bin","dst.bin"` | `Copied` — SD-to-SD file copy |
| `\|FCP` | `\|FCP,"A:FILE.BAS","sd:file.bas"` | `Copied` — floppy↔SD copy via READSECTOR/WRITESECTOR |
| `\|DSKX` | `\|DSKX,"game.dsk"` | `Extracting...`<br>`LOADER  .BAS`<br>`GAME    .BIN`<br>`Done` — extracts files from DSK image |

### Snapshot & Cartridge

| RSX | Example | Output |
|-----|---------|--------|
| `\|SNA` | `\|SNA,"game.sna"` | _(loads snapshot, CPC state restored)_ |
| `\|CTR` | `\|CTR,"game.cpr"` | _(loads Plus cartridge, CPC resets)_ |
| `\|CTRUP` | `\|CTRUP,"game.cpr",5` | `Uploaded to slot 5` — uploads cartridge to flash |

### Network

The emulator bridges to the host computer's real network — `|NETSTAT` shows the host's IP and WiFi SSID, `|HTTPGET` downloads files via the host's internet connection, and `|NETHOSTIP` resolves hostnames using the host's DNS.

| RSX | Example | Output |
|-----|---------|--------|
| `\|HTTPGET` | `\|HTTPGET,"cpcpower.com/dl/game.dsk"` | `Downloaded game.dsk` — saves to current SD directory |
| `\|HTTPMEM` | `\|HTTPMEM,&4000,8192,"host/data.bin"` | _(downloads to CPC memory at &4000)_ |
| `\|NETSET` | `\|NETSET,"MyWiFi:password"` | _(acknowledged — emulator uses host network directly)_ |
| `\|NETSTAT` | `\|NETSTAT` | `IP: 192.168.1.42 (MyWiFi)` + status byte 5 (connected) |
| `\|WIFI` | `\|WIFI,1` | _(enable/disable WiFi module — no-op, host always connected)_ |

### ROM Management

| RSX | Example | Output |
|-----|---------|--------|
| `\|ROMUP` | `\|ROMUP,"basic.rom",3` | `Uploaded to slot 3` — uploads ROM image to slot |
| `\|ROMSET` | `\|ROMSET,3,1` | _(enables ROM in slot 3)_ |
| `\|ROMUPD` | `\|ROMUPD` | _(applies ROM config changes without reboot)_ |
| `\|ROMSOFF` | `\|ROMSOFF` | _(disables all ROMs except M4)_ |
| `\|M4ROMOFF` | `\|M4ROMOFF` | _(disables M4 Board until next power cycle)_ |

### System & Info

| RSX | Example | Output |
|-----|---------|--------|
| `\|VERSION` | `\|VERSION` | `M4 konCePCja v1.0` — emulated M4 version |
| `\|TIME` | `\|TIME` | `14:35:22 2026-03-08` — host system clock |
| `\|LONGNAME` | `\|LONGNAME,"GAME~1.DSK"` | `game_collection.dsk` — full LFN for 8.3 name |
| `\|UDIR` | _(internal)_ | _(used internally by DIR for paging)_ |
| `\|M4HELP` | `\|M4HELP` | `SD DISC TAPE CD DIR LS ERA REN...` — lists all commands |
| `\|UPGRADE` | `\|UPGRADE` | _(downloads firmware update via HTTPGET)_ |

## Protocol Commands (39 total)

All protocol codes in the `&43xx` range are now handled:

| Range | Commands | Status |
|-------|----------|--------|
| File I/O | OPEN, READ, READ2, WRITE, WRITE2, CLOSE, SEEK, EOF, FTELL, FSIZE, FSTAT | ✅ Full |
| Directory | READDIR, CD, DIRSETARGS, FREE, GETPATH, ERASEFILE, RENAME, MAKEDIR | ✅ Full |
| Disc Image | READSECTOR, **WRITESECTOR**, **FORMATTRACK** | ✅ Full (FORMAT returns error, matching real HW) |
| Raw SD | **SDREAD**, **SDWRITE** | ✅ Stub (returns error — no raw SD in emulation) |
| Network | HTTPGET, **HTTPGETMEM**, **SETNETWORK**, **NETSTAT**, **TIME** | ✅ Full (uses host network) |
| Socket | **NETSOCKET**, **NETCONNECT**, **NETCLOSE**, **NETSEND**, **NETRECV**, **NETHOSTIP** | ✅ NETHOSTIP resolves via host DNS; sockets return "not connected" |
| System | VERSION, **M4OFF**, CONFIG | ✅ Full |
| ROM | ROMWRITE, **ROMSUPDATE** | ✅ Full |

**Bold** = newly implemented in this PR.

## Test plan
- [x] `make ARCH=macos` — 770 tests pass (43 M4-specific)
- [ ] CI: macOS, Linux, MINGW32, MINGW64 builds
- [ ] Manual: enable M4, set SD path, `|SD`, `CAT`, `LOAD"file"`, `SAVE"file"`
- [ ] Manual: `|CD,"game.dsk"` → `|DIR` → `LOAD"file"` inside DSK container
- [ ] Manual: `|NETSTAT` shows host IP and WiFi SSID
- [ ] Manual: `|TIME` shows host system clock
- [ ] Manual: verify topbar LED (green flash on M4 activity, container name shown)
- [ ] IPC: `echo "m4 status" | nc localhost 6543` returns M4 state