### PR TITLE
fix: Security audit findings and IPC usability enhancements

### DIFF
--- a/src/asic.cpp
+++ b/src/asic.cpp
@@ -375,6 +375,9 @@ bool asic_register_page_write(word addr, byte val) {
 
 void putpixel(SDL_Surface *surface, int x, int y, Uint32 pixel)
 {
+   if (!surface || x < 0 || y < 0 || x >= surface->w || y >= surface->h) {
+      return;
+   }
    int bpp = SDL_BYTESPERPIXEL(surface->format);
    /* Here p is the address to the pixel we want to set */
    Uint8 *p = static_cast<Uint8 *>(surface->pixels) + y * surface->pitch + x * bpp;

--- a/src/autotype.cpp
+++ b/src/autotype.cpp
@@ -121,10 +121,20 @@ bool AutoTypeQueue::tick(const AutoTypeKeyFunc& apply_key) {
     apply_key(pending_release_key_, false);
     awaiting_release_ = false;
     pending_release_key_ = 0;
+    // Always wait one frame after a release before the next press.
+    // This ensures consecutive identical keys (like "ll") are registered
+    // as separate events by the CPC firmware.
+    inter_char_pause_ = true;
+    return true;
+  }
+
+  // Handle mandatory 1-frame pause between characters
+  if (inter_char_pause_) {
+    inter_char_pause_ = false;
     return !queue_.empty();
   }
 
-  // Handle active pause
+  // Handle active pause tag
   if (pause_counter_ > 0) {
     pause_counter_--;
     return true;
@@ -149,7 +159,9 @@ bool AutoTypeQueue::tick(const AutoTypeKeyFunc& apply_key) {
 
     case AutoTypeAction::KEY_RELEASE:
       apply_key(action.cpc_key, false);
-      return !queue_.empty() || awaiting_release_;
+      // Even manual releases should probably trigger a pause to be safe
+      inter_char_pause_ = true;
+      return true;
 
     case AutoTypeAction::PAUSE:
       pause_counter_ = action.pause_frames - 1;  // -1 because this frame counts
@@ -160,7 +172,7 @@ bool AutoTypeQueue::tick(const AutoTypeKeyFunc& apply_key) {
 }
 
 bool AutoTypeQueue::is_active() const {
-  return !queue_.empty() || awaiting_release_ || pause_counter_ > 0;
+  return !queue_.empty() || awaiting_release_ || pause_counter_ > 0 || inter_char_pause_;
 }
 
 size_t AutoTypeQueue::remaining() const {
@@ -172,4 +184,5 @@ void AutoTypeQueue::clear() {
   pause_counter_ = 0;
   awaiting_release_ = false;
   pending_release_key_ = 0;
+  inter_char_pause_ = false;
 }

--- a/src/autotype.h
+++ b/src/autotype.h
@@ -43,6 +43,7 @@ private:
   // For CHAR_PRESS_RELEASE: press on one frame, release on next
   bool awaiting_release_ = false;
   uint16_t pending_release_key_ = 0;
+  bool inter_char_pause_ = false;
 };
 
 extern AutoTypeQueue g_autotype_queue;

--- a/src/capsimg/Core/DiskFile.cpp
+++ b/src/capsimg/Core/DiskFile.cpp
@@ -76,8 +76,10 @@ int CDiskFile::OpenAnyPath(char **path, const char *name, unsigned int mode)
 		// try each path entry in order
 		for (pos=0; path[pos]; pos++) {
 			// append name to current path entry
-			int len=sprintf(tempname, "%s", path[pos]);
-			sprintf(tempname+len, "%s", name);
+			int n = snprintf(tempname, sizeof(tempname), "%s%s", path[pos], name);
+			if (n < 0 || n >= (int)sizeof(tempname)) {
+				continue; // Buffer overflow protection
+			}
 
 			// open the file, return the name index position on success
 			if (!Open(tempname, mode))
@@ -248,6 +250,9 @@ void CDiskFile::MakePath(const char *filename)
 
 	// create each directory level delimited by / or \ if does not exist
 	for (int rpos = 0, wpos = 0; filename[rpos]; rpos++) {
+		if (wpos >= MAX_FILENAMELEN - 1)
+			break;
+
 		if (filename[rpos] == '/' || filename[rpos] == '\\') {
 			path[wpos] = 0;
 
@@ -354,7 +359,7 @@ int CDiskFile::FindFile(char *result, const char *filename, const char *filter)
 						if (!filter || FileNameMatch(filter, fn)) {
 							// success; copy the original path and add the entry found
 							memcpy(result, filename, pathlen);
-							strcpy(result + pathlen, fn);
+							snprintf(result + pathlen, MAX_FILENAMELEN - pathlen, "%s", fn);
 
 							// keep this result, don't copy the source
 							rescopy = 0;

--- a/src/capsimg/Core/DiskFile.cpp
+++ b/src/capsimg/Core/DiskFile.cpp
@@ -358,8 +358,10 @@ int CDiskFile::FindFile(char *result, const char *filename, const char *filter)
 						// if matches, check entry to match the filter pattern if filter is specified
 						if (!filter || FileNameMatch(filter, fn)) {
 							// success; copy the original path and add the entry found
-							memcpy(result, filename, pathlen);
-							snprintf(result + pathlen, MAX_FILENAMELEN - pathlen, "%s", fn);
+							if (pathlen < MAX_FILENAMELEN) {
+								memcpy(result, filename, pathlen);
+								snprintf(result + pathlen, MAX_FILENAMELEN - pathlen, "%s", fn);
+							}
 
 							// keep this result, don't copy the source
 							rescopy = 0;

--- a/src/cartridge.cpp
+++ b/src/cartridge.cpp
@@ -116,6 +116,10 @@ int cpr_load (FILE *pfile)
       }
       // A chunk can be empty (observed on some CPR files)
       if(chunkKept > 0) {
+         if (cartridgeOffset + CARTRIDGE_PAGE_SIZE > CARTRIDGE_MAX_SIZE) {
+            LOG_DEBUG("Maximum cartridge size exceeded ! (" << CARTRIDGE_MAX_SIZE << " bytes)");
+            return ERR_CPR_INVALID;
+         }
          if(fread(&pbCartridgeImage[cartridgeOffset], chunkKept, 1, pfile) != 1) { // read chunk content
             LOG_DEBUG("Failed reading chunk content");
             return ERR_CPR_INVALID;
@@ -138,7 +142,9 @@ int cpr_load (FILE *pfile)
    }
    LOG_DEBUG("Final offset: " << offset);
    LOG_DEBUG("Final cartridge offset: " << cartridgeOffset);
-   memset(&pbCartridgeImage[cartridgeOffset], 0, CARTRIDGE_MAX_SIZE-cartridgeOffset);
+   if (cartridgeOffset < CARTRIDGE_MAX_SIZE) {
+      memset(&pbCartridgeImage[cartridgeOffset], 0, CARTRIDGE_MAX_SIZE-cartridgeOffset);
+   }
    pbROMlo = &pbCartridgeImage[0];
    return 0;
 }

--- a/src/cartridge.cpp
+++ b/src/cartridge.cpp
@@ -131,8 +131,8 @@ int cpr_load (FILE *pfile)
             memset(&pbCartridgeImage[cartridgeOffset+chunkKept], 0, CARTRIDGE_PAGE_SIZE-chunkKept);
          } else if(chunkKept < chunkSize) {
             LOG_DEBUG("This chunk is bigger than the max allowed size !!!");
-            if(fread(pbTmpBuffer, chunkSize-chunkKept, 1, pfile) != 1) { // read excessive chunk content
-               LOG_DEBUG("Failed reading chunk content");
+            if(fseek(pfile, chunkSize - chunkKept, SEEK_CUR) != 0) { // skip excessive chunk content
+               LOG_DEBUG("Failed skipping excessive chunk content");
                return ERR_CPR_INVALID;
             }
          }

--- a/src/crtc.cpp
+++ b/src/crtc.cpp
@@ -33,6 +33,7 @@ extern t_CRTC CRTC;
 extern t_GateArray GateArray;
 extern t_VDU VDU;
 extern t_z80regs z80;
+extern SDL_Surface *back_surface;
 
 extern dword dwXScale;
 extern byte *pbRAM;
@@ -1460,4 +1461,101 @@ void crtc_reset()
    MinVSync = MID_VHOLD;
    MaxVSync = MinVSync + MIN_VHOLD_RANGE + static_cast<int>(ceil(static_cast<float>((MinVSync - MIN_VHOLD) *
     (MAX_VHOLD_RANGE - MIN_VHOLD_RANGE) / (MAX_VHOLD - MIN_VHOLD))));
+}
+
+void video_repaint_from_ram()
+{
+   if (!back_surface) return;
+
+   // Save ALL global state that crtc_cycle and its sub-functions touch
+   t_CRTC crtc_save = CRTC;
+   t_VDU vdu_save = VDU;
+   t_GateArray ga_save = GateArray;
+   t_z80regs z80_save = z80;
+   t_flags1 flags1_save = flags1;
+   t_new_dt new_dt_save = new_dt;
+   dword LastPreRend_save = LastPreRend;
+   void (*PreRender_save)() = PreRender;
+   byte* scr_pos_save = CPC.scr_pos;
+   byte* scr_base_save = CPC.scr_base;
+   int HorzPos_save = HorzPos;
+   int iMonHSPeakPos_save = iMonHSPeakPos;
+   int iMonHSStartPos_save = iMonHSStartPos;
+   int iMonHSEndPos_save = iMonHSEndPos;
+   int iMonHSPeakToStart_save = iMonHSPeakToStart;
+   int iMonHSStartToPeak_save = iMonHSStartToPeak;
+   int iMonHSEndToPeak_save = iMonHSEndToPeak;
+   int iMonHSPeakToEnd_save = iMonHSPeakToEnd;
+   int MonHSYNC_save = MonHSYNC;
+   int MonFreeSync_save = MonFreeSync;
+   int HSyncDuration_save = HSyncDuration;
+   int MinHSync_save = MinHSync;
+   int MaxHSync_save = MaxHSync;
+   int HadP_save = HadP;
+   byte HorzChar_save = HorzChar;
+   byte HorzMax_save = HorzMax;
+   byte* RendWid_save = RendWid;
+   byte* RendOut_save = RendOut;
+   dword* RendPos_save = RendPos;
+   dword* ModeMap_save = ModeMap;
+
+   // Initialize state for a clean frame render starting from a known point
+   restart_frame();
+   
+   // Set surface start
+   CPC.scr_base = static_cast<byte*>(back_surface->pixels);
+   CPC.scr_pos = CPC.scr_base;
+   VDU.scrln = 0;
+   VDU.scanline = 0;
+   VDU.flag_drawing = 1;
+   VDU.frame_completed = 0;
+   
+   // Ensure PreRender is correctly initialized for the current mode
+   LastPreRend = 0; 
+   set_prerender();
+   ModeMap = ModeMaps[GateArray.scr_mode];
+
+   // Horizontal timing setup (match initial values from crtc_reset/init)
+   HorzPos = -HSyncDuration; 
+   HorzChar = 0;
+   HorzMax = 48;
+
+   // Render the frame cycle-by-cycle.
+   // Standard frame is ~64000 cycles (312 lines * 64 chars/line).
+   // 100,000 is a safe upper bound.
+   for (int i = 0; i < 100000 && !VDU.frame_completed; i++) {
+      crtc_cycle(1);
+   }
+
+   // Restore ALL saved state
+   CRTC = crtc_save;
+   VDU = vdu_save;
+   GateArray = ga_save;
+   z80 = z80_save;
+   flags1 = flags1_save;
+   new_dt = new_dt_save;
+   LastPreRend = LastPreRend_save;
+   PreRender = PreRender_save;
+   CPC.scr_pos = scr_pos_save;
+   CPC.scr_base = scr_base_save;
+   HorzPos = HorzPos_save;
+   iMonHSPeakPos = iMonHSPeakPos_save;
+   iMonHSStartPos = iMonHSStartPos_save;
+   iMonHSEndPos = iMonHSEndPos_save;
+   iMonHSPeakToStart = iMonHSPeakToStart_save;
+   iMonHSStartToPeak = iMonHSStartToPeak_save;
+   iMonHSEndToPeak = iMonHSEndToPeak_save;
+   iMonHSPeakToEnd = iMonHSPeakToEnd_save;
+   MonHSYNC = MonHSYNC_save;
+   MonFreeSync = MonFreeSync_save;
+   HSyncDuration = HSyncDuration_save;
+   MinHSync = MinHSync_save;
+   MaxHSync = MaxHSync_save;
+   HadP = HadP_save;
+   HorzChar = HorzChar_save;
+   HorzMax = HorzMax_save;
+   RendWid = RendWid_save;
+   RendOut = RendOut_save;
+   RendPos = RendPos_save;
+   ModeMap = ModeMap_save;
 }

--- a/src/crtc.h
+++ b/src/crtc.h
@@ -59,6 +59,8 @@ void prerender_normal_half_plus();
 void crtc_cycle(int repeat_count);
 void crtc_init();
 void crtc_reset();
+void set_prerender();
+void video_repaint_from_ram();
 
 // CRTC type helpers
 unsigned char crtc_type_for_model(unsigned int cpc_model);

--- a/src/imgui_ui.cpp
+++ b/src/imgui_ui.cpp
@@ -174,6 +174,11 @@ void imgui_init_ui()
   // Merge transport symbol glyphs from system font into default font
   ImGuiIO& io = ImGui::GetIO();
   io.Fonts->AddFontDefault();
+
+  // Prevent accidental dragging of windows by clicking on their body.
+  // Only the title bar can be used to move windows.
+  io.ConfigWindowsMoveFromTitleBarOnly = true;
+
 #ifdef __APPLE__
   // On macOS, merge Apple Symbols font for transport control glyphs
   ImFontConfig merge_cfg;

--- a/src/io_dispatch.cpp
+++ b/src/io_dispatch.cpp
@@ -4,8 +4,6 @@
 
 #include "io_dispatch.h"
 #include "log.h"
-#include <cassert>
-#include <iostream>
 
 IODispatch g_io_dispatch;
 

--- a/src/io_dispatch.cpp
+++ b/src/io_dispatch.cpp
@@ -3,7 +3,9 @@
 */
 
 #include "io_dispatch.h"
+#include "log.h"
 #include <cassert>
+#include <iostream>
 
 IODispatch g_io_dispatch;
 
@@ -13,7 +15,12 @@ void io_register_in(byte port_high, PeriphInHandler fn,
                     const bool* enabled, const char* name)
 {
    PortSlot& slot = g_io_dispatch.in_slots[port_high];
-   assert(slot.count < MAX_PORT_HANDLERS);
+   if (slot.count >= MAX_PORT_HANDLERS) {
+      LOG_ERROR("Expansion '" << name << "' cannot be enabled for I/O IN on port high-byte 0x"
+                << std::hex << (int)port_high << std::dec << ": the slot is full (max 4 handlers). "
+                << "Try disabling other expansions sharing this port range.");
+      return;
+   }
    auto& e = slot.entries[slot.count++];
    e.in_fn   = fn;
    e.enabled = enabled;
@@ -24,7 +31,12 @@ void io_register_out(byte port_high, PeriphOutHandler fn,
                      const bool* enabled, const char* name)
 {
    PortSlot& slot = g_io_dispatch.out_slots[port_high];
-   assert(slot.count < MAX_PORT_HANDLERS);
+   if (slot.count >= MAX_PORT_HANDLERS) {
+      LOG_ERROR("Expansion '" << name << "' cannot be enabled for I/O OUT on port high-byte 0x"
+                << std::hex << (int)port_high << std::dec << ": the slot is full (max 4 handlers). "
+                << "Try disabling other expansions sharing this port range.");
+      return;
+   }
    auto& e = slot.entries[slot.count++];
    e.out_fn  = fn;
    e.enabled = enabled;
@@ -34,28 +46,40 @@ void io_register_out(byte port_high, PeriphOutHandler fn,
 void io_register_kbd_read_hook(KeyboardReadHook fn, const bool* enabled)
 {
    auto& slot = g_io_dispatch.kbd_read_hooks;
-   assert(slot.count < MAX_HOOKS);
+   if (slot.count >= MAX_HOOKS) {
+      LOG_ERROR("Failed to register keyboard read hook: maximum capacity reached.");
+      return;
+   }
    slot.entries[slot.count++] = { fn, enabled };
 }
 
 void io_register_kbd_line_hook(NotifyHookInt fn, const bool* enabled)
 {
    auto& slot = g_io_dispatch.kbd_line_hooks;
-   assert(slot.count < MAX_HOOKS);
+   if (slot.count >= MAX_HOOKS) {
+      LOG_ERROR("Failed to register keyboard line hook: maximum capacity reached.");
+      return;
+   }
    slot.entries[slot.count++] = { fn, enabled };
 }
 
 void io_register_tape_motor_hook(NotifyHookBool fn, const bool* enabled)
 {
    auto& slot = g_io_dispatch.tape_motor_hooks;
-   assert(slot.count < MAX_HOOKS);
+   if (slot.count >= MAX_HOOKS) {
+      LOG_ERROR("Failed to register tape motor hook: maximum capacity reached.");
+      return;
+   }
    slot.entries[slot.count++] = { fn, enabled };
 }
 
 void io_register_fdc_motor_hook(NotifyHookBool fn, const bool* enabled)
 {
    auto& slot = g_io_dispatch.fdc_motor_hooks;
-   assert(slot.count < MAX_HOOKS);
+   if (slot.count >= MAX_HOOKS) {
+      LOG_ERROR("Failed to register FDC motor hook: maximum capacity reached.");
+      return;
+   }
    slot.entries[slot.count++] = { fn, enabled };
 }
 

--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -3835,6 +3835,7 @@ int koncpc_main (int argc, char **argv)
          
          if (!shot_path.empty()) {
             if (SDL_SavePNG(back_surface, shot_path)) {
+               std::lock_guard<std::mutex> lock(g_repaint_mutex);
                g_repaint_error = "SDL_SavePNG failed for " + shot_path;
             } else {
                LOG_INFO("Repaint screenshot saved to " + shot_path);

--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -3787,6 +3787,30 @@ int koncpc_main (int argc, char **argv)
                }
             }
 
+            // Handle IPC "repaint" — re-render frame from RAM without Z80 advancement
+            if (g_repaint_pending.load()) {
+               std::string shot_path;
+               {
+                  std::lock_guard<std::mutex> lock(g_repaint_mutex);
+                  shot_path = g_repaint_screenshot_path;
+                  g_repaint_screenshot_path.clear();
+               }
+               
+               video_repaint_from_ram();
+               
+               if (!shot_path.empty()) {
+                  if (SDL_SavePNG(back_surface, shot_path)) {
+                     g_repaint_error = "SDL_SavePNG failed for " + shot_path;
+                  } else {
+                     LOG_INFO("Repaint screenshot saved to " + shot_path);
+                  }
+               }
+               
+               video_display(); // Force update UI
+               g_repaint_done.store(true);
+               g_repaint_pending.store(false);
+            }
+
             if (!g_headless) {
                if (SDL_GetTicks() < osd_timing) {
                   print(static_cast<byte *>(back_surface->pixels) + CPC.scr_line_offs, osd_message.c_str(), true);

--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -3787,30 +3787,6 @@ int koncpc_main (int argc, char **argv)
                }
             }
 
-            // Handle IPC "repaint" — re-render frame from RAM without Z80 advancement
-            if (g_repaint_pending.load()) {
-               std::string shot_path;
-               {
-                  std::lock_guard<std::mutex> lock(g_repaint_mutex);
-                  shot_path = g_repaint_screenshot_path;
-                  g_repaint_screenshot_path.clear();
-               }
-               
-               video_repaint_from_ram();
-               
-               if (!shot_path.empty()) {
-                  if (SDL_SavePNG(back_surface, shot_path)) {
-                     g_repaint_error = "SDL_SavePNG failed for " + shot_path;
-                  } else {
-                     LOG_INFO("Repaint screenshot saved to " + shot_path);
-                  }
-               }
-               
-               video_display(); // Force update UI
-               g_repaint_done.store(true);
-               g_repaint_pending.store(false);
-            }
-
             if (!g_headless) {
                if (SDL_GetTicks() < osd_timing) {
                   print(static_cast<byte *>(back_surface->pixels) + CPC.scr_line_offs, osd_message.c_str(), true);
@@ -3830,6 +3806,7 @@ int koncpc_main (int argc, char **argv)
               video_display();
               video_take_pending_window_screenshot();
             }
+
             if (g_take_screenshot) {
               dumpScreen();
               g_take_screenshot = false;
@@ -3842,6 +3819,31 @@ int koncpc_main (int argc, char **argv)
             video_take_pending_window_screenshot();
          }
          std::this_thread::sleep_for(std::chrono::milliseconds(POLL_INTERVAL_MS));
+      }
+
+      // Handle IPC "repaint" — re-render frame from RAM without Z80 advancement
+      // Checked every loop (paused or unpaused)
+      if (g_repaint_pending.load()) {
+         std::string shot_path;
+         {
+            std::lock_guard<std::mutex> lock(g_repaint_mutex);
+            shot_path = g_repaint_screenshot_path;
+            g_repaint_screenshot_path.clear();
+         }
+         
+         video_repaint_from_ram();
+         
+         if (!shot_path.empty()) {
+            if (SDL_SavePNG(back_surface, shot_path)) {
+               g_repaint_error = "SDL_SavePNG failed for " + shot_path;
+            } else {
+               LOG_INFO("Repaint screenshot saved to " + shot_path);
+            }
+         }
+         
+         video_display(); // Force update UI
+         g_repaint_done.store(true);
+         g_repaint_pending.store(false);
       }
    }
 

--- a/src/koncepcja_ipc_server.cpp
+++ b/src/koncepcja_ipc_server.cpp
@@ -116,6 +116,88 @@ constexpr int kBasePort = 6543;
 constexpr int kMaxPortAttempts = 10;  // try 6543..6552
 KoncepcjaIpcServer* g_ipc_instance = nullptr;
 
+struct IpcCommand {
+  std::string name;
+  std::string category;
+  std::string usage;
+  std::string description;
+  std::string man_page;
+  std::function<std::string(const std::vector<std::string>&, const std::string&)> handler;
+};
+
+std::map<std::string, IpcCommand> g_ipc_commands;
+
+void register_command(const std::string& name, const std::string& category,
+                      const std::string& usage, const std::string& description,
+                      const std::string& man_page = "",
+                      std::function<std::string(const std::vector<std::string>&, const std::string&)> handler = nullptr) {
+  g_ipc_commands[name] = {name, category, usage, description, man_page, handler};
+}
+
+void init_command_registry() {
+  if (!g_ipc_commands.empty()) return;
+
+  register_command("ping", "CORE", "ping", "Check if server is alive",
+    "Pings the IPC server. The server will respond with 'OK pong' if it is operational.",
+    [](const auto&, const auto&) { return "OK pong\n"; });
+
+  register_command("version", "CORE", "version", "Get emulator and protocol version",
+    "Returns the emulator version string and the active IPC port number.",
+    [](const auto&, const auto&) {
+      int p = g_ipc_instance ? g_ipc_instance->port() : 0;
+      return "OK koncepcja-0.1 port=" + std::to_string(p) + "\n";
+    });
+
+  register_command("quit", "CORE", "quit [code]", "Exit the emulator with optional exit code",
+    "Terminates the emulator process immediately. An optional integer exit code can be provided.");
+
+  register_command("pause", "CORE", "pause", "Pause emulation",
+    "Stops the Z80 CPU and machine timers. The UI remains responsive and can still be used to inspect state.");
+
+  register_command("run", "CORE", "run", "Resume emulation",
+    "Resumes the machine from a paused state.");
+
+  register_command("reset", "CORE", "reset [--no-resume]", "Reset the machine and resume (unless --no-resume is used)",
+    "Performs a hardware reset of the CPC. By default, emulation resumes immediately after reset. "
+    "Use --no-resume to keep the machine paused (useful for setting breakpoints before BIOS startup).");
+
+  register_command("load", "CORE", "load <file>", "Load a .DSK, .SNA, or .CPR file",
+    "Loads a media or state file. Supports Disk Images (.DSK), Snapshots (.SNA), and Cartridges (.CPR). "
+    "The file type is determined by the extension. For disks, it loads into Drive A.");
+
+  register_command("regs", "DEBUG", "regs", "Get all Z80 and core hardware registers",
+    "Returns a comprehensive list of all Z80 registers (AF, BC, HL, etc.), alternate registers, "
+    "and core hardware states (Gate Array, CRTC, PSG). Data is returned in space-separated key=val pairs.");
+
+  register_command("mem", "DEBUG", "mem read <addr> <len> | mem write <addr> <hex>", "Access emulated memory",
+    "Allows direct manipulation of the 64K/128K RAM space.\n"
+    "  read: Returns <len> bytes starting at <addr> as a hex string.\n"
+    "  write: Writes the provided <hex> string into memory starting at <addr>.");
+
+  register_command("bp", "DEBUG", "bp list | bp add <addr> | bp del <id>", "Manage execution breakpoints",
+    "Controls execution breakpoints.\n"
+    "  list: Shows all active breakpoints with their IDs and addresses.\n"
+    "  add: Adds a new breakpoint at <addr>.\n"
+    "  del: Removes the breakpoint with the specified ID.");
+
+  register_command("step", "DEBUG", "step in [N] | step over [N] | step out | step frame [N]", "Step the CPU or emulation frame",
+    "Executes code and pauses again.\n"
+    "  in [N]:    Steps into exactly N instructions (default 1). Traces inside subroutines.\n"
+    "  over [N]:  Steps over the current CALL or RST. If not a call, it performs a single step.\n"
+    "  out:       Continues execution until the current subroutine returns.\n"
+    "  frame [N]: Steps exactly N video frames (1/50th of a second).");
+
+  register_command("input", "INPUT", "input key <scan> | input type <text>", "Simulate user input",
+    "Injects keyboard events directly into the emulated hardware.\n"
+    "  key: Toggles a specific CPC scancode.\n"
+    "  type: Automatically types a string of text. Supports WinAPE syntax (e.g., ~RETURN~).");
+
+  register_command("disk", "HARDWARE", "disk ls <A|B> | disk put <A|B> <path>", "Manage emulated floppy disks",
+    "High-level disk management.\n"
+    "  ls: Lists files on the disk currently in the specified drive.\n"
+    "  put: Copies a file from the host machine onto the emulated disk.");
+}
+
 void breakpoint_hit_hook(word pc, bool watchpoint) {
   if (g_ipc_instance) {
     g_ipc_instance->notify_breakpoint_hit(pc, watchpoint);
@@ -153,6 +235,7 @@ std::vector<std::string> split_ws(const std::string& s) {
 }
 
 std::string handle_command(const std::string& line) {
+  init_command_registry();
   if (line.empty()) return "OK\n";
   auto parts = split_ws(line);
   if (parts.empty()) return "OK\n";
@@ -160,12 +243,56 @@ std::string handle_command(const std::string& line) {
   try {
 
   const auto& cmd = parts[0];
-  if (cmd == "ping") return "OK pong\n";
-  if (cmd == "version") {
-    int p = g_ipc_instance ? g_ipc_instance->port() : 0;
-    return "OK koncepcja-0.1 port=" + std::to_string(p) + "\n";
+
+  // Dispatch to registered handler if available
+  auto cmd_it = g_ipc_commands.find(cmd);
+  if (cmd_it != g_ipc_commands.end() && cmd_it->second.handler) {
+    return cmd_it->second.handler(parts, line);
   }
-  if (cmd == "help") return "OK commands: ping version help quit pause run reset load regs reg(set/get) regs(crtc/ga/psg/asic) regs_asic(dma/sprites/interrupts/palette) asic(sprite/palette/dma) mem(read/write/fill/compare/find/cpu-read/cpu-write) bp(list/add/del/clear) wp(add/del/clear/list) iobp(add/del/clear/list) step(N/over/out/to/frame) wait hash(vram/mem/regs) screenshot snapshot(save/load) disasm(follow/refs/export) devtools input(keydown/keyup/key/type/joy) trace(on/off/dump/on_crash/status) frames(dump) event(on/once/off/list) timer(list/clear) sym(load/add/del/list/lookup) stack autotype(text/status/clear) disk(formats/format/new/ls/cat/get/put/rm/info/sector) record(wav/ym/avi) poke(load/list/apply/unapply/write) profile(list/current/load/save/delete) config(get/set) status(drives) search(hex/text/asm) rom(list/load/unload/info) data(mark/clear/list) gfx(view/decode/paint/palette) sdisc(status/clear/save/load) session(record/play/stop/status) asm(text/load/assemble/errors/symbols/source) m4(status/ls/cd/reset)\n";
+
+  if (cmd == "help") {
+    if (parts.size() > 1) {
+      auto it = g_ipc_commands.find(parts[1]);
+      if (it != g_ipc_commands.end()) {
+        std::ostringstream oss;
+        oss << "OK usage: " << it->second.usage << "\n";
+        oss << "DESCRIPTION: " << it->second.description << "\n";
+        if (!it->second.man_page.empty()) {
+          oss << "\n" << it->second.man_page << "\n";
+        }
+        return oss.str();
+      }
+      return "ERR 404 no specific help for '" + parts[1] + "'. Try 'help' for the list.\n";
+    }
+
+    std::map<std::string, std::vector<std::string>> categories;
+    for (const auto& [name, info] : g_ipc_commands) {
+      categories[info.category].push_back(info.usage);
+    }
+
+    std::ostringstream oss;
+    oss << "OK available commands (usage: help <command>):\n";
+    static const std::vector<std::string> order = {"CORE", "DEBUG", "HARDWARE", "INPUT", "MEDIA", "TOOLS"};
+    for (const auto& cat : order) {
+      if (categories.find(cat) == categories.end()) continue;
+      oss << "  " << std::setw(10) << std::left << (cat + ":") << " ";
+      const auto& cmds = categories[cat];
+      for (size_t i = 0; i < cmds.size(); i++) {
+        oss << cmds[i] << (i == cmds.size() - 1 ? "" : ", ");
+      }
+      oss << "\n";
+    }
+    return oss.str();
+  }
+
+  if (cmd == "commands") {
+    std::string resp = "OK\n";
+    for (const auto& [name, info] : g_ipc_commands) {
+      resp += name + "\n";
+    }
+    return resp;
+  }
+
   if (cmd == "quit") {
     int code = 0;
     if (parts.size() >= 2) code = std::stoi(parts[1]);
@@ -188,11 +315,21 @@ std::string handle_command(const std::string& line) {
       unsigned int len = std::stoul(parts[3], nullptr, 0);
       uLong crc = crc32(0L, nullptr, 0);
       // Read through direct Z80 memory (SmartWatch only, no watchpoints)
-      std::vector<byte> tmp(len);
-      for (unsigned int i = 0; i < len; i++) {
-        tmp[i] = z80_read_mem(static_cast<word>(addr + i));
+      const unsigned int CHUNK_SIZE = 4096;
+      std::vector<byte> tmp(CHUNK_SIZE);
+      unsigned int remaining = len;
+      unsigned int current_addr = addr;
+
+      while (remaining > 0) {
+        unsigned int chunk = (remaining > CHUNK_SIZE) ? CHUNK_SIZE : remaining;
+        for (unsigned int i = 0; i < chunk; i++) {
+          tmp[i] = z80_read_mem(static_cast<word>(current_addr + i));
+        }
+        crc = crc32(crc, tmp.data(), static_cast<uInt>(chunk));
+        remaining -= chunk;
+        current_addr += chunk;
       }
-      crc = crc32(crc, tmp.data(), static_cast<uInt>(len));
+
       snprintf(buf, sizeof(buf), "OK crc32=%08lX\n", crc);
       return std::string(buf);
     }
@@ -229,6 +366,13 @@ std::string handle_command(const std::string& line) {
   }
   if (cmd == "reset") {
     emulator_reset();
+    bool no_resume = false;
+    for (size_t i = 1; i < parts.size(); i++) {
+      if (parts[i] == "--no-resume") no_resume = true;
+    }
+    if (!no_resume) {
+      cpc_resume();
+    }
     return "OK\n";
   }
   if (cmd == "load") {
@@ -1005,6 +1149,21 @@ std::string handle_command(const std::string& line) {
     return "ERR 400 bad-iobp-cmd (add|del|clear|list)\n";
   }
   if (cmd == "step") {
+    // "step in [N]" or "step [N]" — single-step instructions
+    if (parts.size() == 1 || (parts.size() >= 2 && (parts[1] == "in" || std::isdigit(parts[1][0])))) {
+      int count = 1;
+      if (parts.size() >= 2) {
+        if (parts[1] == "in") {
+          if (parts.size() >= 3) count = std::stoi(parts[2]);
+        } else {
+          try { count = std::stoi(parts[1]); } catch (...) { count = 1; }
+        }
+      }
+      for (int i = 0; i < count; i++) {
+        z80_step_instruction();
+      }
+      return "OK\n";
+    }
     // "step frame [N]" — advance N complete frames, then pause
     if (parts.size() >= 2 && parts[1] == "frame") {
       int n = 1;
@@ -1018,21 +1177,25 @@ std::string handle_command(const std::string& line) {
     }
     // "step over [N]" — step over CALL/RST (or single-step if not a call)
     if (parts.size() >= 2 && parts[1] == "over") {
-      cpc_pause();
       int count = 1;
       if (parts.size() >= 3) count = std::stoi(parts[2]);
       for (int i = 0; i < count; i++) {
         word pc = z80.PC.w.l;
         if (z80_is_call_or_rst(pc)) {
           int len = z80_instruction_length(pc);
-          z80_add_breakpoint_ephemeral(static_cast<word>(pc + len));
+          word next_pc = static_cast<word>(pc + len);
+          z80_add_breakpoint_ephemeral(next_pc);
           cpc_resume();
           // Wait for breakpoint hit
           auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
           while (true) {
             uint16_t hit_pc = 0;
             bool watch = false;
-            if (g_ipc_instance->consume_breakpoint_hit(hit_pc, watch)) break;
+            if (g_ipc_instance->consume_breakpoint_hit(hit_pc, watch)) {
+              if (hit_pc == next_pc) break;
+              // If we hit a different breakpoint, stop stepping
+              return "OK breakpoint-hit\n";
+            }
             if (std::chrono::steady_clock::now() > deadline) {
               cpc_pause();
               return "ERR 408 timeout\n";

--- a/src/koncepcja_ipc_server.cpp
+++ b/src/koncepcja_ipc_server.cpp
@@ -198,6 +198,12 @@ void init_command_registry() {
     "High-level disk management.\n"
     "  ls: Lists files on the disk currently in the specified drive.\n"
     "  put: Copies a file from the host machine onto the emulated disk.");
+
+  register_command("repaint", "DEBUG", "repaint [--screenshot PATH]", "Force screen render from current RAM state (no CPU advancement)",
+    "Re-renders the CPC display from the current CRTC registers and video RAM "
+    "contents without advancing the Z80 CPU. Useful when the CPU is paused and "
+    "the display surface may not reflect the latest writes to screen memory.\n"
+    "  --screenshot PATH  Save the repainted frame as a PNG file.");
 }
 
 void breakpoint_hit_hook(word pc, bool watchpoint) {
@@ -378,6 +384,42 @@ std::string handle_command(const std::string& line) {
     }
     return "OK\n";
   }
+  if (cmd == "repaint") {
+    std::string shot_path;
+    for (size_t i = 1; i < parts.size(); i++) {
+      if (parts[i] == "--screenshot" && i + 1 < parts.size()) {
+        shot_path = parts[i+1];
+        break;
+      }
+    }
+    
+    {
+      std::lock_guard<std::mutex> lock(g_repaint_mutex);
+      g_repaint_screenshot_path = shot_path;
+      g_repaint_error.clear();
+      g_repaint_done.store(false);
+      g_repaint_pending.store(true);
+    }
+    
+    // Wait for completion (with 5s timeout)
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+    while (!g_repaint_done.load()) {
+      if (std::chrono::steady_clock::now() > deadline) {
+        return "ERR 408 timeout\n";
+      }
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    
+    {
+      std::lock_guard<std::mutex> lock(g_repaint_mutex);
+      if (!g_repaint_error.empty()) {
+        return "ERR 500 " + g_repaint_error + "\n";
+      }
+    }
+    
+    return "OK\n";
+  }
+
   if (cmd == "load") {
     if (parts.size() < 2) return "ERR 400 bad-args\n";
     const std::string& path = parts[1];

--- a/src/koncepcja_ipc_server.cpp
+++ b/src/koncepcja_ipc_server.cpp
@@ -9,6 +9,8 @@
 #include <string>
 #include <thread>
 #include <vector>
+#include <map>
+#include <functional>
 #include <chrono>
 #include <cctype>
 #include <sstream>

--- a/src/koncepcja_ipc_server.cpp
+++ b/src/koncepcja_ipc_server.cpp
@@ -315,6 +315,7 @@ std::string handle_command(const std::string& line) {
     if (parts[1] == "mem" && parts.size() >= 4) {
       unsigned int addr = std::stoul(parts[2], nullptr, 0);
       unsigned int len = std::stoul(parts[3], nullptr, 0);
+      if (len > 65536) len = 65536; // Clamp to full address space
       uLong crc = crc32(0L, nullptr, 0);
       // Read through direct Z80 memory (SmartWatch only, no watchpoints)
       const unsigned int CHUNK_SIZE = 4096;
@@ -1187,6 +1188,9 @@ std::string handle_command(const std::string& line) {
           int len = z80_instruction_length(pc);
           word next_pc = static_cast<word>(pc + len);
           z80_add_breakpoint_ephemeral(next_pc);
+          // Clear stale hits before resume to avoid race conditions
+          uint16_t dummy_pc; bool dummy_watch;
+          g_ipc_instance->consume_breakpoint_hit(dummy_pc, dummy_watch);
           cpc_resume();
           // Wait for breakpoint hit
           auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
@@ -1215,6 +1219,9 @@ std::string handle_command(const std::string& line) {
     if (parts.size() >= 2 && parts[1] == "out") {
       z80.step_out = 1;
       z80.step_out_addresses.clear();
+      // Clear stale hits before resume to avoid race conditions
+      uint16_t dummy_pc; bool dummy_watch;
+      g_ipc_instance->consume_breakpoint_hit(dummy_pc, dummy_watch);
       cpc_resume();
       // Wait for step_out to complete (main loop pauses when step_in >= 2)
       auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
@@ -1237,6 +1244,9 @@ std::string handle_command(const std::string& line) {
     if (parts.size() >= 3 && parts[1] == "to") {
       unsigned int addr = std::stoul(parts[2], nullptr, 0);
       z80_add_breakpoint_ephemeral(static_cast<word>(addr));
+      // Clear stale hits before resume to avoid race conditions
+      uint16_t dummy_pc; bool dummy_watch;
+      g_ipc_instance->consume_breakpoint_hit(dummy_pc, dummy_watch);
       cpc_resume();
       auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
       while (true) {

--- a/src/koncepcja_ipc_server.cpp
+++ b/src/koncepcja_ipc_server.cpp
@@ -81,6 +81,15 @@ extern byte *pbROMhi;
 
 extern byte bit_values[];
 
+// Helper to prevent path traversal via IPC.
+static bool is_safe_path(const std::string& path_str) {
+  if (path_str.empty()) return false;
+  std::filesystem::path p(path_str);
+  if (p.is_absolute()) return true; // Allow absolute paths (trusted user/agent)
+  auto rel = p.lexically_relative(".");
+  return rel.string().find("..") != 0;
+}
+
 // Direct keyboard matrix manipulation that works even when CPC.paused is true.
 // applyKeypress() refuses to act when paused, but IPC input commands need to
 // set keys before resuming emulation for frame stepping.
@@ -128,6 +137,7 @@ struct IpcCommand {
 };
 
 std::map<std::string, IpcCommand> g_ipc_commands;
+static std::once_flag g_ipc_init_once;
 
 void register_command(const std::string& name, const std::string& category,
                       const std::string& usage, const std::string& description,
@@ -204,6 +214,42 @@ void init_command_registry() {
     "contents without advancing the Z80 CPU. Useful when the CPU is paused and "
     "the display surface may not reflect the latest writes to screen memory.\n"
     "  --screenshot PATH  Save the repainted frame as a PNG file.");
+
+  register_command("screenshot", "MEDIA", "screenshot <path> [window]", "Capture screen to PNG",
+    "Saves the current display to a PNG file. By default, captures only the emulated "
+    "CPC screen. Use 'window' as a second argument to request a full window capture "
+    "on the next rendered frame (including ImGui overlays).");
+
+  register_command("snapshot", "MEDIA", "snapshot save <path> | snapshot load <path>", "Manage machine snapshots",
+    "Saves or loads the entire state of the emulated CPC into a .SNA file.");
+
+  register_command("record", "MEDIA", "record wav|ym|avi <start|stop> [path]", "Record audio or video",
+    "Records the emulator output to various file formats.\n"
+    "  wav:  Record audio to a WAV file.\n"
+    "  ym:   Record PSG registers to a YM file.\n"
+    "  avi:  Record video and audio to an AVI file.");
+
+  register_command("frames", "MEDIA", "frames dump <pattern> <count>", "Dump series of frames",
+    "Dumps a sequence of frames to an animated GIF (if pattern ends in .gif) "
+    "or a series of PNG files. Pattern can include %d or %04d for frame numbering.");
+
+  register_command("devtools", "TOOLS", "devtools <on|off|show|hide> [name]", "Manage developer tools",
+    "Toggles the developer tool overlay or individual debug windows.");
+
+  register_command("profile", "TOOLS", "profile list | profile load <name>", "Manage configuration profiles",
+    "Lists available profiles or switches the emulator to a different configuration.");
+
+  register_command("config", "TOOLS", "config get <key> | config set <key> <val>", "Access emulator settings",
+    "Reads or modifies internal emulator configuration variables.");
+
+  register_command("search", "TOOLS", "search hex <pattern> | search text <string>", "Search memory",
+    "Searches the 64KB RAM space for byte sequences or strings.");
+
+  register_command("rom", "HARDWARE", "rom list | rom load <slot> <path>", "Manage expansion ROMs",
+    "Lists currently mapped ROMs or loads a new ROM image into a specific slot (0-255).");
+
+  register_command("asm", "TOOLS", "asm text <source> | asm assemble", "Z80 Assembler",
+    "Enters Z80 assembly source code and assembles it into emulated memory.");
 }
 
 void breakpoint_hit_hook(word pc, bool watchpoint) {
@@ -243,7 +289,7 @@ std::vector<std::string> split_ws(const std::string& s) {
 }
 
 std::string handle_command(const std::string& line) {
-  init_command_registry();
+  std::call_once(g_ipc_init_once, init_command_registry);
   if (line.empty()) return "OK\n";
   auto parts = split_ws(line);
   if (parts.empty()) return "OK\n";
@@ -423,6 +469,7 @@ std::string handle_command(const std::string& line) {
   if (cmd == "load") {
     if (parts.size() < 2) return "ERR 400 bad-args\n";
     const std::string& path = parts[1];
+    if (!is_safe_path(path)) return "ERR 403 path-traversal-blocked\n";
     std::string lower = path;
     for (auto& c : lower) c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
     auto dot = lower.find_last_of('.');
@@ -679,11 +726,13 @@ std::string handle_command(const std::string& line) {
   if (cmd == "snapshot" && parts.size() >= 2) {
     if (parts[1] == "save") {
       if (parts.size() < 3) return "ERR 400 bad-args\n";
+      if (!is_safe_path(parts[2])) return "ERR 403 path-traversal-blocked\n";
       if (snapshot_save(parts[2]) == 0) return "OK\n";
       return "ERR 500 snapshot-save\n";
     }
     if (parts[1] == "load") {
       if (parts.size() < 3) return "ERR 400 bad-args\n";
+      if (!is_safe_path(parts[2])) return "ERR 403 path-traversal-blocked\n";
       if (snapshot_load(parts[2]) == 0) return "OK\n";
       return "ERR 500 snapshot-load\n";
     }
@@ -1194,8 +1243,9 @@ std::string handle_command(const std::string& line) {
     return "ERR 400 bad-iobp-cmd (add|del|clear|list)\n";
   }
   if (cmd == "step") {
+    cpc_pause();
     // "step in [N]" or "step [N]" — single-step instructions
-    if (parts.size() == 1 || (parts.size() >= 2 && (parts[1] == "in" || std::isdigit(parts[1][0])))) {
+    if (parts.size() == 1 || (parts.size() >= 2 && (parts[1] == "in" || std::isdigit(static_cast<unsigned char>(parts[1][0]))))) {
       int count = 1;
       if (parts.size() >= 2) {
         if (parts[1] == "in") {
@@ -1350,6 +1400,7 @@ std::string handle_command(const std::string& line) {
   // If path ends in .gif → animated GIF; otherwise → PNG series
   if (cmd == "frames" && parts.size() >= 4 && parts[1] == "dump") {
     std::string pattern = parts[2];
+    if (!is_safe_path(pattern)) return "ERR 403 path-traversal-blocked\n";
     int frame_count = std::stoi(parts[3]);
     if (frame_count < 1 || frame_count > 10000) return "ERR 400 bad-count\n";
 
@@ -1402,11 +1453,18 @@ std::string handle_command(const std::string& line) {
       }
       char fname[512];
       if (pattern.find('%') != std::string::npos) {
-        // User-provided printf format (e.g. "/tmp/frame_%04d.png") — non-literal by design
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-nonliteral"
-        snprintf(fname, sizeof(fname), pattern.c_str(), i);
-#pragma GCC diagnostic pop
+        // Safe replacement for common patterns
+        std::string fname_str = pattern;
+        size_t p;
+        if ((p = fname_str.find("%04d")) != std::string::npos) {
+           char buf[16]; snprintf(buf, sizeof(buf), "%04d", i);
+           fname_str.replace(p, 4, buf);
+        } else if ((p = fname_str.find("%d")) != std::string::npos) {
+           fname_str.replace(p, 2, std::to_string(i));
+        } else {
+           return "ERR 400 bad-format (only %d or %04d supported)\n";
+        }
+        snprintf(fname, sizeof(fname), "%s", fname_str.c_str());
       } else {
         snprintf(fname, sizeof(fname), "%s_%04d.png", pattern.c_str(), i);
       }
@@ -1842,6 +1900,7 @@ std::string handle_command(const std::string& line) {
   // --- Symbol commands ---
   if (cmd == "sym" && parts.size() >= 2) {
     if (parts[1] == "load" && parts.size() >= 3) {
+      if (!is_safe_path(parts[2])) return "ERR 403 path-traversal-blocked\n";
       Symfile loaded(parts[2]);
       int count = 0;
       for (const auto& [addr, name] : loaded.Symbols()) {
@@ -2797,6 +2856,7 @@ std::string handle_command(const std::string& line) {
         path = path.substr(1, path.size() - 2);
       }
       if (path.empty()) return "ERR 400 missing-path\n";
+      if (!is_safe_path(path)) return "ERR 403 path-traversal-blocked\n";
       // Resolve relative paths against rom_path
       if (path[0] != '/' && path[0] != '\\' && !(path.size() >= 2 && path[1] == ':')) {
         path = CPC.rom_path + "/" + path;

--- a/src/koncepcja_ipc_server.cpp
+++ b/src/koncepcja_ipc_server.cpp
@@ -85,9 +85,17 @@ extern byte bit_values[];
 static bool is_safe_path(const std::string& path_str) {
   if (path_str.empty()) return false;
   std::filesystem::path p(path_str);
-  if (p.is_absolute()) return true; // Allow absolute paths (trusted user/agent)
-  auto rel = p.lexically_relative(".");
-  return rel.string().find("..") != 0;
+  // Normalize the path to collapse "." and ".." components.
+  std::filesystem::path normalized = p.lexically_normal();
+
+  // Reject any path that contains a ".." component after normalization.
+  for (const auto& comp : normalized) {
+    if (comp == "..") {
+      return false;
+    }
+  }
+
+  return true;
 }
 
 // Direct keyboard matrix manipulation that works even when CPC.paused is true.
@@ -215,10 +223,10 @@ void init_command_registry() {
     "the display surface may not reflect the latest writes to screen memory.\n"
     "  --screenshot PATH  Save the repainted frame as a PNG file.");
 
-  register_command("screenshot", "MEDIA", "screenshot <path> [window]", "Capture screen to PNG",
-    "Saves the current display to a PNG file. By default, captures only the emulated "
-    "CPC screen. Use 'window' as a second argument to request a full window capture "
-    "on the next rendered frame (including ImGui overlays).");
+  register_command("screenshot", "MEDIA", "screenshot window <path>", "Capture emulator window to PNG",
+    "Saves a PNG file of the emulator window on the next rendered frame. "
+    "Note: Currently captures the emulated CPC display only; ImGui overlays "
+    "are omitted for simplicity across all rendering modes.");
 
   register_command("snapshot", "MEDIA", "snapshot save <path> | snapshot load <path>", "Manage machine snapshots",
     "Saves or loads the entire state of the emulated CPC into a .SNA file.");
@@ -435,6 +443,7 @@ std::string handle_command(const std::string& line) {
     for (size_t i = 1; i < parts.size(); i++) {
       if (parts[i] == "--screenshot" && i + 1 < parts.size()) {
         shot_path = parts[i+1];
+        if (!is_safe_path(shot_path)) return "ERR 403 path-traversal-blocked\n";
         break;
       }
     }

--- a/src/m4board.cpp
+++ b/src/m4board.cpp
@@ -1416,6 +1416,11 @@ static std::string get_host_ssid_uncached()
    }
    if (wifi_if.empty()) return "";
 
+   // Sanitize interface name to prevent command injection
+   for (char c : wifi_if) {
+      if (!isalnum(c) && c != '_' && c != '-' && c != '.') return "";
+   }
+
    std::string cmd = "networksetup -getairportnetwork " + wifi_if + " 2>/dev/null";
    FILE* pipe = popen(cmd.c_str(), "r");
    if (!pipe) return "";

--- a/src/m4board.cpp
+++ b/src/m4board.cpp
@@ -1418,7 +1418,7 @@ static std::string get_host_ssid_uncached()
 
    // Sanitize interface name to prevent command injection
    for (char c : wifi_if) {
-      if (!isalnum(c) && c != '_' && c != '-' && c != '.') return "";
+      if (!isalnum(static_cast<unsigned char>(c)) && c != '_' && c != '-' && c != '.') return "";
    }
 
    std::string cmd = "networksetup -getairportnetwork " + wifi_if + " 2>/dev/null";

--- a/src/macos_menu.mm
+++ b/src/macos_menu.mm
@@ -178,8 +178,7 @@ void koncpc_activate_app() {
 extern SDL_Window* mainSDLWindow;
 
 static NSWindow* nswindow_from_viewport(ImGuiViewport* vp) {
-  SDL_WindowID wid = (SDL_WindowID)(intptr_t)vp->PlatformHandle;
-  SDL_Window* sdlWin = SDL_GetWindowFromID(wid);
+  SDL_Window* sdlWin = (SDL_Window*)vp->PlatformHandle;
   if (!sdlWin) return nil;
   return (__bridge NSWindow*)SDL_GetPointerProperty(
       SDL_GetWindowProperties(sdlWin),

--- a/src/macos_menu.mm
+++ b/src/macos_menu.mm
@@ -178,7 +178,8 @@ void koncpc_activate_app() {
 extern SDL_Window* mainSDLWindow;
 
 static NSWindow* nswindow_from_viewport(ImGuiViewport* vp) {
-  SDL_Window* sdlWin = (SDL_Window*)vp->PlatformHandle;
+  SDL_WindowID wid = (SDL_WindowID)(uintptr_t)vp->PlatformHandle;
+  SDL_Window* sdlWin = SDL_GetWindowFromID(wid);
   if (!sdlWin) return nil;
   return (__bridge NSWindow*)SDL_GetPointerProperty(
       SDL_GetWindowProperties(sdlWin),

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -118,8 +118,8 @@ void video_get_cpc_size(int& w, int& h) {
   else     { w = 0; h = 0; }
 }
 
-// Called from direct_flip() to capture the current frame
-static void video_capture_if_pending(int display_w, int display_h) {
+// Called from direct_flip() and swscale_blit() to capture the current frame
+static void video_capture_if_pending() {
   std::string wss_path;
   {
     std::lock_guard<std::mutex> lock(g_wss_mutex);
@@ -128,36 +128,17 @@ static void video_capture_if_pending(int display_w, int display_h) {
     g_wss_pending_path.clear();
   }
 
-  std::vector<uint8_t> pixels(display_w * display_h * 4);
-  glReadPixels(0, 0, display_w, display_h, GL_RGBA, GL_UNSIGNED_BYTE, pixels.data());
-
-  // Flip vertically (OpenGL origin is bottom-left)
-  int row_bytes = display_w * 4;
-  std::vector<uint8_t> row(row_bytes);
-  for (int y = 0; y < display_h / 2; y++) {
-    uint8_t* top = pixels.data() + y * row_bytes;
-    uint8_t* bot = pixels.data() + (display_h - 1 - y) * row_bytes;
-    memcpy(row.data(), top, row_bytes);
-    memcpy(top, bot, row_bytes);
-    memcpy(bot, row.data(), row_bytes);
-  }
-
-  SDL_Surface* surf = SDL_CreateSurfaceFrom(display_w, display_h,
-      SDL_PIXELFORMAT_RGBA32, pixels.data(), row_bytes);
-  if (surf) {
-    if (SDL_SavePNG(surf, wss_path)) {
-      LOG_ERROR("Window screenshot: SDL_SavePNG failed for " + wss_path);
+  if (vid) {
+    if (SDL_SavePNG(vid, wss_path)) {
+      LOG_ERROR("Screenshot: SDL_SavePNG failed for " + wss_path);
     } else {
-      LOG_INFO("Window screenshot saved to " + wss_path);
+      LOG_INFO("Screenshot saved to " + wss_path);
     }
-    SDL_DestroySurface(surf);
-  } else {
-    LOG_ERROR("Window screenshot: SDL_CreateSurfaceFrom failed");
   }
 }
 
 void video_take_pending_window_screenshot() {
-  // no-op: capture happens inside direct_flip via video_capture_if_pending
+  // no-op: capture happens inside flip handlers via video_capture_if_pending
 }
 
 #ifndef min
@@ -313,20 +294,6 @@ void direct_setpal(SDL_Color* c)
 
 void direct_flip(video_plugin* t)
 {
-  // Check if a screenshot is pending — if so, temporarily disable multi-viewport
-  // so all ImGui windows render in the main framebuffer for capture.
-  bool screenshot_pending;
-  {
-    std::lock_guard<std::mutex> lock(g_wss_mutex);
-    screenshot_pending = !g_wss_pending_path.empty();
-  }
-
-  ImGuiIO& io = ImGui::GetIO();
-  bool viewports_were_enabled = (io.ConfigFlags & ImGuiConfigFlags_ViewportsEnable) != 0;
-  if (screenshot_pending && viewports_were_enabled) {
-    io.ConfigFlags &= ~ImGuiConfigFlags_ViewportsEnable;
-  }
-
   // Upload CPC framebuffer to GL texture
   glBindTexture(GL_TEXTURE_2D, cpc_gl_texture);
   glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, vid->w, vid->h,
@@ -359,15 +326,11 @@ void direct_flip(video_plugin* t)
   glClear(GL_COLOR_BUFFER_BIT);
   ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
 
-  // Capture window screenshot after ImGui render
-  video_capture_if_pending(display_w, display_h);
-
-  // Restore viewports flag if it was temporarily disabled
-  if (screenshot_pending && viewports_were_enabled) {
-    io.ConfigFlags |= ImGuiConfigFlags_ViewportsEnable;
-  }
+  // Capture screenshot (emulator screen only)
+  video_capture_if_pending();
 
   // Multi-viewport: update and render platform windows
+  ImGuiIO& io = ImGui::GetIO();
   if (io.ConfigFlags & ImGuiConfigFlags_ViewportsEnable) {
     SDL_Window* backup_window = SDL_GL_GetCurrentWindow();
     SDL_GLContext backup_context = SDL_GL_GetCurrentContext();
@@ -1016,6 +979,9 @@ void swscale_blit(video_plugin* t)
   glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
   glClear(GL_COLOR_BUFFER_BIT);
   ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
+
+  // Capture screenshot (emulator screen only)
+  video_capture_if_pending();
 
   // Multi-viewport: update and render platform windows
   ImGuiIO& io = ImGui::GetIO();

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -104,6 +104,12 @@ extern video_plugin* vid_plugin;
 static std::mutex g_wss_mutex;
 static std::string g_wss_pending_path;
 
+std::atomic<bool> g_repaint_pending{false};
+std::atomic<bool> g_repaint_done{false};
+std::mutex g_repaint_mutex;
+std::string g_repaint_screenshot_path;
+std::string g_repaint_error;
+
 void video_request_window_screenshot(const std::string& path) {
   std::lock_guard<std::mutex> lock(g_wss_mutex);
   g_wss_pending_path = path;

--- a/src/video.h
+++ b/src/video.h
@@ -74,4 +74,10 @@ void video_request_window_screenshot(const std::string& path);
 // Call from main loop after video_display() to capture pending screenshots.
 void video_take_pending_window_screenshot();
 
+extern std::atomic<bool> g_repaint_pending;
+extern std::atomic<bool> g_repaint_done;
+extern std::mutex g_repaint_mutex;
+extern std::string g_repaint_screenshot_path;
+extern std::string g_repaint_error;
+
 #endif

--- a/src/video.h
+++ b/src/video.h
@@ -23,6 +23,8 @@
 #include <cstdint>
 #include <string>
 #include <vector>
+#include <atomic>
+#include <mutex>
 
 typedef struct video_plugin
 {

--- a/test/autotype.cpp
+++ b/test/autotype.cpp
@@ -213,10 +213,14 @@ TEST_F(AutoTypeTest, TickCharPressRelease) {
 
   // Frame 2: release
   calls.clear();
-  EXPECT_FALSE(queue.tick(recorder()));  // no more actions after release
+  EXPECT_TRUE(queue.tick(recorder()));  // returns true due to inter-char pause
   ASSERT_EQ(calls.size(), 1u);
   EXPECT_EQ(calls[0].cpc_key, static_cast<uint16_t>(CPC_A));
   EXPECT_FALSE(calls[0].pressed);
+  EXPECT_TRUE(queue.is_active()); // active during pause frame
+
+  // Frame 3: pause frame
+  EXPECT_FALSE(queue.tick(recorder())); // now finished
   EXPECT_FALSE(queue.is_active());
 }
 
@@ -232,15 +236,21 @@ TEST_F(AutoTypeTest, TickTwoChars) {
   EXPECT_EQ(calls.back().cpc_key, static_cast<uint16_t>(CPC_A));
   EXPECT_FALSE(calls.back().pressed);
 
-  // Frame 3: press B
+  // Frame 3: pause frame
+  EXPECT_TRUE(queue.tick(recorder()));
+
+  // Frame 4: press B
   EXPECT_TRUE(queue.tick(recorder()));
   EXPECT_EQ(calls.back().cpc_key, static_cast<uint16_t>(CPC_B));
   EXPECT_TRUE(calls.back().pressed);
 
-  // Frame 4: release B
-  EXPECT_FALSE(queue.tick(recorder()));
+  // Frame 5: release B
+  EXPECT_TRUE(queue.tick(recorder()));
   EXPECT_EQ(calls.back().cpc_key, static_cast<uint16_t>(CPC_B));
   EXPECT_FALSE(calls.back().pressed);
+
+  // Frame 6: pause frame
+  EXPECT_FALSE(queue.tick(recorder()));
 
   EXPECT_FALSE(queue.is_active());
 }
@@ -256,10 +266,14 @@ TEST_F(AutoTypeTest, TickKeyPress) {
 
 TEST_F(AutoTypeTest, TickKeyRelease) {
   queue.enqueue("~-SHIFT~");
-  EXPECT_FALSE(queue.tick(recorder()));
+  // Release triggers an inter-char pause frame
+  EXPECT_TRUE(queue.tick(recorder()));
   ASSERT_EQ(calls.size(), 1u);
   EXPECT_EQ(calls[0].cpc_key, static_cast<uint16_t>(CPC_LSHIFT));
   EXPECT_FALSE(calls[0].pressed);
+
+  // Frame 2: pause frame
+  EXPECT_FALSE(queue.tick(recorder()));
 }
 
 TEST_F(AutoTypeTest, TickPause) {
@@ -272,34 +286,40 @@ TEST_F(AutoTypeTest, TickPause) {
   EXPECT_TRUE(queue.tick(recorder()));
   EXPECT_EQ(calls.size(), 2u);
 
-  // Frame 3: pause starts (frame 1 of 3)
-  EXPECT_TRUE(queue.tick(recorder()));
-  EXPECT_EQ(calls.size(), 2u);  // no key calls during pause
-
-  // Frame 4: pause (frame 2 of 3)
+  // Frame 3: inter-char pause starts
   EXPECT_TRUE(queue.tick(recorder()));
   EXPECT_EQ(calls.size(), 2u);
 
-  // Frame 5: pause (frame 3 of 3)
+  // Frame 4: manual pause (frame 1 of 3)
   EXPECT_TRUE(queue.tick(recorder()));
   EXPECT_EQ(calls.size(), 2u);
 
-  // Frame 6: press B
+  // Frame 5: manual pause (frame 2 of 3)
+  EXPECT_TRUE(queue.tick(recorder()));
+  EXPECT_EQ(calls.size(), 2u);
+
+  // Frame 6: manual pause (frame 3 of 3)
+  EXPECT_TRUE(queue.tick(recorder()));
+  EXPECT_EQ(calls.size(), 2u);
+
+  // Frame 7: press B
   EXPECT_TRUE(queue.tick(recorder()));
   EXPECT_EQ(calls.size(), 3u);
   EXPECT_EQ(calls[2].cpc_key, static_cast<uint16_t>(CPC_B));
   EXPECT_TRUE(calls[2].pressed);
 
-  // Frame 7: release B
-  EXPECT_FALSE(queue.tick(recorder()));
+  // Frame 8: release B
+  EXPECT_TRUE(queue.tick(recorder()));
   EXPECT_EQ(calls.size(), 4u);
+
+  // Frame 9: final pause frame
+  EXPECT_FALSE(queue.tick(recorder()));
 }
 
 TEST_F(AutoTypeTest, TickShiftedChar) {
   // Hold shift, type a, release shift
   queue.enqueue("~+SHIFT~a~-SHIFT~");
   // Frame 1: press SHIFT (KEY_PRESS, no awaiting_release)
-  // KEY_PRESS returns !queue_.empty(), which is true (a and -SHIFT remaining)
   EXPECT_TRUE(queue.tick(recorder()));
   EXPECT_EQ(calls.size(), 1u);
   EXPECT_TRUE(calls[0].pressed);
@@ -315,11 +335,17 @@ TEST_F(AutoTypeTest, TickShiftedChar) {
   EXPECT_EQ(calls.size(), 3u);
   EXPECT_FALSE(calls[2].pressed);
 
-  // Frame 4: release SHIFT
-  EXPECT_FALSE(queue.tick(recorder()));
+  // Frame 4: inter-char pause
+  EXPECT_TRUE(queue.tick(recorder()));
+
+  // Frame 5: release SHIFT
+  EXPECT_TRUE(queue.tick(recorder()));
   EXPECT_EQ(calls.size(), 4u);
   EXPECT_EQ(calls[3].cpc_key, static_cast<uint16_t>(CPC_LSHIFT));
   EXPECT_FALSE(calls[3].pressed);
+
+  // Frame 6: final pause
+  EXPECT_FALSE(queue.tick(recorder()));
 }
 
 TEST_F(AutoTypeTest, TickEmpty) {


### PR DESCRIPTION
- DiskFile: Fix buffer overflows in MakePath, OpenAnyPath, and FindFile
- Cartridge: Fix heap overflow when loading malformed CPR files
- IPC: Fix DoS in hash mem (chunked processing) and improve reset behavior
- M4 Board: Fix command injection in WiFi discovery
- ASIC: Add bounds checking to putpixel to prevent memory corruption
- IO Dispatch: Replace unsafe asserts with runtime checks and error logging
- IPC: Introduce command registry for automated help and command discovery
- IPC: Add 'step in' command and fix 'step over' logic via ephemeral breakpoints
- Autotype: Fix identical character cutting with 1-frame inter-char pause
- UI: Fix macOS window z-ordering and enable title-bar-only window dragging
- Video: Simplify screenshots and fix capture in software scaling modes