### PR TITLE
fix: Address PR #56 review feedback for .clangd

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,9 +1,13 @@
 # Minimal clangd config for IDE support (vendored library includes).
 # For full build-accurate flags, generate compile_commands.json:
-#   bear -- make ARCH=macos
+#   bear -- make              # Linux/macOS (auto-detects arch)
+#   bear -- make ARCH=win64   # cross-compiling for Windows
 #
-# Note: HAS_LIBJPEG, HAS_LIBCURL, WITH_GL are conditionally enabled
-# by the Makefile. Enable them in a local .clangd override if needed.
+# Optional defines (conditionally enabled by the Makefile):
+#   -DHAS_LIBJPEG, -DHAS_LIBCURL, -DWITH_GL
+# To enable them for clangd, add to your user config (~/.config/clangd/config.yaml):
+#   CompileFlags:
+#     Add: [-DWITH_GL, -DHAS_LIBJPEG, -DHAS_LIBCURL]
 CompileFlags:
   Add:
     - "-std=c++17"

--- a/.clangd
+++ b/.clangd
@@ -1,10 +1,13 @@
+# Minimal clangd config for IDE support (vendored library includes).
+# For full build-accurate flags, generate compile_commands.json:
+#   bear -- make ARCH=macos
+#
+# Note: HAS_LIBJPEG, HAS_LIBCURL, WITH_GL are conditionally enabled
+# by the Makefile. Enable them in a local .clangd override if needed.
 CompileFlags:
   Add:
     - "-std=c++17"
     - "-DGL_SILENCE_DEPRECATION"
-    - "-DHAS_LIBJPEG"
-    - "-DHAS_LIBCURL"
-    - "-DWITH_GL"
     # Project sources
     - "-Isrc/"
     # CAPS disk image library


### PR DESCRIPTION
## Summary
- Remove `HAS_LIBJPEG`, `HAS_LIBCURL`, `WITH_GL` defines that are conditionally detected by the Makefile — forcing them on causes clangd errors on machines without those deps
- Add comment about generating `compile_commands.json` with `bear` for full build-accurate flags
- Document that optional defines can be added in a local `.clangd` override

## Test plan
- [x] clangd still picks up SDL/ImGui includes
- [ ] No false `file not found` errors for jpeglib.h/curl.h on clean checkout