### PR TITLE
fix: Add .clangd config for IDE include paths

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,20 @@
+CompileFlags:
+  Add:
+    - "-std=c++17"
+    - "-DGL_SILENCE_DEPRECATION"
+    - "-DHAS_LIBJPEG"
+    - "-DHAS_LIBCURL"
+    - "-DWITH_GL"
+    # Project sources
+    - "-Isrc/"
+    # CAPS disk image library
+    - "-Isrc/capsimg/LibIPF"
+    - "-Isrc/capsimg/Device"
+    - "-Isrc/capsimg/CAPSImg"
+    - "-Isrc/capsimg/Codec"
+    - "-Isrc/capsimg/Core"
+    # Dear ImGui
+    - "-Ivendor/imgui"
+    - "-Ivendor/imgui/backends"
+    # SDL3 (vendored build)
+    - "-Ivendor/SDL/include"


### PR DESCRIPTION
## Summary

- Add a `.clangd` configuration file with all include paths (`src/`, `vendor/imgui/`, `vendor/SDL/include/`, capsimg subdirs) and defines (`-std=c++17`, `-DGL_SILENCE_DEPRECATION`, `-DWITH_GL`, etc.) matching the macOS Makefile build
- Eliminates false `'SDL3/SDL.h' file not found` and similar diagnostics in clangd-based IDEs (VS Code, Neovim, Emacs)

## Test plan

- [ ] Open any `.cpp` file in an IDE using clangd and verify no false "file not found" errors for SDL3, ImGui, or capsimg headers
- [ ] Verify `clangd --check=src/kon_cpc_ja.cpp` produces no include-related diagnostics
- [ ] Confirm the project still builds normally with `make -j$(sysctl -n hw.ncpu) ARCH=macos`