### PR TITLE
fix: Address PR #54 review feedback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,7 +119,7 @@ echo "help" | nc localhost 6543
 | Command | Description | Example |
 |---------|-------------|---------|
 | `ping` | Test connection | `ping` → `OK pong` |
-| `version` | Get version | `version` → `OK koncepcja-0.2` |
+| `version` | Get version | `version` → `OK koncepcja-0.2 port=6543` |
 | `help` | List commands | `help` → `OK commands: ...` |
 | `pause` | Pause emulation | `pause` → `OK` |
 | `run` | Resume emulation | `run` → `OK` |

--- a/src/crtc.cpp
+++ b/src/crtc.cpp
@@ -1480,7 +1480,8 @@ void video_repaint_from_ram()
    t_VDU vdu_save = VDU;
    t_GateArray ga_save = GateArray;
    
-   // Don't shallow copy z80 regs (contains a vector)
+   // Save only the z80 fields that crtc_cycle touches (PC, int_pending).
+   // A full copy of t_z80regs is safe (std::vector deep-copies) but wasteful.
    word pc_save = z80.PC.w.l;
    byte int_pending_save = z80.int_pending;
 

--- a/src/crtc.cpp
+++ b/src/crtc.cpp
@@ -1480,8 +1480,9 @@ void video_repaint_from_ram()
    t_VDU vdu_save = VDU;
    t_GateArray ga_save = GateArray;
    
-   // Save only the z80 fields that crtc_cycle touches (PC, int_pending).
-   // A full copy of t_z80regs is safe (std::vector deep-copies) but wasteful.
+   // Save z80 fields that the repaint loop may affect (int_pending via
+   // interrupt logic, PC as a safety net). A full t_z80regs copy is safe
+   // (std::vector deep-copies) but wasteful for just two fields.
    word pc_save = z80.PC.w.l;
    byte int_pending_save = z80.int_pending;
 

--- a/src/imgui_ui.cpp
+++ b/src/imgui_ui.cpp
@@ -1749,6 +1749,10 @@ static void imgui_render_options()
       bool scanlines = CPC.scr_scanlines != 0;
       if (ImGui::Checkbox("Scanlines", &scanlines)) {
         CPC.scr_scanlines = scanlines ? 1 : 0;
+        if (!scanlines) {
+          CPC.scr_oglscanlines = 0;
+          video_set_palette();
+        }
       }
       if (scanlines) {
         int sl_intensity = static_cast<int>(CPC.scr_oglscanlines);

--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -1675,8 +1675,9 @@ void video_update_palette_entry(int index, uint8_t r, uint8_t g, uint8_t b) {
   SDL_Palette* pal = SDL_GetSurfacePalette(back_surface);
   GateArray.palette[index] = SDL_MapRGB(fmt, pal, r, g, b);
 
-  float factor = (100 - CPC.scr_oglscanlines) / 100.0f;
-  GateArray.dark_palette[index] = SDL_MapRGB(fmt, pal, 
+  unsigned int clamped = CPC.scr_oglscanlines > 100 ? 100 : CPC.scr_oglscanlines;
+  float factor = (100 - clamped) / 100.0f;
+  GateArray.dark_palette[index] = SDL_MapRGB(fmt, pal,
       static_cast<uint8_t>(r * factor),
       static_cast<uint8_t>(g * factor),
       static_cast<uint8_t>(b * factor));

--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -1675,7 +1675,7 @@ void video_update_palette_entry(int index, uint8_t r, uint8_t g, uint8_t b) {
   SDL_Palette* pal = SDL_GetSurfacePalette(back_surface);
   GateArray.palette[index] = SDL_MapRGB(fmt, pal, r, g, b);
 
-  unsigned int clamped = CPC.scr_oglscanlines > 100 ? 100 : CPC.scr_oglscanlines;
+  unsigned int clamped = std::clamp(CPC.scr_oglscanlines, 0u, 100u);
   float factor = (100 - clamped) / 100.0f;
   GateArray.dark_palette[index] = SDL_MapRGB(fmt, pal,
       static_cast<uint8_t>(r * factor),

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -37,6 +37,7 @@
 #ifdef HAVE_GL
 #include "SDL3/SDL_opengl.h"
 #endif
+#include <algorithm>
 #include <atomic>
 #include <math.h>
 #include <memory>
@@ -662,7 +663,8 @@ void headless_close()
 /* ------------------------------------------------------------------------------------ */
 static int tex_x,tex_y;
 static GLuint screen_texnum,modulate_texnum;
-static int gl_scanlines;
+static int gl_scanlines;       // last-applied value, compared each frame
+static bool gl_scanlines_inited; // whether the modulation texture exists
 
 SDL_Surface* glscale_init(video_plugin* t, int scale, bool fs)
 {
@@ -803,22 +805,17 @@ SDL_Surface* glscale_init(video_plugin* t, int scale, bool fs)
       break;
   }
 
-  if (gl_scanlines!=0)
+  // Always create the modulation texture so scanlines can be toggled at runtime.
   {
-    Uint8 texmod;
-    texmod=(100-gl_scanlines)*255/100;
-    eglGenTextures(1,&modulate_texnum);
-    eglBindTexture(GL_TEXTURE_2D,modulate_texnum);
-    eglTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, CPC.scr_oglfilter?GL_LINEAR:GL_NEAREST);
-    eglTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, CPC.scr_oglfilter?GL_LINEAR:GL_NEAREST);
-
-    Uint8 modulate_texture[]={
-      255,255,255,
-      0,0,0};
-    modulate_texture[3]=texmod;
-    modulate_texture[4]=texmod;
-    modulate_texture[5]=texmod;
-    eglTexImage2D(GL_TEXTURE_2D, 0,GL_RGB8,1,2, 0,GL_RGB,GL_UNSIGNED_BYTE, modulate_texture);
+    unsigned int clamped = std::clamp(CPC.scr_oglscanlines, 0u, 100u);
+    Uint8 texmod = static_cast<Uint8>((100 - clamped) * 255 / 100);
+    eglGenTextures(1, &modulate_texnum);
+    eglBindTexture(GL_TEXTURE_2D, modulate_texnum);
+    eglTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, CPC.scr_oglfilter ? GL_LINEAR : GL_NEAREST);
+    eglTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, CPC.scr_oglfilter ? GL_LINEAR : GL_NEAREST);
+    Uint8 modulate_texture[] = { 255, 255, 255, texmod, texmod, texmod };
+    eglTexImage2D(GL_TEXTURE_2D, 0, GL_RGB8, 1, 2, 0, GL_RGB, GL_UNSIGNED_BYTE, modulate_texture);
+    gl_scanlines_inited = true;
   }
   if (CPC.scr_preserve_aspect_ratio) {
     eglViewport(t->x_offset, t->y_offset, t->width, t->height);
@@ -863,17 +860,36 @@ void glscale_setpal(SDL_Color* c)
 
 void glscale_flip([[maybe_unused]] video_plugin* t)
 {
+  // Update GL scanline state from CPC config each frame
+  {
+    int cur = static_cast<int>(std::clamp(CPC.scr_oglscanlines, 0u, 100u));
+    if (cur != gl_scanlines && gl_scanlines_inited) {
+      gl_scanlines = cur;
+      Uint8 texmod = static_cast<Uint8>((100 - cur) * 255 / 100);
+      Uint8 modulate_texture[] = { 255, 255, 255, texmod, texmod, texmod };
+      eglBindTexture(GL_TEXTURE_2D, modulate_texnum);
+      eglTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, 1, 2, GL_RGB, GL_UNSIGNED_BYTE, modulate_texture);
+    }
+  }
+
   eglDisable(GL_BLEND);
   eglClearColor(0,0,0,1);
   eglClear(GL_COLOR_BUFFER_BIT);
-  
-  if (gl_scanlines!=0)
+
+  if (gl_scanlines != 0)
   {
     eglActiveTextureARB(GL_TEXTURE1_ARB);
     eglEnable(GL_TEXTURE_2D);
     eglBindTexture(GL_TEXTURE_2D,modulate_texnum);
     eglTexEnvf (GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_MODULATE);
     eglColor4f(1.0,1.0,1.0,1.0);
+    eglActiveTextureARB(GL_TEXTURE0_ARB);
+  }
+  else if (gl_scanlines_inited)
+  {
+    // Ensure texture unit 1 is disabled when scanlines are off
+    eglActiveTextureARB(GL_TEXTURE1_ARB);
+    eglDisable(GL_TEXTURE_2D);
     eglActiveTextureARB(GL_TEXTURE0_ARB);
   }
 


### PR DESCRIPTION
## Summary
- Reword misleading "shallow copy" comment in `crtc.cpp` — the issue is copy cost, not shallow-copy semantics
- Clamp `scr_oglscanlines` to [0,100] in `video_update_palette_entry` to prevent unsigned underflow producing garbled dark palette colors
- Wire scanlines checkbox to zero `scr_oglscanlines` when unchecked, so GL/software scanlines are fully disabled
- Fix `AGENTS.md` version example to include `port=` field matching actual IPC output

## Test plan
- [x] Build passes (774 tests pass)
- [ ] Verify scanlines toggle fully disables dark palette
- [ ] Verify setting `scr_oglscanlines>100` in config doesn't produce garbled colors