### PR TITLE
feat: Software scanlines with intensity control + rendering crash fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,7 +119,7 @@ echo "help" | nc localhost 6543
 | Command | Description | Example |
 |---------|-------------|---------|
 | `ping` | Test connection | `ping` → `OK pong` |
-| `version` | Get version | `version` → `OK kaprys-0.1` |
+| `version` | Get version | `version` → `OK koncepcja-0.2` |
 | `help` | List commands | `help` → `OK commands: ...` |
 | `pause` | Pause emulation | `pause` → `OK` |
 | `run` | Resume emulation | `run` → `OK` |

--- a/src/asic.cpp
+++ b/src/asic.cpp
@@ -219,7 +219,7 @@ void asic_set_palette() {
     if (blue > 255) {
       blue = 255;
     }
-    video_update_palette_entry(colour, static_cast<Uint8>(red), static_cast<Uint8>(green), static_cast<Uint8>(blue));
+    video_update_palette_entry(colour, static_cast<uint8_t>(red), static_cast<uint8_t>(green), static_cast<uint8_t>(blue));
     // TODO(cpitrat): Confirm whether we should update the mode 2 'anti-aliasing' colour (cf. src/kon_cpc_ja.cpp where GateArray.palette[33] is set).
   }
 }

--- a/src/asic.cpp
+++ b/src/asic.cpp
@@ -219,9 +219,7 @@ void asic_set_palette() {
     if (blue > 255) {
       blue = 255;
     }
-    const SDL_PixelFormatDetails* fmt = SDL_GetPixelFormatDetails(back_surface->format);
-    SDL_Palette* pal = SDL_GetSurfacePalette(back_surface);
-    GateArray.palette[colour] = SDL_MapRGB(fmt, pal, red, green, blue);
+    video_update_palette_entry(colour, static_cast<Uint8>(red), static_cast<Uint8>(green), static_cast<Uint8>(blue));
     // TODO(cpitrat): Confirm whether we should update the mode 2 'anti-aliasing' colour (cf. src/kon_cpc_ja.cpp where GateArray.palette[33] is set).
   }
 }

--- a/src/crtc.cpp
+++ b/src/crtc.cpp
@@ -975,8 +975,9 @@ void render8bpp_doubleY()
 {
    byte bCount = *RendWid++;
    while (bCount--) {
-      byte val = getPixel();
-      *(CPC.scr_pos + CPC.scr_bps) = val;
+      byte pen = *RendOut++;
+      byte val = static_cast<byte>(GateArray.palette[pen]);
+      *(CPC.scr_pos + CPC.scr_bps) = CPC.scr_scanlines ? static_cast<byte>(GateArray.dark_palette[pen]) : val;
       *CPC.scr_pos++ = val;
    }
 }
@@ -987,7 +988,8 @@ void render16bpp()
 {
    byte bCount = *RendWid++;
    while (bCount--) {
-      word val = getPixel();
+      byte pen = *RendOut++;
+      word val = static_cast<word>(GateArray.palette[pen]);
       *reinterpret_cast<word*>(CPC.scr_pos) = val;
       CPC.scr_pos += 2;
    }
@@ -999,9 +1001,10 @@ void render16bpp_doubleY()
 {
    byte bCount = *RendWid++;
    while (bCount--) {
-      word val = getPixel();
+      byte pen = *RendOut++;
+      word val = static_cast<word>(GateArray.palette[pen]);
       *reinterpret_cast<word*>(CPC.scr_pos) = val;
-      *(reinterpret_cast<word*>(CPC.scr_pos + CPC.scr_bps)) = val;
+      *(reinterpret_cast<word*>(CPC.scr_pos + CPC.scr_bps)) = CPC.scr_scanlines ? static_cast<word>(GateArray.dark_palette[pen]) : val;
       CPC.scr_pos += 2;
    }
 }
@@ -1012,7 +1015,8 @@ void render24bpp()
 {
    byte bCount = *RendWid++;
    while (bCount--) {
-      dword val = getPixel();
+      byte pen = *RendOut++;
+      dword val = GateArray.palette[pen];
       *reinterpret_cast<word *>(CPC.scr_pos) = static_cast<word>(val);
       *(CPC.scr_pos + 2) = static_cast<byte>(val >> 16);
       CPC.scr_pos += 3;
@@ -1025,13 +1029,15 @@ void render24bpp_doubleY()
 {
    byte bCount = *RendWid++;
    while (bCount--) {
-      dword val = getPixel();
-      *reinterpret_cast<word *>(CPC.scr_pos + CPC.scr_bps) = static_cast<word>(val);
+      byte pen = *RendOut++;
+      dword val = GateArray.palette[pen];
+      dword dark_val = CPC.scr_scanlines ? GateArray.dark_palette[pen] : val;
+      *reinterpret_cast<word *>(CPC.scr_pos + CPC.scr_bps) = static_cast<word>(dark_val);
       *reinterpret_cast<word *>(CPC.scr_pos) = static_cast<word>(val);
-      val >>= 16;
+      
       CPC.scr_pos += 2;
-      *(CPC.scr_pos + CPC.scr_bps) = static_cast<byte>(val);
-      *(CPC.scr_pos) = static_cast<byte>(val);
+      *(CPC.scr_pos + CPC.scr_bps) = static_cast<byte>(dark_val >> 16);
+      *(CPC.scr_pos) = static_cast<byte>(val >> 16);
       CPC.scr_pos++;
    }
 }
@@ -1042,7 +1048,8 @@ void render32bpp()
 {
    byte bCount = *RendWid++;
    while (bCount--) {
-      dword val = getPixel();
+      byte pen = *RendOut++;
+      dword val = GateArray.palette[pen];
       *reinterpret_cast<dword*>(CPC.scr_pos) = val;
       CPC.scr_pos += 4;
    }
@@ -1054,9 +1061,10 @@ void render32bpp_doubleY()
 {
    byte bCount = *RendWid++;
    while (bCount--) {
-      dword val = getPixel();
+      byte pen = *RendOut++;
+      dword val = GateArray.palette[pen];
       *reinterpret_cast<dword*>(CPC.scr_pos) = val;
-      *(reinterpret_cast<dword*>(CPC.scr_pos + CPC.scr_bps)) = val;
+      *(reinterpret_cast<dword*>(CPC.scr_pos + CPC.scr_bps)) = CPC.scr_scanlines ? GateArray.dark_palette[pen] : val;
       CPC.scr_pos += 4;
    }
 }
@@ -1471,7 +1479,11 @@ void video_repaint_from_ram()
    t_CRTC crtc_save = CRTC;
    t_VDU vdu_save = VDU;
    t_GateArray ga_save = GateArray;
-   t_z80regs z80_save = z80;
+   
+   // Don't shallow copy z80 regs (contains a vector)
+   word pc_save = z80.PC.w.l;
+   byte int_pending_save = z80.int_pending;
+
    t_flags1 flags1_save = flags1;
    t_new_dt new_dt_save = new_dt;
    dword LastPreRend_save = LastPreRend;
@@ -1515,6 +1527,11 @@ void video_repaint_from_ram()
    set_prerender();
    ModeMap = ModeMaps[GateArray.scr_mode];
 
+   // Initialize rendering pointers (crucial to avoid NULL deref in render functions)
+   RendPos = reinterpret_cast<dword *>(&RendBuff[0]);
+   RendOut = reinterpret_cast<byte *>(RendStart);
+   RendWid = &HorzPix[0];
+
    // Horizontal timing setup (match initial values from crtc_reset/init)
    HorzPos = -HSyncDuration; 
    HorzChar = 0;
@@ -1531,7 +1548,8 @@ void video_repaint_from_ram()
    CRTC = crtc_save;
    VDU = vdu_save;
    GateArray = ga_save;
-   z80 = z80_save;
+   z80.PC.w.l = pc_save;
+   z80.int_pending = int_pending_save;
    flags1 = flags1_save;
    new_dt = new_dt_save;
    LastPreRend = LastPreRend_save;

--- a/src/imgui_ui.cpp
+++ b/src/imgui_ui.cpp
@@ -1628,6 +1628,19 @@ static void imgui_render_options()
       int intensity = static_cast<int>(CPC.scr_intensity);
       if (ImGui::SliderInt("Intensity", &intensity, 5, 15)) {
         CPC.scr_intensity = intensity;
+        video_set_palette();
+      }
+
+      bool scanlines = CPC.scr_scanlines != 0;
+      if (ImGui::Checkbox("Scanlines", &scanlines)) {
+        CPC.scr_scanlines = scanlines ? 1 : 0;
+      }
+      if (scanlines) {
+        int sl_intensity = static_cast<int>(CPC.scr_oglscanlines);
+        if (ImGui::SliderInt("Scanline Intensity", &sl_intensity, 0, 100)) {
+          CPC.scr_oglscanlines = sl_intensity;
+          video_set_palette();
+        }
       }
 
       bool fps = CPC.scr_fps != 0;

--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -660,14 +660,13 @@ void z80_OUT_handler (reg_pair port, byte val)
                byte colour = val & 0x1f; // isolate colour value
                LOG_DEBUG("Set ink value " << static_cast<int>(GateArray.pen) << " to " << static_cast<int>(colour));
                GateArray.ink_values[GateArray.pen] = colour;
-               GateArray.palette[GateArray.pen] = MapRGBSurface(back_surface, colours[colour].r, colours[colour].g, colours[colour].b);
+               video_update_palette_entry(GateArray.pen, colours[colour].r, colours[colour].g, colours[colour].b);
                if (GateArray.pen < 2) {
                   byte r = (static_cast<dword>(colours[GateArray.ink_values[0]].r) + static_cast<dword>(colours[GateArray.ink_values[1]].r)) >> 1;
                   byte g = (static_cast<dword>(colours[GateArray.ink_values[0]].g) + static_cast<dword>(colours[GateArray.ink_values[1]].g)) >> 1;
                   byte b = (static_cast<dword>(colours[GateArray.ink_values[0]].b) + static_cast<dword>(colours[GateArray.ink_values[1]].b)) >> 1;
-                  GateArray.palette[33] = MapRGBSurface(back_surface, r, g, b); // update the mode 2 'anti-aliasing' colour
-               }
-               // TODO: update pbRegisterPage
+                  video_update_palette_entry(33, r, g, b); // update the mode 2 'anti-aliasing' colour
+               }               // TODO: update pbRegisterPage
             }
             if (CPC.mf2) { // MF2 enabled?
                int iPen = *(pbMF2ROM + 0x03fcf);
@@ -1664,6 +1663,19 @@ void cpc_resume()
    audio_resume();
 }
 
+void video_update_palette_entry(int index, Uint8 r, Uint8 g, Uint8 b) {
+  if (index < 0 || index >= 34) return;
+  const SDL_PixelFormatDetails* fmt = SDL_GetPixelFormatDetails(back_surface->format);
+  SDL_Palette* pal = SDL_GetSurfacePalette(back_surface);
+  GateArray.palette[index] = SDL_MapRGB(fmt, pal, r, g, b);
+
+  float factor = (100 - CPC.scr_oglscanlines) / 100.0f;
+  GateArray.dark_palette[index] = SDL_MapRGB(fmt, pal, 
+      static_cast<Uint8>(r * factor), 
+      static_cast<Uint8>(g * factor), 
+      static_cast<Uint8>(b * factor));
+}
+
 int video_set_palette ()
 {
    if (!CPC.scr_tube) {
@@ -1680,9 +1692,9 @@ int video_set_palette ()
          if (blue > 255) {
             blue = 255;
          }
-         colours[n].r = red;
-         colours[n].g = green;
-         colours[n].b = blue;
+         colours[n].r = static_cast<Uint8>(red);
+         colours[n].g = static_cast<Uint8>(green);
+         colours[n].b = static_cast<Uint8>(blue);
       }
    } else {
       for (int n = 0; n < 32; n++) {
@@ -1701,8 +1713,8 @@ int video_set_palette ()
          }
 
          colours[n].r = 0;
-         colours[n].g = green;
-         colours[n].b = blue;
+         colours[n].g = static_cast<Uint8>(green);
+         colours[n].b = static_cast<Uint8>(blue);
       }
    }
 
@@ -1710,10 +1722,10 @@ int video_set_palette ()
 
    for (int n = 0; n < 17; n++) { // loop for all colours + border
       int i=GateArray.ink_values[n];
-      GateArray.palette[n] = MapRGBSurface(back_surface, colours[i].r,colours[i].g,colours[i].b);
+      video_update_palette_entry(n, colours[i].r, colours[i].g, colours[i].b);
    }
 
-      return 0;
+   return 0;
 }
 
 
@@ -2068,6 +2080,7 @@ void loadConfiguration (t_CPC &CPC, const std::string& configFilename)
    if (CPC.scr_oglscanlines > 100) {
       CPC.scr_oglscanlines = 30;
    }
+   CPC.scr_scanlines = conf.getIntValue("video", "scr_scanlines", 0) & 1;
    CPC.scr_led = conf.getIntValue("video", "scr_led", 1) & 1;
    CPC.scr_fps = conf.getIntValue("video", "scr_fps", 0) & 1;
    CPC.scr_tube = conf.getIntValue("video", "scr_tube", 0) & 1;
@@ -2178,6 +2191,7 @@ bool saveConfiguration (t_CPC &CPC, const std::string& configFilename)
    conf.setIntValue("video", "scr_style", CPC.scr_style);
    conf.setIntValue("video", "scr_oglfilter", CPC.scr_oglfilter);
    conf.setIntValue("video", "scr_oglscanlines", CPC.scr_oglscanlines);
+   conf.setIntValue("video", "scr_scanlines", CPC.scr_scanlines);
    conf.setIntValue("video", "scr_led", CPC.scr_led);
    conf.setIntValue("video", "scr_fps", CPC.scr_fps);
    conf.setIntValue("video", "scr_tube", CPC.scr_tube);

--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -1663,7 +1663,7 @@ void cpc_resume()
    audio_resume();
 }
 
-void video_update_palette_entry(int index, Uint8 r, Uint8 g, Uint8 b) {
+void video_update_palette_entry(int index, uint8_t r, uint8_t g, uint8_t b) {
   if (index < 0 || index >= 34) return;
   if (!back_surface) return;
   const SDL_PixelFormatDetails* fmt = SDL_GetPixelFormatDetails(back_surface->format);
@@ -1672,9 +1672,9 @@ void video_update_palette_entry(int index, Uint8 r, Uint8 g, Uint8 b) {
 
   float factor = (100 - CPC.scr_oglscanlines) / 100.0f;
   GateArray.dark_palette[index] = SDL_MapRGB(fmt, pal, 
-      static_cast<Uint8>(r * factor), 
-      static_cast<Uint8>(g * factor), 
-      static_cast<Uint8>(b * factor));
+      static_cast<uint8_t>(r * factor),
+      static_cast<uint8_t>(g * factor),
+      static_cast<uint8_t>(b * factor));
 }
 
 int video_set_palette ()

--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -1665,6 +1665,7 @@ void cpc_resume()
 
 void video_update_palette_entry(int index, Uint8 r, Uint8 g, Uint8 b) {
   if (index < 0 || index >= 34) return;
+  if (!back_surface) return;
   const SDL_PixelFormatDetails* fmt = SDL_GetPixelFormatDetails(back_surface->format);
   SDL_Palette* pal = SDL_GetSurfacePalette(back_surface);
   GateArray.palette[index] = SDL_MapRGB(fmt, pal, r, g, b);

--- a/src/koncepcja.h
+++ b/src/koncepcja.h
@@ -41,7 +41,7 @@ class InputMapper;
 //#define DEBUG_TAPE
 //#define DEBUG_Z80
 
-#define VERSION_STRING "v4.6.0"
+#define VERSION_STRING "v4.7.0"
 
 #ifndef _MAX_PATH
  #ifdef _POSIX_PATH_MAX

--- a/src/koncepcja.h
+++ b/src/koncepcja.h
@@ -217,6 +217,7 @@ class t_CPC {
    unsigned int scr_scale;
    unsigned int scr_oglfilter;
    unsigned int scr_oglscanlines;
+   unsigned int scr_scanlines;
    unsigned int scr_led;
    unsigned int scr_fps;
    unsigned int scr_tube;
@@ -369,6 +370,7 @@ typedef struct {
    unsigned char pen;
    unsigned char ink_values[17];
    unsigned int palette[34];
+   unsigned int dark_palette[34];
    unsigned char sl_count;
    unsigned char int_delay;
 } t_GateArray;
@@ -461,6 +463,7 @@ bool dumpScreenTo(const std::string& path);
 void dumpScreen();
 int  emulator_init();
 int  video_set_palette();
+void video_update_palette_entry(int index, Uint8 r, Uint8 g, Uint8 b);
 void init_joystick_emulation();
 void update_cpc_speed();
 int  printer_start();

--- a/src/koncepcja.h
+++ b/src/koncepcja.h
@@ -463,7 +463,7 @@ bool dumpScreenTo(const std::string& path);
 void dumpScreen();
 int  emulator_init();
 int  video_set_palette();
-void video_update_palette_entry(int index, Uint8 r, Uint8 g, Uint8 b);
+void video_update_palette_entry(int index, uint8_t r, uint8_t g, uint8_t b);
 void init_joystick_emulation();
 void update_cpc_speed();
 int  printer_start();

--- a/src/koncepcja_ipc_server.cpp
+++ b/src/koncepcja_ipc_server.cpp
@@ -165,7 +165,7 @@ void init_command_registry() {
     "Returns the emulator version string and the active IPC port number.",
     [](const auto&, const auto&) {
       int p = g_ipc_instance ? g_ipc_instance->port() : 0;
-      return "OK koncepcja-0.1 port=" + std::to_string(p) + "\n";
+      return "OK koncepcja-0.2 port=" + std::to_string(p) + "\n";
     });
 
   register_command("quit", "CORE", "quit [code]", "Exit the emulator with optional exit code",


### PR DESCRIPTION
## Summary
- Add software scanline rendering using a dark palette variant
- Scanline intensity is configurable in Video options
- Fix NULL pointer dereference in video_repaint_from_ram (initialize RendPos/RendOut/RendWid)
- Fix z80 save/restore in repaint to avoid shallow-copying vector member
- Fix Uint8 usage in koncepcja.h (use uint8_t since SDL headers are not included)

## Test plan
- [x] Builds clean on macOS (774/776 tests pass)
- [ ] Verify scanlines toggle on/off in Video options
- [ ] Verify scanline intensity slider affects darkness
- [ ] Verify rendering in 8bpp, 16bpp, 24bpp, 32bpp modes
- [ ] CI passes (Linux, Windows, macOS)