### PR TITLE
feat: UX improvements — toasts, drag-and-drop, MRU, debugger enhancements

### DIFF
--- a/src/devtools_ui.cpp
+++ b/src/devtools_ui.cpp
@@ -586,6 +586,8 @@ void DevToolsUI::render_memory_hex()
     ImGui::SameLine();
     if (ImGui::SmallButton(memhex_search_hex_ ? "Hex" : "ASCII")) {
       memhex_search_hex_ = !memhex_search_hex_;
+      memhex_matches_.clear();
+      memhex_match_idx_ = -1;
     }
     if (ImGui::IsItemHovered())
       ImGui::SetTooltip("Toggle Hex/ASCII search mode");
@@ -619,7 +621,8 @@ void DevToolsUI::render_memory_hex()
           char* end;
           unsigned long v = strtoul(p, &end, 16);
           if (end == p) break;
-          pattern.push_back(static_cast<byte>(v & 0xFF));
+          if (v > 0xFF) { pattern.clear(); imgui_toast_error("Hex byte > FF"); break; }
+          pattern.push_back(static_cast<byte>(v));
           p = end;
         }
       } else {
@@ -758,18 +761,18 @@ void DevToolsUI::render_memory_hex()
               ImGui::ColorConvertFloat4ToU32(ImVec4(1.0f, 0.8f, 0.0f, 0.5f * alpha)));
           }
 
-          // Search match highlighting (yellow background)
-          if (search_plen > 0) {
-            for (word ma : memhex_matches_) {
-              if (a >= ma && a < ma + search_plen) {
-                ImVec2 rmin = ImGui::GetItemRectMin();
-                ImVec2 rmax = ImGui::GetItemRectMax();
-                bool is_current = (memhex_match_idx_ >= 0 &&
-                    memhex_matches_[memhex_match_idx_] == ma);
-                ImU32 hcol = is_current ? IM_COL32(255, 200, 0, 100) : IM_COL32(200, 200, 0, 60);
-                ImGui::GetWindowDrawList()->AddRectFilled(rmin, rmax, hcol);
-                break;
-              }
+          // Search match highlighting (yellow background, O(log N) via sorted matches)
+          if (search_plen > 0 && !memhex_matches_.empty()) {
+            // Find first match whose start + plen > a (i.e. could contain a)
+            word range_start = (a >= static_cast<word>(search_plen - 1)) ? a - (search_plen - 1) : 0;
+            auto it = std::lower_bound(memhex_matches_.begin(), memhex_matches_.end(), range_start);
+            if (it != memhex_matches_.end() && a >= *it && a < *it + search_plen) {
+              ImVec2 rmin = ImGui::GetItemRectMin();
+              ImVec2 rmax = ImGui::GetItemRectMax();
+              bool is_current = (memhex_match_idx_ >= 0 &&
+                  memhex_matches_[memhex_match_idx_] == *it);
+              ImU32 hcol = is_current ? IM_COL32(255, 200, 0, 100) : IM_COL32(200, 200, 0, 60);
+              ImGui::GetWindowDrawList()->AddRectFilled(rmin, rmax, hcol);
             }
           }
 

--- a/src/devtools_ui.cpp
+++ b/src/devtools_ui.cpp
@@ -2850,8 +2850,16 @@ void DevToolsUI::render_assembler()
     ImGui::Text("Errors:");
     ImGui::BeginChild("##asm_errors", ImVec2(0, 0), ImGuiChildFlags_None);
     for (auto& err : asm_errors_) {
-      ImGui::TextColored(ImVec4(1.0f, 0.4f, 0.4f, 1.0f),
-                         "Line %d: %s", err.line, err.message.c_str());
+      ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 0.4f, 0.4f, 1.0f));
+      ImGui::Text("Line %d: %s", err.line, err.message.c_str());
+      ImGui::PopStyleColor();
+      if (ImGui::IsItemHovered()) {
+        ImGui::SetMouseCursor(ImGuiMouseCursor_Hand);
+        ImGui::SetTooltip("Click to jump to line %d", err.line);
+      }
+      if (ImGui::IsItemClicked() && asm_editor_ && err.line > 0) {
+        asm_editor_->SetCursorPosition(err.line - 1, 0);
+      }
     }
     ImGui::EndChild();
   }

--- a/src/devtools_ui.cpp
+++ b/src/devtools_ui.cpp
@@ -628,7 +628,38 @@ void DevToolsUI::render_memory_hex()
             ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.3f, 1.0f, 0.3f, 1.0f));
           }
 
-          ImGui::Text("%02X", val);
+          // Inline editing or display
+          if (memhex_edit_addr_ == static_cast<int>(a)) {
+            ImGui::SetNextItemWidth(ImGui::CalcTextSize("FF").x + 8.0f);
+            if (memhex_edit_focus_) {
+              ImGui::SetKeyboardFocusHere();
+              memhex_edit_focus_ = false;
+            }
+            ImGuiInputTextFlags eflags = ImGuiInputTextFlags_CharsHexadecimal |
+                                         ImGuiInputTextFlags_EnterReturnsTrue |
+                                         ImGuiInputTextFlags_AutoSelectAll;
+            if (ImGui::InputText("##mhedit", memhex_edit_buf_, sizeof(memhex_edit_buf_), eflags)) {
+              // Enter pressed — commit
+              unsigned long nv;
+              if (parse_hex(memhex_edit_buf_, &nv, 0xFF)) {
+                if (memhex_cpu_view_)
+                  z80_cpu_write_mem(a, static_cast<byte>(nv));
+                else
+                  z80_write_mem(a, static_cast<byte>(nv));
+              }
+              memhex_edit_addr_ = -1;
+            }
+            if (ImGui::IsKeyPressed(ImGuiKey_Escape)) {
+              memhex_edit_addr_ = -1;
+            }
+          } else {
+            ImGui::Text("%02X", val);
+            if (ImGui::IsItemHovered() && ImGui::IsMouseDoubleClicked(0)) {
+              memhex_edit_addr_ = static_cast<int>(a);
+              snprintf(memhex_edit_buf_, sizeof(memhex_edit_buf_), "%02X", val);
+              memhex_edit_focus_ = true;
+            }
+          }
 
           // Flash-highlight the navigation target byte
           if (memhex_highlight_frames_ > 0 && a == static_cast<word>(memhex_highlight_addr_)) {
@@ -673,6 +704,12 @@ void DevToolsUI::render_memory_hex()
 
       ImGui::TextDisabled("%04X", ctx_addr);
       ImGui::Separator();
+      if (ImGui::MenuItem("Edit byte")) {
+        byte v = memhex_cpu_view_ ? z80_cpu_read_mem(ctx_addr) : z80_read_mem(ctx_addr);
+        memhex_edit_addr_ = static_cast<int>(ctx_addr);
+        snprintf(memhex_edit_buf_, sizeof(memhex_edit_buf_), "%02X", v);
+        memhex_edit_focus_ = true;
+      }
       if (ImGui::MenuItem("Disassemble here")) {
         navigate_to(ctx_addr, NavTarget::DISASM);
       }

--- a/src/devtools_ui.cpp
+++ b/src/devtools_ui.cpp
@@ -686,12 +686,36 @@ void DevToolsUI::render_memory_hex()
       memhex_goto_value_ = -1;
     }
 
+    // ROM banking state for background tinting
+    bool lo_rom_active = !(GateArray.ROM_config & 0x04); // &0000-&3FFF
+    bool hi_rom_active = !(GateArray.ROM_config & 0x08); // &C000-&FFFF
+
     while (clipper.Step()) {
       for (int row = clipper.DisplayStart; row < clipper.DisplayEnd; row++) {
         unsigned int base_addr = row * bytes_per_row;
 
+        // Check if this row is in a ROM-overlaid region
+        word row_start = static_cast<word>(base_addr & 0xFFFF);
+        word row_end = static_cast<word>((base_addr + bytes_per_row - 1) & 0xFFFF);
+        bool in_rom = (lo_rom_active && row_start < 0x4000) ||
+                      (hi_rom_active && row_end >= 0xC000);
+
+        // ROM row background tint (dark purple)
+        if (in_rom) {
+          ImVec2 rpos = ImGui::GetCursorScreenPos();
+          float row_h = ImGui::GetTextLineHeightWithSpacing();
+          float row_w = ImGui::GetContentRegionAvail().x;
+          ImGui::GetWindowDrawList()->AddRectFilled(
+            rpos, ImVec2(rpos.x + row_w, rpos.y + row_h),
+            IM_COL32(60, 20, 60, 80));
+        }
+
         // Address
-        ImGui::Text("%04X:", base_addr & 0xFFFF);
+        if (in_rom) {
+          ImGui::TextColored(ImVec4(0.7f, 0.5f, 0.8f, 1.0f), "%04X:", base_addr & 0xFFFF);
+        } else {
+          ImGui::Text("%04X:", base_addr & 0xFFFF);
+        }
 
         // Hex bytes with watchpoint highlighting
         for (int col = 0; col < bytes_per_row; col++) {

--- a/src/devtools_ui.cpp
+++ b/src/devtools_ui.cpp
@@ -686,19 +686,16 @@ void DevToolsUI::render_memory_hex()
       memhex_goto_value_ = -1;
     }
 
-    // ROM banking state for background tinting
-    bool lo_rom_active = !(GateArray.ROM_config & 0x04); // &0000-&3FFF
-    bool hi_rom_active = !(GateArray.ROM_config & 0x08); // &C000-&FFFF
+    // ROM detection: when read and write banks differ for a slot, ROM is overlaid
+    extern byte *membank_read[4], *membank_write[4];
 
     while (clipper.Step()) {
       for (int row = clipper.DisplayStart; row < clipper.DisplayEnd; row++) {
         unsigned int base_addr = row * bytes_per_row;
 
-        // Check if this row is in a ROM-overlaid region
-        word row_start = static_cast<word>(base_addr & 0xFFFF);
-        word row_end = static_cast<word>((base_addr + bytes_per_row - 1) & 0xFFFF);
-        bool in_rom = (lo_rom_active && row_start < 0x4000) ||
-                      (hi_rom_active && row_end >= 0xC000);
+        // Check if this row overlaps any ROM-overlaid 16K slot
+        int slot = (base_addr >> 14) & 3;
+        bool in_rom = (membank_read[slot] != membank_write[slot]);
 
         // ROM row background tint (dark purple)
         if (in_rom) {

--- a/src/devtools_ui.cpp
+++ b/src/devtools_ui.cpp
@@ -638,7 +638,8 @@ void DevToolsUI::render_memory_hex()
         for (int addr = 0; addr <= 0xFFFF - plen + 1; addr++) {
           bool match = true;
           for (int j = 0; j < plen; j++) {
-            byte m = z80_read_mem(static_cast<word>(addr + j));
+            word sa = static_cast<word>(addr + j);
+            byte m = memhex_cpu_view_ ? z80_cpu_read_mem(sa) : z80_read_mem(sa);
             if (m != pattern[j]) { match = false; break; }
           }
           if (match) memhex_matches_.push_back(static_cast<word>(addr));
@@ -1149,7 +1150,8 @@ void DevToolsUI::render_breakpoints()
       unsigned long addr;
       if (parse_hex(bp_addr_, &addr, 0xFFFF)) {
         std::string cond_str(bp_cond_);
-        int pass = std::atoi(bp_pass_);
+        int pass = (bp_pass_[0] != '\0') ? std::atoi(bp_pass_) : 0;
+        if (pass < 0) pass = 0;
         if (cond_str.empty() && pass == 0) {
           z80_add_breakpoint(static_cast<word>(addr));
         } else {
@@ -1564,13 +1566,14 @@ void DevToolsUI::render_disc_tools()
 
     // Import button
     if (ImGui::Button("Import File...")) {
+      dt_dialog_drive_ = dt_drive_;  // capture drive at dialog-open time
       static const SDL_DialogFileFilter filters[] = { { "All files", "*" } };
       SDL_ShowOpenFileDialog(
         [](void* ud, const char* const* filelist, int) {
           if (!filelist || !filelist[0]) return;
           auto* self = static_cast<DevToolsUI*>(ud);
           std::string host_path(filelist[0]);
-          t_drive* d = (self->dt_drive_ == 0) ? &driveA : &driveB;
+          t_drive* d = (self->dt_dialog_drive_ == 0) ? &driveA : &driveB;
 
           // Read host file
           std::ifstream f(host_path, std::ios::binary);
@@ -1627,13 +1630,14 @@ void DevToolsUI::render_disc_tools()
           // Export: read file from disc, save to host
           dt_export_filename_ = fe.filename;
           dt_export_display_ = fe.display_name;
+          dt_dialog_drive_ = dt_drive_;  // capture drive at dialog-open time
           // Show save dialog
           static const SDL_DialogFileFilter ef[] = { { "All files", "*" } };
           SDL_ShowSaveFileDialog(
             [](void* ud, const char* const* filelist, int) {
               if (!filelist || !filelist[0]) return;
               auto* self = static_cast<DevToolsUI*>(ud);
-              t_drive* d = (self->dt_drive_ == 0) ? &driveA : &driveB;
+              t_drive* d = (self->dt_dialog_drive_ == 0) ? &driveA : &driveB;
               std::string err;
               auto data = disk_read_file(d, self->dt_export_filename_, err);
               if (!err.empty()) {

--- a/src/devtools_ui.cpp
+++ b/src/devtools_ui.cpp
@@ -573,8 +573,78 @@ void DevToolsUI::render_memory_hex()
     ImGui::Separator();
     ImGui::TextDisabled("(?)");
     if (ImGui::IsItemHovered())
-      ImGui::SetTooltip("Right-click for navigation options.");
+      ImGui::SetTooltip("Right-click for navigation options.\nDouble-click a byte to edit.");
     ImGui::EndMenuBar();
+  }
+
+  // ── Search bar ──
+  {
+    ImGui::SetNextItemWidth(120);
+    bool do_search = ImGui::InputText("Find##mh", memhex_search_, sizeof(memhex_search_),
+        ImGuiInputTextFlags_EnterReturnsTrue);
+    ImGui::SameLine();
+    if (ImGui::SmallButton(memhex_search_hex_ ? "Hex" : "ASCII")) {
+      memhex_search_hex_ = !memhex_search_hex_;
+    }
+    if (ImGui::IsItemHovered())
+      ImGui::SetTooltip("Toggle Hex/ASCII search mode");
+    ImGui::SameLine();
+    do_search |= ImGui::SmallButton("Go##mhsearch");
+    ImGui::SameLine();
+    if (ImGui::SmallButton("<##mhprev") && !memhex_matches_.empty()) {
+      memhex_match_idx_ = (memhex_match_idx_ - 1 + static_cast<int>(memhex_matches_.size())) %
+                           static_cast<int>(memhex_matches_.size());
+      memhex_goto_value_ = memhex_matches_[memhex_match_idx_];
+    }
+    ImGui::SameLine();
+    if (ImGui::SmallButton(">##mhnext") && !memhex_matches_.empty()) {
+      memhex_match_idx_ = (memhex_match_idx_ + 1) % static_cast<int>(memhex_matches_.size());
+      memhex_goto_value_ = memhex_matches_[memhex_match_idx_];
+    }
+    if (!memhex_matches_.empty()) {
+      ImGui::SameLine();
+      ImGui::Text("%d/%d", memhex_match_idx_ + 1, static_cast<int>(memhex_matches_.size()));
+    }
+
+    if (do_search && memhex_search_[0]) {
+      // Parse search pattern
+      std::vector<byte> pattern;
+      if (memhex_search_hex_) {
+        // Parse space-separated hex bytes: "C3 00 40"
+        const char* p = memhex_search_;
+        while (*p) {
+          while (*p == ' ') p++;
+          if (!*p) break;
+          char* end;
+          unsigned long v = strtoul(p, &end, 16);
+          if (end == p) break;
+          pattern.push_back(static_cast<byte>(v & 0xFF));
+          p = end;
+        }
+      } else {
+        // ASCII: use raw bytes
+        for (const char* p = memhex_search_; *p; p++)
+          pattern.push_back(static_cast<byte>(*p));
+      }
+      // Linear scan
+      memhex_matches_.clear();
+      memhex_match_idx_ = -1;
+      if (!pattern.empty()) {
+        int plen = static_cast<int>(pattern.size());
+        for (int addr = 0; addr <= 0xFFFF - plen + 1; addr++) {
+          bool match = true;
+          for (int j = 0; j < plen; j++) {
+            byte m = z80_read_mem(static_cast<word>(addr + j));
+            if (m != pattern[j]) { match = false; break; }
+          }
+          if (match) memhex_matches_.push_back(static_cast<word>(addr));
+        }
+        if (!memhex_matches_.empty()) {
+          memhex_match_idx_ = 0;
+          memhex_goto_value_ = memhex_matches_[0];
+        }
+      }
+    }
   }
 
   int bytes_per_row = memhex_bytes_per_row_;
@@ -669,6 +739,33 @@ void DevToolsUI::render_memory_hex()
             ImGui::GetWindowDrawList()->AddRectFilled(
               rmin, rmax,
               ImGui::ColorConvertFloat4ToU32(ImVec4(1.0f, 0.8f, 0.0f, 0.5f * alpha)));
+          }
+
+          // Search match highlighting (yellow background)
+          if (!memhex_matches_.empty() && memhex_search_[0]) {
+            int plen = 0;
+            if (memhex_search_hex_) {
+              for (const char* sp = memhex_search_; *sp; ) {
+                while (*sp == ' ') sp++;
+                if (!*sp) break;
+                char* se; strtoul(sp, &se, 16);
+                if (se == sp) break;
+                plen++; sp = se;
+              }
+            } else {
+              plen = static_cast<int>(strlen(memhex_search_));
+            }
+            for (word ma : memhex_matches_) {
+              if (a >= ma && a < ma + plen) {
+                ImVec2 rmin = ImGui::GetItemRectMin();
+                ImVec2 rmax = ImGui::GetItemRectMax();
+                bool is_current = (memhex_match_idx_ >= 0 &&
+                    memhex_matches_[memhex_match_idx_] == ma);
+                ImU32 hcol = is_current ? IM_COL32(255, 200, 0, 100) : IM_COL32(200, 200, 0, 60);
+                ImGui::GetWindowDrawList()->AddRectFilled(rmin, rmax, hcol);
+                break;
+              }
+            }
           }
 
           if (colored) ImGui::PopStyleColor();

--- a/src/devtools_ui.cpp
+++ b/src/devtools_ui.cpp
@@ -35,6 +35,7 @@
 #include "portable-file-dialogs.h"
 #include "z80_opcode_table.h"
 
+extern SDL_Window* mainSDLWindow;
 extern t_CPC CPC;
 extern t_z80regs z80;
 extern byte* pbRAM;
@@ -1481,18 +1482,55 @@ void DevToolsUI::render_disc_tools()
       dt_files_dirty_ = false;
     }
     if (ImGui::Button("Refresh##files")) dt_files_dirty_ = true;
+    ImGui::SameLine();
+
+    // Import button
+    if (ImGui::Button("Import File...")) {
+      static const SDL_DialogFileFilter filters[] = { { "All files", "*" } };
+      SDL_ShowOpenFileDialog(
+        [](void* ud, const char* const* filelist, int) {
+          if (!filelist || !filelist[0]) return;
+          auto* self = static_cast<DevToolsUI*>(ud);
+          std::string host_path(filelist[0]);
+          t_drive* d = (self->dt_drive_ == 0) ? &driveA : &driveB;
+
+          // Read host file
+          std::ifstream f(host_path, std::ios::binary);
+          if (!f) { imgui_toast_error("Cannot open: " + host_path); return; }
+          std::vector<uint8_t> data((std::istreambuf_iterator<char>(f)),
+                                     std::istreambuf_iterator<char>());
+
+          // Convert filename to CPC 8.3
+          auto fname = std::filesystem::path(host_path).filename().string();
+          std::string cpc_name = disk_to_cpc_filename(fname);
+          if (cpc_name.empty()) {
+            imgui_toast_error("Cannot convert filename: " + fname);
+            return;
+          }
+
+          std::string err = disk_write_file(d, cpc_name, data, false);
+          if (err.empty()) {
+            imgui_toast_success("Imported: " + fname);
+            self->dt_files_dirty_ = true;
+          } else {
+            imgui_toast_error("Import failed: " + err);
+          }
+        },
+        this, mainSDLWindow, filters, 1, nullptr, false);
+    }
 
     if (!dt_file_error_.empty()) {
       ImGui::TextColored(ImVec4(1,0.3f,0.3f,1), "%s", dt_file_error_.c_str());
     }
 
-    if (ImGui::BeginTable("dt_files", 4,
+    if (ImGui::BeginTable("dt_files", 5,
         ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg | ImGuiTableFlags_ScrollY,
         ImVec2(0, 200))) {
       ImGui::TableSetupScrollFreeze(0, 1);
       ImGui::TableSetupColumn("Name", ImGuiTableColumnFlags_WidthStretch);
       ImGui::TableSetupColumn("Size", ImGuiTableColumnFlags_WidthFixed, 60);
       ImGui::TableSetupColumn("User", ImGuiTableColumnFlags_WidthFixed, 30);
+      ImGui::TableSetupColumn("##export", ImGuiTableColumnFlags_WidthFixed, 42);
       ImGui::TableSetupColumn("##del", ImGuiTableColumnFlags_WidthFixed, 20);
       ImGui::TableHeadersRow();
 
@@ -1506,6 +1544,34 @@ void DevToolsUI::render_disc_tools()
         ImGui::TableSetColumnIndex(2);
         ImGui::Text("%d", fe.user);
         ImGui::TableSetColumnIndex(3);
+        ImGui::PushID(static_cast<int>(i) + 3000);
+        if (ImGui::SmallButton("Save")) {
+          // Export: read file from disc, save to host
+          dt_export_filename_ = fe.filename;
+          dt_export_display_ = fe.display_name;
+          // Show save dialog
+          static const SDL_DialogFileFilter ef[] = { { "All files", "*" } };
+          SDL_ShowSaveFileDialog(
+            [](void* ud, const char* const* filelist, int) {
+              if (!filelist || !filelist[0]) return;
+              auto* self = static_cast<DevToolsUI*>(ud);
+              t_drive* d = (self->dt_drive_ == 0) ? &driveA : &driveB;
+              std::string err;
+              auto data = disk_read_file(d, self->dt_export_filename_, err);
+              if (!err.empty()) {
+                imgui_toast_error("Export failed: " + err);
+                return;
+              }
+              std::ofstream f(filelist[0], std::ios::binary);
+              if (!f) { imgui_toast_error("Cannot write: " + std::string(filelist[0])); return; }
+              f.write(reinterpret_cast<const char*>(data.data()),
+                      static_cast<std::streamsize>(data.size()));
+              imgui_toast_success("Exported: " + self->dt_export_display_);
+            },
+            this, mainSDLWindow, ef, 1, fe.display_name.c_str());
+        }
+        ImGui::PopID();
+        ImGui::TableSetColumnIndex(4);
         ImGui::PushID(static_cast<int>(i));
         if (ImGui::SmallButton("X")) {
           disk_delete_file(drv, fe.filename);

--- a/src/devtools_ui.cpp
+++ b/src/devtools_ui.cpp
@@ -790,7 +790,7 @@ void DevToolsUI::render_memory_hex()
               if (ImGui::IsItemClicked(0)) {
                 memhex_sel_addr_ = static_cast<int>(a);
               }
-              // Start editing: double-click OR type while selected
+              // Start editing: double-click OR type while selected (not on ROM cells)
               bool start_edit = false;
               if (ImGui::IsItemHovered() && ImGui::IsMouseDoubleClicked(0))
                 start_edit = true;
@@ -813,7 +813,7 @@ void DevToolsUI::render_memory_hex()
                   }
                 }
               }
-              if (start_edit) {
+              if (start_edit && !in_rom) {
                 memhex_edit_addr_ = static_cast<int>(a);
                 if (memhex_edit_buf_[0] == '\0') // double-click: prefill
                   snprintf(memhex_edit_buf_, sizeof(memhex_edit_buf_), "%02X", val);

--- a/src/devtools_ui.cpp
+++ b/src/devtools_ui.cpp
@@ -719,35 +719,87 @@ void DevToolsUI::render_memory_hex()
           }
 
           // Inline editing or display
-          if (memhex_edit_addr_ == static_cast<int>(a)) {
-            ImGui::SetNextItemWidth(ImGui::CalcTextSize("FF").x + 8.0f);
-            if (memhex_edit_focus_) {
-              ImGui::SetKeyboardFocusHere();
-              memhex_edit_focus_ = false;
-            }
-            ImGuiInputTextFlags eflags = ImGuiInputTextFlags_CharsHexadecimal |
-                                         ImGuiInputTextFlags_EnterReturnsTrue |
-                                         ImGuiInputTextFlags_AutoSelectAll;
-            if (ImGui::InputText("##mhedit", memhex_edit_buf_, sizeof(memhex_edit_buf_), eflags)) {
-              // Enter pressed — commit
-              unsigned long nv;
-              if (parse_hex(memhex_edit_buf_, &nv, 0xFF)) {
-                if (memhex_cpu_view_)
-                  z80_cpu_write_mem(a, static_cast<byte>(nv));
-                else
-                  z80_write_mem(a, static_cast<byte>(nv));
+          {
+            bool is_editing = (memhex_edit_addr_ == static_cast<int>(a));
+            bool is_selected = (memhex_sel_addr_ == static_cast<int>(a));
+            char hex_label[8];
+            snprintf(hex_label, sizeof(hex_label), "%02X", val);
+
+            if (is_editing) {
+              // Compact inline edit — fixed width matching "FF"
+              ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(0, 0));
+              ImGui::SetNextItemWidth(ImGui::CalcTextSize("FF").x);
+              if (memhex_edit_focus_) {
+                ImGui::SetKeyboardFocusHere();
+                memhex_edit_focus_ = false;
               }
-              memhex_edit_addr_ = -1;
-            }
-            if (ImGui::IsKeyPressed(ImGuiKey_Escape)) {
-              memhex_edit_addr_ = -1;
-            }
-          } else {
-            ImGui::Text("%02X", val);
-            if (ImGui::IsItemHovered() && ImGui::IsMouseDoubleClicked(0)) {
-              memhex_edit_addr_ = static_cast<int>(a);
-              snprintf(memhex_edit_buf_, sizeof(memhex_edit_buf_), "%02X", val);
-              memhex_edit_focus_ = true;
+              ImGuiInputTextFlags eflags = ImGuiInputTextFlags_CharsHexadecimal |
+                                           ImGuiInputTextFlags_EnterReturnsTrue |
+                                           ImGuiInputTextFlags_AutoSelectAll;
+              bool committed = ImGui::InputText("##mhedit", memhex_edit_buf_,
+                                                sizeof(memhex_edit_buf_), eflags);
+              ImGui::PopStyleVar();
+
+              if (committed) {
+                unsigned long nv;
+                if (parse_hex(memhex_edit_buf_, &nv, 0xFF)) {
+                  z80_write_mem(a, static_cast<byte>(nv));
+                }
+                memhex_edit_addr_ = -1;
+                memhex_sel_addr_ = -1;
+              }
+              if (!committed && !ImGui::IsItemActive()) {
+                // Lost focus without Enter — cancel
+                memhex_edit_addr_ = -1;
+              }
+              if (ImGui::IsKeyPressed(ImGuiKey_Escape)) {
+                memhex_edit_addr_ = -1;
+                memhex_sel_addr_ = -1;
+              }
+            } else {
+              // Normal display — clickable
+              if (is_selected) {
+                // Draw selection highlight
+                ImVec2 tpos = ImGui::GetCursorScreenPos();
+                ImVec2 tsz = ImGui::CalcTextSize(hex_label);
+                ImGui::GetWindowDrawList()->AddRectFilled(
+                  tpos, ImVec2(tpos.x + tsz.x, tpos.y + tsz.y),
+                  IM_COL32(80, 80, 180, 120));
+              }
+              ImGui::Text("%s", hex_label);
+
+              if (ImGui::IsItemClicked(0)) {
+                memhex_sel_addr_ = static_cast<int>(a);
+              }
+              // Start editing: double-click OR type while selected
+              bool start_edit = false;
+              if (ImGui::IsItemHovered() && ImGui::IsMouseDoubleClicked(0))
+                start_edit = true;
+              if (is_selected) {
+                // Any hex digit typed while selected → start editing
+                for (ImGuiKey k = ImGuiKey_0; k <= ImGuiKey_9; k = static_cast<ImGuiKey>(k + 1)) {
+                  if (ImGui::IsKeyPressed(k)) {
+                    memhex_edit_buf_[0] = '0' + (k - ImGuiKey_0);
+                    memhex_edit_buf_[1] = '\0';
+                    start_edit = true;
+                    break;
+                  }
+                }
+                for (ImGuiKey k = ImGuiKey_A; k <= ImGuiKey_F; k = static_cast<ImGuiKey>(k + 1)) {
+                  if (ImGui::IsKeyPressed(k)) {
+                    memhex_edit_buf_[0] = 'A' + (k - ImGuiKey_A);
+                    memhex_edit_buf_[1] = '\0';
+                    start_edit = true;
+                    break;
+                  }
+                }
+              }
+              if (start_edit) {
+                memhex_edit_addr_ = static_cast<int>(a);
+                if (memhex_edit_buf_[0] == '\0') // double-click: prefill
+                  snprintf(memhex_edit_buf_, sizeof(memhex_edit_buf_), "%02X", val);
+                memhex_edit_focus_ = true;
+              }
             }
           }
 

--- a/src/devtools_ui.cpp
+++ b/src/devtools_ui.cpp
@@ -21,6 +21,8 @@
 #include "disk_format.h"
 #include "data_areas.h"
 #include "z80_assembler.h"
+#include "expr_parser.h"
+#include "imgui_ui.h"
 #include "wav_recorder.h"
 #include "ym_recorder.h"
 #include "avi_recorder.h"
@@ -912,8 +914,50 @@ void DevToolsUI::render_breakpoints()
     ImGui::EndTable();
   }
 
-  // Add Watchpoint form
+  // Add Breakpoint form
   ImGui::Spacing();
+  if (ImGui::CollapsingHeader("Add Breakpoint", ImGuiTreeNodeFlags_DefaultOpen)) {
+    ImGui::SetNextItemWidth(60);
+    ImGui::InputText("Addr##bp", bp_addr_, sizeof(bp_addr_),
+                     ImGuiInputTextFlags_CharsHexadecimal);
+    ImGui::SameLine();
+    ImGui::SetNextItemWidth(180);
+    ImGui::InputText("Condition##bp", bp_cond_, sizeof(bp_cond_));
+    if (ImGui::IsItemHovered())
+      ImGui::SetTooltip("e.g. A==0x42, (HL)>0x100, BC==DE\nLeave empty for unconditional");
+    ImGui::SameLine();
+    ImGui::SetNextItemWidth(40);
+    ImGui::InputText("Pass##bp", bp_pass_, sizeof(bp_pass_),
+                     ImGuiInputTextFlags_CharsDecimal);
+    if (ImGui::IsItemHovered())
+      ImGui::SetTooltip("Break after N hits (0 = every hit)");
+    ImGui::SameLine();
+    if (ImGui::Button("Add BP")) {
+      unsigned long addr;
+      if (parse_hex(bp_addr_, &addr, 0xFFFF)) {
+        std::string cond_str(bp_cond_);
+        int pass = std::atoi(bp_pass_);
+        if (cond_str.empty() && pass == 0) {
+          z80_add_breakpoint(static_cast<word>(addr));
+        } else {
+          std::unique_ptr<ExprNode> cond;
+          if (!cond_str.empty()) {
+            std::string err;
+            cond = expr_parse(cond_str, err);
+            if (!cond) {
+              imgui_toast_error("Bad condition: " + err);
+              goto bp_form_end;
+            }
+          }
+          z80_add_breakpoint_cond(static_cast<word>(addr), std::move(cond), cond_str, pass);
+        }
+        bp_addr_[0] = bp_cond_[0] = bp_pass_[0] = '\0';
+      }
+    }
+    bp_form_end:;
+  }
+
+  // Add Watchpoint form
   if (ImGui::CollapsingHeader("Add Watchpoint")) {
     ImGui::SetNextItemWidth(60);
     ImGui::InputText("Addr##wp", wp_addr_, sizeof(wp_addr_),

--- a/src/devtools_ui.cpp
+++ b/src/devtools_ui.cpp
@@ -731,7 +731,7 @@ void DevToolsUI::render_memory_hex()
               ImGui::SetNextItemWidth(ImGui::CalcTextSize("FF").x);
               if (memhex_edit_focus_) {
                 ImGui::SetKeyboardFocusHere();
-                memhex_edit_focus_ = false;
+                // Don't clear yet — give InputText one frame to activate
               }
               ImGuiInputTextFlags eflags = ImGuiInputTextFlags_CharsHexadecimal |
                                            ImGuiInputTextFlags_EnterReturnsTrue |
@@ -740,6 +740,9 @@ void DevToolsUI::render_memory_hex()
                                                 sizeof(memhex_edit_buf_), eflags);
               ImGui::PopStyleVar();
 
+              // Clear the focus request AFTER InputText has had a chance to use it
+              memhex_edit_focus_ = false;
+
               if (committed) {
                 unsigned long nv;
                 if (parse_hex(memhex_edit_buf_, &nv, 0xFF)) {
@@ -747,24 +750,19 @@ void DevToolsUI::render_memory_hex()
                 }
                 memhex_edit_addr_ = -1;
                 memhex_sel_addr_ = -1;
-              }
-              if (!committed && !ImGui::IsItemActive()) {
-                // Lost focus without Enter — cancel
-                memhex_edit_addr_ = -1;
-              }
-              if (ImGui::IsKeyPressed(ImGuiKey_Escape)) {
+              } else if (ImGui::IsKeyPressed(ImGuiKey_Escape)) {
                 memhex_edit_addr_ = -1;
                 memhex_sel_addr_ = -1;
               }
             } else {
               // Normal display — clickable
               if (is_selected) {
-                // Draw selection highlight
+                // Draw selection highlight — bright blue
                 ImVec2 tpos = ImGui::GetCursorScreenPos();
                 ImVec2 tsz = ImGui::CalcTextSize(hex_label);
                 ImGui::GetWindowDrawList()->AddRectFilled(
                   tpos, ImVec2(tpos.x + tsz.x, tpos.y + tsz.y),
-                  IM_COL32(80, 80, 180, 120));
+                  IM_COL32(40, 80, 220, 180));
               }
               ImGui::Text("%s", hex_label);
 

--- a/src/devtools_ui.cpp
+++ b/src/devtools_ui.cpp
@@ -654,6 +654,22 @@ void DevToolsUI::render_memory_hex()
   // Collect watchpoint ranges for highlighting
   const auto& watchpoints = z80_list_watchpoints_ref();
 
+  // Pre-compute search pattern length (avoids reparse per byte in render loop)
+  int search_plen = 0;
+  if (!memhex_matches_.empty() && memhex_search_[0]) {
+    if (memhex_search_hex_) {
+      for (const char* sp = memhex_search_; *sp; ) {
+        while (*sp == ' ') sp++;
+        if (!*sp) break;
+        char* se; strtoul(sp, &se, 16);
+        if (se == sp) break;
+        search_plen++; sp = se;
+      }
+    } else {
+      search_plen = static_cast<int>(strlen(memhex_search_));
+    }
+  }
+
   if (ImGui::BeginChild("##hexview", ImVec2(0, 0), ImGuiChildFlags_Borders)) {
     // Use clipper for efficient scrolling over all 64K
     ImGuiListClipper clipper;
@@ -743,21 +759,9 @@ void DevToolsUI::render_memory_hex()
           }
 
           // Search match highlighting (yellow background)
-          if (!memhex_matches_.empty() && memhex_search_[0]) {
-            int plen = 0;
-            if (memhex_search_hex_) {
-              for (const char* sp = memhex_search_; *sp; ) {
-                while (*sp == ' ') sp++;
-                if (!*sp) break;
-                char* se; strtoul(sp, &se, 16);
-                if (se == sp) break;
-                plen++; sp = se;
-              }
-            } else {
-              plen = static_cast<int>(strlen(memhex_search_));
-            }
+          if (search_plen > 0) {
             for (word ma : memhex_matches_) {
-              if (a >= ma && a < ma + plen) {
+              if (a >= ma && a < ma + search_plen) {
                 ImVec2 rmin = ImGui::GetItemRectMin();
                 ImVec2 rmax = ImGui::GetItemRectMax();
                 bool is_current = (memhex_match_idx_ >= 0 &&

--- a/src/devtools_ui.h
+++ b/src/devtools_ui.h
@@ -113,7 +113,8 @@ private:
     char memhex_edit_buf_[3] = "";  // 2 hex chars + null
     bool memhex_edit_focus_ = false; // Set focus on first frame
 
-    // Disc tools export state (for async file dialog callback)
+    // Disc tools async dialog state (captured at dialog-open time)
+    int dt_dialog_drive_ = 0;          // Drive at time dialog was opened
     std::string dt_export_filename_;   // CPC filename being exported
     std::string dt_export_display_;    // Display name for toast
 

--- a/src/devtools_ui.h
+++ b/src/devtools_ui.h
@@ -112,6 +112,10 @@ private:
     char memhex_edit_buf_[3] = "";  // 2 hex chars + null
     bool memhex_edit_focus_ = false; // Set focus on first frame
 
+    // Disc tools export state (for async file dialog callback)
+    std::string dt_export_filename_;   // CPC filename being exported
+    std::string dt_export_display_;    // Display name for toast
+
     // Add Breakpoint form state
     char bp_addr_[8] = "";
     char bp_cond_[128] = "";

--- a/src/devtools_ui.h
+++ b/src/devtools_ui.h
@@ -107,7 +107,8 @@ private:
     std::vector<word> memhex_matches_;
     int memhex_match_idx_ = -1;
 
-    // Memory Hex inline editing
+    // Memory Hex selection and inline editing
+    int memhex_sel_addr_ = -1;      // Selected (highlighted) byte (-1 = none)
     int memhex_edit_addr_ = -1;     // Address being edited (-1 = none)
     char memhex_edit_buf_[3] = "";  // 2 hex chars + null
     bool memhex_edit_focus_ = false; // Set focus on first frame

--- a/src/devtools_ui.h
+++ b/src/devtools_ui.h
@@ -101,6 +101,11 @@ private:
     std::vector<uint8_t> dt_sector_data_;
     std::string dt_sector_read_error_;
 
+    // Add Breakpoint form state
+    char bp_addr_[8] = "";
+    char bp_cond_[128] = "";
+    char bp_pass_[8] = "";
+
     // Add Watchpoint form state
     char wp_addr_[8] = "";
     char wp_len_[8] = "1";

--- a/src/devtools_ui.h
+++ b/src/devtools_ui.h
@@ -101,6 +101,11 @@ private:
     std::vector<uint8_t> dt_sector_data_;
     std::string dt_sector_read_error_;
 
+    // Memory Hex inline editing
+    int memhex_edit_addr_ = -1;     // Address being edited (-1 = none)
+    char memhex_edit_buf_[3] = "";  // 2 hex chars + null
+    bool memhex_edit_focus_ = false; // Set focus on first frame
+
     // Add Breakpoint form state
     char bp_addr_[8] = "";
     char bp_cond_[128] = "";

--- a/src/devtools_ui.h
+++ b/src/devtools_ui.h
@@ -101,6 +101,12 @@ private:
     std::vector<uint8_t> dt_sector_data_;
     std::string dt_sector_read_error_;
 
+    // Memory Hex search
+    char memhex_search_[64] = "";
+    bool memhex_search_hex_ = true; // true=hex bytes, false=ASCII
+    std::vector<word> memhex_matches_;
+    int memhex_match_idx_ = -1;
+
     // Memory Hex inline editing
     int memhex_edit_addr_ = -1;     // Address being edited (-1 = none)
     char memhex_edit_buf_[3] = "";  // 2 hex chars + null

--- a/src/imgui_ui.cpp
+++ b/src/imgui_ui.cpp
@@ -161,10 +161,10 @@ static void process_pending_dialog()
       if (file_load(CPC.tape) == 0) {
         imgui_toast_success("Tape loaded: " + fname);
         mru_push(CPC.mru_tapes, path);
+        tape_scan_blocks();
       } else
         imgui_toast_error("Failed to load tape: " + fname);
       CPC.current_tape_path = dir;
-      tape_scan_blocks();
       close_menu();
       break;
     case FileDialogAction::LoadTape_LED:
@@ -172,10 +172,10 @@ static void process_pending_dialog()
       if (file_load(CPC.tape) == 0) {
         imgui_toast_success("Tape loaded: " + fname);
         mru_push(CPC.mru_tapes, path);
+        tape_scan_blocks();
       } else
         imgui_toast_error("Failed to load tape: " + fname);
       CPC.current_tape_path = dir;
-      tape_scan_blocks();
       break;
     case FileDialogAction::LoadCartridge:
       CPC.cartridge.file = path;
@@ -398,7 +398,8 @@ void imgui_render_ui()
     }
 
     // Render from bottom of viewport, stacking upward
-    ImVec2 vpSize = io.DisplaySize;
+    ImVec2 vpPos = ImGui::GetMainViewport()->Pos;
+    ImVec2 vpSize = ImGui::GetMainViewport()->Size;
     for (int i = static_cast<int>(imgui_state.toasts.size()) - 1; i >= 0; --i) {
       auto& t = imgui_state.toasts[i];
 
@@ -434,8 +435,8 @@ void imgui_render_ui()
       float boxW = textSize.x + 16.0f;
       float boxH = textSize.y + 12.0f;
 
-      float x = vpSize.x - boxW - xMargin;
-      float y = vpSize.y - yOffset - boxH;
+      float x = vpPos.x + vpSize.x - boxW - xMargin;
+      float y = vpPos.y + vpSize.y - yOffset - boxH;
 
       ImDrawList* dl = ImGui::GetForegroundDrawList();
       ImVec2 p0(x, y), p1(x + boxW, y + boxH);
@@ -793,7 +794,7 @@ static void imgui_render_menubar()
       render_mru_section("Tapes", CPC.mru_tapes, [](const std::string& p) {
         CPC.tape.file = p;
         auto f = std::filesystem::path(p).filename().string();
-        if (file_load(CPC.tape) == 0) imgui_toast_success("Tape: " + f);
+        if (file_load(CPC.tape) == 0) { imgui_toast_success("Tape: " + f); tape_scan_blocks(); }
         else imgui_toast_error("Failed: " + f);
       });
       render_mru_section("Snapshots", CPC.mru_snaps, [](const std::string& p) {

--- a/src/imgui_ui.cpp
+++ b/src/imgui_ui.cpp
@@ -1055,7 +1055,7 @@ static void imgui_render_topbar()
     if (imgui_state.eject_confirm_drive >= 0) {
       ImGui::OpenPopup("Eject Disk?");
     }
-    if (ImGui::BeginPopup("Eject Disk?")) {
+    if (ImGui::BeginPopupModal("Eject Disk?", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
       int drv = imgui_state.eject_confirm_drive;
       const char* name = drv == 0 ? "A" : "B";
       ImGui::Text("Eject disk from drive %s?", name);
@@ -1348,7 +1348,7 @@ static void imgui_render_topbar()
     if (imgui_state.eject_confirm_tape) {
       ImGui::OpenPopup("Eject Tape?");
     }
-    if (ImGui::BeginPopup("Eject Tape?")) {
+    if (ImGui::BeginPopupModal("Eject Tape?", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
       ImGui::TextUnformatted("Eject tape?");
       ImGui::Spacing();
       if (ImGui::Button("Eject", ImVec2(80, 0))) {
@@ -1622,6 +1622,11 @@ static void imgui_render_menu()
   ImGui::TextWrapped("Emulation paused. Use the menu bar above for all actions.");
   ImGui::Spacing();
 
+  // Enable keyboard navigation for this window (arrows/tab cycle buttons)
+  if (imgui_state.menu_just_opened) {
+    ImGui::SetKeyboardFocusHere();
+    imgui_state.menu_just_opened = false;
+  }
   if (ImGui::Button("Resume (Esc)", ImVec2(bw, 0))) {
     action = true;
   }
@@ -1912,7 +1917,9 @@ static void imgui_render_options()
 
           // Unload button (slots 0-1 are system ROMs, protected)
           ImGui::TableSetColumnIndex(3);
-          if (i >= 2 && loaded) {
+          if (i < 2) {
+            ImGui::TextDisabled("system");
+          } else if (loaded) {
             if (ImGui::SmallButton("X")) {
               delete[] memmap_ROM[i];
               memmap_ROM[i] = nullptr;
@@ -2436,6 +2443,21 @@ static void imgui_render_memory_tool()
       std::cout << "\n";
     }
     std::cout << std::flush;
+  }
+
+  // Active mode indicator
+  if (imgui_state.mem_filter_value >= 0) {
+    ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 0.8f, 0.2f, 1.0f));
+    ImGui::Text("[FILTER: %02X]", imgui_state.mem_filter_value & 0xFF);
+    ImGui::PopStyleColor();
+    ImGui::SameLine();
+    if (ImGui::SmallButton("Clear##mtclear")) { imgui_state.mem_filter_value = -1; }
+  } else if (imgui_state.mem_display_value >= 0) {
+    ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.3f, 1.0f, 0.5f, 1.0f));
+    ImGui::Text("[DISPLAY: %04X]", imgui_state.mem_display_value & 0xFFFF);
+    ImGui::PopStyleColor();
+    ImGui::SameLine();
+    if (ImGui::SmallButton("Clear##mtclear")) { imgui_state.mem_display_value = -1; }
   }
 
   // Hex dump

--- a/src/imgui_ui.cpp
+++ b/src/imgui_ui.cpp
@@ -57,7 +57,6 @@ extern dword dwTapeZeroPulseCycles;
 ImGuiUIState imgui_state;
 
 // Forward declarations
-void tape_scan_blocks();
 static void imgui_render_menubar();
 static void imgui_render_topbar();
 static void imgui_render_menu();

--- a/src/imgui_ui.cpp
+++ b/src/imgui_ui.cpp
@@ -5,6 +5,7 @@
 #include "command_palette.h"
 #include "menu_actions.h"
 #include "workspace_layout.h"
+#include <algorithm>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -66,6 +67,7 @@ static void imgui_render_memory_tool();
 static void imgui_render_vkeyboard();
 
 static void close_menu();
+static void mru_push(std::vector<std::string>& list, const std::string& path);
 
 // Height tracking for stacked menubar + topbar + devtools bar
 static float s_menubar_h = 19.0f; // ImGui main menu bar default height
@@ -105,9 +107,10 @@ static void process_pending_dialog()
     case FileDialogAction::LoadDiskA:
     case FileDialogAction::LoadDiskA_LED:
       CPC.driveA.file = path;
-      if (file_load(CPC.driveA) == 0)
+      if (file_load(CPC.driveA) == 0) {
         imgui_toast_success("Drive A: " + fname);
-      else
+        mru_push(CPC.mru_disks, path);
+      } else
         imgui_toast_error("Failed to load disk: " + fname);
       CPC.current_dsk_path = dir;
       if (action == FileDialogAction::LoadDiskA) close_menu();
@@ -115,9 +118,10 @@ static void process_pending_dialog()
     case FileDialogAction::LoadDiskB:
     case FileDialogAction::LoadDiskB_LED:
       CPC.driveB.file = path;
-      if (file_load(CPC.driveB) == 0)
+      if (file_load(CPC.driveB) == 0) {
         imgui_toast_success("Drive B: " + fname);
-      else
+        mru_push(CPC.mru_disks, path);
+      } else
         imgui_toast_error("Failed to load disk: " + fname);
       CPC.current_dsk_path = dir;
       if (action == FileDialogAction::LoadDiskB) close_menu();
@@ -138,9 +142,10 @@ static void process_pending_dialog()
       break;
     case FileDialogAction::LoadSnapshot:
       CPC.snapshot.file = path;
-      if (file_load(CPC.snapshot) == 0)
+      if (file_load(CPC.snapshot) == 0) {
         imgui_toast_success("Snapshot loaded: " + fname);
-      else
+        mru_push(CPC.mru_snaps, path);
+      } else
         imgui_toast_error("Failed to load snapshot: " + fname);
       CPC.current_snap_path = dir;
       close_menu();
@@ -154,9 +159,10 @@ static void process_pending_dialog()
       break;
     case FileDialogAction::LoadTape:
       CPC.tape.file = path;
-      if (file_load(CPC.tape) == 0)
+      if (file_load(CPC.tape) == 0) {
         imgui_toast_success("Tape loaded: " + fname);
-      else
+        mru_push(CPC.mru_tapes, path);
+      } else
         imgui_toast_error("Failed to load tape: " + fname);
       CPC.current_tape_path = dir;
       tape_scan_blocks();
@@ -164,18 +170,20 @@ static void process_pending_dialog()
       break;
     case FileDialogAction::LoadTape_LED:
       CPC.tape.file = path;
-      if (file_load(CPC.tape) == 0)
+      if (file_load(CPC.tape) == 0) {
         imgui_toast_success("Tape loaded: " + fname);
-      else
+        mru_push(CPC.mru_tapes, path);
+      } else
         imgui_toast_error("Failed to load tape: " + fname);
       CPC.current_tape_path = dir;
       tape_scan_blocks();
       break;
     case FileDialogAction::LoadCartridge:
       CPC.cartridge.file = path;
-      if (file_load(CPC.cartridge) == 0)
+      if (file_load(CPC.cartridge) == 0) {
         imgui_toast_success("Cartridge loaded: " + fname);
-      else
+        mru_push(CPC.mru_carts, path);
+      } else
         imgui_toast_error("Failed to load cartridge: " + fname);
       CPC.current_cart_path = dir;
       emulator_reset();
@@ -501,6 +509,18 @@ void imgui_render_ui()
 }
 
 // ─────────────────────────────────────────────────
+// MRU (recent files) helper
+// ─────────────────────────────────────────────────
+
+static void mru_push(std::vector<std::string>& list, const std::string& path) {
+  mru_list_push(list, path, t_CPC::MRU_MAX);
+}
+
+void imgui_mru_push(std::vector<std::string>& list, const std::string& path) {
+  mru_push(list, path);
+}
+
+// ─────────────────────────────────────────────────
 // Toast notification API
 // ─────────────────────────────────────────────────
 
@@ -744,6 +764,61 @@ static void imgui_render_menubar()
         reinterpret_cast<void*>(static_cast<intptr_t>(FileDialogAction::LoadCartridge)),
         mainSDLWindow, filters, 1, CPC.current_cart_path.c_str(), false);
     }
+
+    // ── Open Recent submenu ──
+    bool has_any_mru = !CPC.mru_disks.empty() || !CPC.mru_tapes.empty() ||
+                       !CPC.mru_snaps.empty() || !CPC.mru_carts.empty();
+    ImGui::Separator();
+    if (ImGui::BeginMenu("Open Recent", has_any_mru)) {
+      auto render_mru_section = [&](const char* label, std::vector<std::string>& list,
+                                    auto load_fn) {
+        if (!list.empty() && ImGui::BeginMenu(label)) {
+          for (int i = 0; i < static_cast<int>(list.size()); i++) {
+            auto item_fname = std::filesystem::path(list[i]).filename().string();
+            ImGui::PushID(i);
+            if (ImGui::MenuItem(item_fname.c_str())) {
+              load_fn(list[i]);
+            }
+            if (ImGui::IsItemHovered()) ImGui::SetTooltip("%s", list[i].c_str());
+            ImGui::PopID();
+          }
+          ImGui::EndMenu();
+        }
+      };
+      render_mru_section("Disks", CPC.mru_disks, [](const std::string& p) {
+        CPC.driveA.file = p;
+        auto f = std::filesystem::path(p).filename().string();
+        if (file_load(CPC.driveA) == 0) imgui_toast_success("Drive A: " + f);
+        else imgui_toast_error("Failed: " + f);
+      });
+      render_mru_section("Tapes", CPC.mru_tapes, [](const std::string& p) {
+        CPC.tape.file = p;
+        auto f = std::filesystem::path(p).filename().string();
+        if (file_load(CPC.tape) == 0) imgui_toast_success("Tape: " + f);
+        else imgui_toast_error("Failed: " + f);
+      });
+      render_mru_section("Snapshots", CPC.mru_snaps, [](const std::string& p) {
+        CPC.snapshot.file = p;
+        auto f = std::filesystem::path(p).filename().string();
+        if (file_load(CPC.snapshot) == 0) imgui_toast_success("Snapshot: " + f);
+        else imgui_toast_error("Failed: " + f);
+      });
+      render_mru_section("Cartridges", CPC.mru_carts, [](const std::string& p) {
+        CPC.cartridge.file = p;
+        auto f = std::filesystem::path(p).filename().string();
+        if (file_load(CPC.cartridge) == 0) { imgui_toast_success("Cartridge: " + f); emulator_reset(); }
+        else imgui_toast_error("Failed: " + f);
+      });
+      ImGui::Separator();
+      if (ImGui::MenuItem("Clear Recent")) {
+        CPC.mru_disks.clear();
+        CPC.mru_tapes.clear();
+        CPC.mru_snaps.clear();
+        CPC.mru_carts.clear();
+      }
+      ImGui::EndMenu();
+    }
+
     ImGui::EndMenu();
   }
 

--- a/src/imgui_ui.cpp
+++ b/src/imgui_ui.cpp
@@ -825,7 +825,9 @@ static void imgui_render_menubar()
   // ── Tools ──
   if (ImGui::BeginMenu("Tools")) {
     if (ImGui::MenuItem("Memory Tool")) {
-      imgui_state.show_memory_tool = true;
+      // Open the DevTools Memory Hex window (superset of legacy Memory Tool)
+      imgui_state.show_devtools = true;
+      g_devtools_ui.toggle_window("memory_hex");
     }
     if (ImGui::MenuItem("DevTools", "Shift+F2")) {
       imgui_state.show_devtools = true;

--- a/src/imgui_ui.cpp
+++ b/src/imgui_ui.cpp
@@ -99,56 +99,84 @@ static void process_pending_dialog()
   imgui_state.pending_rom_slot = -1;
 
   std::string dir = path.substr(0, path.find_last_of("/\\"));
+  auto fname = std::filesystem::path(path).filename().string();
 
   switch (action) {
     case FileDialogAction::LoadDiskA:
     case FileDialogAction::LoadDiskA_LED:
       CPC.driveA.file = path;
-      file_load(CPC.driveA);
+      if (file_load(CPC.driveA) == 0)
+        imgui_toast_success("Drive A: " + fname);
+      else
+        imgui_toast_error("Failed to load disk: " + fname);
       CPC.current_dsk_path = dir;
       if (action == FileDialogAction::LoadDiskA) close_menu();
       break;
     case FileDialogAction::LoadDiskB:
     case FileDialogAction::LoadDiskB_LED:
       CPC.driveB.file = path;
-      file_load(CPC.driveB);
+      if (file_load(CPC.driveB) == 0)
+        imgui_toast_success("Drive B: " + fname);
+      else
+        imgui_toast_error("Failed to load disk: " + fname);
       CPC.current_dsk_path = dir;
       if (action == FileDialogAction::LoadDiskB) close_menu();
       break;
     case FileDialogAction::SaveDiskA:
-      dsk_save(path, &driveA);
+      if (dsk_save(path, &driveA) == 0)
+        imgui_toast_success("Saved disk A: " + fname);
+      else
+        imgui_toast_error("Failed to save disk: " + fname);
       CPC.current_dsk_path = dir;
       break;
     case FileDialogAction::SaveDiskB:
-      dsk_save(path, &driveB);
+      if (dsk_save(path, &driveB) == 0)
+        imgui_toast_success("Saved disk B: " + fname);
+      else
+        imgui_toast_error("Failed to save disk: " + fname);
       CPC.current_dsk_path = dir;
       break;
     case FileDialogAction::LoadSnapshot:
       CPC.snapshot.file = path;
-      file_load(CPC.snapshot);
+      if (file_load(CPC.snapshot) == 0)
+        imgui_toast_success("Snapshot loaded: " + fname);
+      else
+        imgui_toast_error("Failed to load snapshot: " + fname);
       CPC.current_snap_path = dir;
       close_menu();
       break;
     case FileDialogAction::SaveSnapshot:
-      snapshot_save(path);
+      if (snapshot_save(path) == 0)
+        imgui_toast_success("Snapshot saved: " + fname);
+      else
+        imgui_toast_error("Failed to save snapshot: " + fname);
       CPC.current_snap_path = dir;
       break;
     case FileDialogAction::LoadTape:
       CPC.tape.file = path;
-      file_load(CPC.tape);
+      if (file_load(CPC.tape) == 0)
+        imgui_toast_success("Tape loaded: " + fname);
+      else
+        imgui_toast_error("Failed to load tape: " + fname);
       CPC.current_tape_path = dir;
       tape_scan_blocks();
       close_menu();
       break;
     case FileDialogAction::LoadTape_LED:
       CPC.tape.file = path;
-      file_load(CPC.tape);
+      if (file_load(CPC.tape) == 0)
+        imgui_toast_success("Tape loaded: " + fname);
+      else
+        imgui_toast_error("Failed to load tape: " + fname);
       CPC.current_tape_path = dir;
       tape_scan_blocks();
       break;
     case FileDialogAction::LoadCartridge:
       CPC.cartridge.file = path;
-      file_load(CPC.cartridge);
+      if (file_load(CPC.cartridge) == 0)
+        imgui_toast_success("Cartridge loaded: " + fname);
+      else
+        imgui_toast_error("Failed to load cartridge: " + fname);
       CPC.current_cart_path = dir;
       emulator_reset();
       close_menu();
@@ -344,6 +372,75 @@ void imgui_render_ui()
   g_devtools_ui.render();
   g_command_palette.render();
 
+  // ── Toast notifications ──
+  {
+    ImGuiIO& io = ImGui::GetIO();
+    float dt = io.DeltaTime;
+    float yOffset = 40.0f; // bottom margin
+    float xMargin = 16.0f;
+    float maxWidth = 360.0f;
+
+    // Tick timers and remove expired
+    for (auto it = imgui_state.toasts.begin(); it != imgui_state.toasts.end(); ) {
+      it->timer -= dt;
+      if (it->timer <= 0.0f) {
+        it = imgui_state.toasts.erase(it);
+      } else {
+        ++it;
+      }
+    }
+
+    // Render from bottom of viewport, stacking upward
+    ImVec2 vpSize = io.DisplaySize;
+    for (int i = static_cast<int>(imgui_state.toasts.size()) - 1; i >= 0; --i) {
+      auto& t = imgui_state.toasts[i];
+
+      // Fade in/out
+      float alpha = 1.0f;
+      if (t.timer < ImGuiUIState::TOAST_FADE_TIME)
+        alpha = t.timer / ImGuiUIState::TOAST_FADE_TIME;
+      float age = t.initial - t.timer;
+      if (age < ImGuiUIState::TOAST_FADE_TIME)
+        alpha = std::min(alpha, age / ImGuiUIState::TOAST_FADE_TIME);
+
+      // Colors by level
+      ImU32 bgCol, borderCol, textCol;
+      switch (t.level) {
+        case ImGuiUIState::ToastLevel::Success:
+          bgCol     = IM_COL32(0x10, 0x30, 0x18, static_cast<int>(210 * alpha));
+          borderCol = IM_COL32(0x20, 0x90, 0x40, static_cast<int>(200 * alpha));
+          textCol   = IM_COL32(0x80, 0xFF, 0x80, static_cast<int>(255 * alpha));
+          break;
+        case ImGuiUIState::ToastLevel::Error:
+          bgCol     = IM_COL32(0x30, 0x10, 0x10, static_cast<int>(210 * alpha));
+          borderCol = IM_COL32(0x90, 0x20, 0x20, static_cast<int>(200 * alpha));
+          textCol   = IM_COL32(0xFF, 0x80, 0x80, static_cast<int>(255 * alpha));
+          break;
+        default: // Info
+          bgCol     = IM_COL32(0x18, 0x18, 0x20, static_cast<int>(210 * alpha));
+          borderCol = IM_COL32(0x50, 0x50, 0x70, static_cast<int>(200 * alpha));
+          textCol   = IM_COL32(0xD0, 0xD0, 0xD0, static_cast<int>(255 * alpha));
+          break;
+      }
+
+      ImVec2 textSize = ImGui::CalcTextSize(t.message.c_str(), nullptr, false, maxWidth - 16.0f);
+      float boxW = textSize.x + 16.0f;
+      float boxH = textSize.y + 12.0f;
+
+      float x = vpSize.x - boxW - xMargin;
+      float y = vpSize.y - yOffset - boxH;
+
+      ImDrawList* dl = ImGui::GetForegroundDrawList();
+      ImVec2 p0(x, y), p1(x + boxW, y + boxH);
+      dl->AddRectFilled(p0, p1, bgCol, 4.0f);
+      dl->AddRect(p0, p1, borderCol, 4.0f);
+      dl->AddText(nullptr, 0.0f, ImVec2(x + 8.0f, y + 6.0f), textCol,
+                  t.message.c_str(), nullptr, maxWidth - 16.0f);
+
+      yOffset += boxH + 4.0f;
+    }
+  }
+
   // --- Quit confirmation popup (rendered here so it works regardless of show_menu) ---
   if (imgui_state.show_quit_confirm) {
     ImGui::OpenPopup("Confirm Quit");
@@ -402,6 +499,26 @@ void imgui_render_ui()
     }
   }
 }
+
+// ─────────────────────────────────────────────────
+// Toast notification API
+// ─────────────────────────────────────────────────
+
+void imgui_toast(const std::string& message, ImGuiUIState::ToastLevel level)
+{
+  // Cap queue size
+  while (static_cast<int>(imgui_state.toasts.size()) >= ImGuiUIState::MAX_TOASTS) {
+    imgui_state.toasts.pop_front();
+  }
+  float duration = (level == ImGuiUIState::ToastLevel::Error)
+    ? ImGuiUIState::TOAST_DURATION * 1.5f   // errors stay longer
+    : ImGuiUIState::TOAST_DURATION;
+  imgui_state.toasts.push_back({message, level, duration, duration});
+}
+
+void imgui_toast_info(const std::string& message)    { imgui_toast(message, ImGuiUIState::ToastLevel::Info); }
+void imgui_toast_success(const std::string& message) { imgui_toast(message, ImGuiUIState::ToastLevel::Success); }
+void imgui_toast_error(const std::string& message)   { imgui_toast(message, ImGuiUIState::ToastLevel::Error); }
 
 // ─────────────────────────────────────────────────
 // Helper: close menu and resume emulation
@@ -1134,10 +1251,21 @@ static void imgui_render_topbar()
         }
       }
 
+      // Mode label overlay (top-right corner of waveform box)
+      {
+        const char* modeLabel = (mode == 0) ? "RAW" : "BITS";
+        ImVec2 labelSize = ImGui::CalcTextSize(modeLabel);
+        ImVec2 labelPos(p1.x - labelSize.x - 2.0f, p0.y + 1.0f);
+        dl->AddText(labelPos, IM_COL32(0x80, 0x80, 0x80, 0xA0), modeLabel);
+      }
+
       // Advance cursor past the waveform box; click cycles mode (2 modes now)
       ImGui::Dummy(ImVec2(waveW, frameH));
       if (ImGui::IsItemClicked()) {
         imgui_state.tape_wave_mode = (imgui_state.tape_wave_mode + 1) % 2;
+      }
+      if (ImGui::IsItemHovered()) {
+        ImGui::SetTooltip("Click to cycle waveform mode (RAW pulse / decoded BITS)");
       }
     }
 
@@ -1453,7 +1581,12 @@ static void imgui_render_menu()
     ImGui::BulletText("Shift+F2 - DevTools");
     ImGui::BulletText("F5 - Reset");
     ImGui::BulletText("F10 - Quit");
-    ImGui::BulletText("Ctrl+F5 - Screenshot");
+    ImGui::BulletText("F3 - Screenshot");
+#ifdef __APPLE__
+    ImGui::BulletText("Cmd+K - Command Palette");
+#else
+    ImGui::BulletText("Ctrl+K - Command Palette");
+#endif
     ImGui::Spacing();
     if (ImGui::Button("OK", ImVec2(120, 0))) { ImGui::CloseCurrentPopup(); }
     ImGui::EndPopup();
@@ -1536,6 +1669,9 @@ static void imgui_render_options()
       int speed = static_cast<int>(CPC.speed);
       if (ImGui::SliderInt("Speed", &speed, MIN_SPEED_SETTING, MAX_SPEED_SETTING)) {
         CPC.speed = speed;
+      }
+      if (ImGui::IsItemHovered()) {
+        ImGui::SetTooltip("CPU clock speed in MHz (default: 4).\nHigher = faster emulation.");
       }
 
       bool printer = CPC.printer != 0;
@@ -1738,6 +1874,9 @@ static void imgui_render_options()
       if (ImGui::Combo("Scale", &scale, scale_items, IM_ARRAYSIZE(scale_items))) {
         CPC.scr_scale = scale + 1;
       }
+      if (ImGui::IsItemHovered()) {
+        ImGui::SetTooltip("Window size multiplier (1x = 384x270)");
+      }
 
       bool colour = CPC.scr_tube == 0;
       if (ImGui::RadioButton("Colour", colour)) { CPC.scr_tube = 0; }
@@ -1748,6 +1887,9 @@ static void imgui_render_options()
       if (ImGui::SliderInt("Intensity", &intensity, 5, 15)) {
         CPC.scr_intensity = intensity;
         video_set_palette();
+      }
+      if (ImGui::IsItemHovered()) {
+        ImGui::SetTooltip("CRT phosphor brightness.\nHigher = brighter colours.");
       }
 
       bool scanlines = CPC.scr_scanlines != 0;
@@ -1775,6 +1917,9 @@ static void imgui_render_options()
       bool aspect = CPC.scr_preserve_aspect_ratio != 0;
       if (ImGui::Checkbox("Preserve Aspect Ratio", &aspect)) {
         CPC.scr_preserve_aspect_ratio = aspect ? 1 : 0;
+      }
+      if (ImGui::IsItemHovered()) {
+        ImGui::SetTooltip("When off, the CPC screen stretches\nto fill the entire window.");
       }
 
       ImGui::EndTabItem();
@@ -1869,6 +2014,9 @@ static void imgui_render_options()
     CPC.paused = false;
     first_open = true;
   }
+  if (ImGui::IsItemHovered()) {
+    ImGui::SetTooltip("Apply changes and save to config file");
+  }
   ImGui::SameLine();
   if (ImGui::Button("Cancel", ImVec2(80, 0))) {
     CPC = imgui_state.old_cpc_settings;
@@ -1879,7 +2027,7 @@ static void imgui_render_options()
     first_open = true;
   }
   ImGui::SameLine();
-  if (ImGui::Button("OK", ImVec2(80, 0))) {
+  if (ImGui::Button("Apply", ImVec2(80, 0))) {
     if (CPC.model != imgui_state.old_cpc_settings.model ||
         CPC.ram_size != imgui_state.old_cpc_settings.ram_size ||
         CPC.keyboard != imgui_state.old_cpc_settings.keyboard ||
@@ -1891,6 +2039,9 @@ static void imgui_render_options()
     imgui_state.show_options = false;
     CPC.paused = false;
     first_open = true;
+  }
+  if (ImGui::IsItemHovered()) {
+    ImGui::SetTooltip("Apply changes for this session only\n(not saved to config file)");
   }
 
   if (!open) {
@@ -2100,6 +2251,7 @@ static void imgui_render_devtools()
       z80.step_out_addresses.clear();
       CPC.paused = false;
     }
+    if (ImGui::IsItemHovered()) { ImGui::SetTooltip("Execute one instruction (enters CALLs)"); }
     ImGui::SameLine();
     if (ImGui::Button("Step Over")) {
       z80.step_in = 0;
@@ -2114,6 +2266,7 @@ static void imgui_render_devtools()
         CPC.paused = false;
       }
     }
+    if (ImGui::IsItemHovered()) { ImGui::SetTooltip("Execute one instruction (skips over CALLs/RSTs)"); }
     ImGui::SameLine();
     if (ImGui::Button("Step Out")) {
       z80.step_out = 1;
@@ -2121,6 +2274,7 @@ static void imgui_render_devtools()
       z80.step_in = 0;
       CPC.paused = false;
     }
+    if (ImGui::IsItemHovered()) { ImGui::SetTooltip("Run until the current subroutine returns"); }
     if (!was_paused) ImGui::EndDisabled();
     ImGui::SameLine();
     if (ImGui::Button(CPC.paused ? "Resume" : "Pause")) {

--- a/src/imgui_ui.cpp
+++ b/src/imgui_ui.cpp
@@ -57,7 +57,7 @@ extern dword dwTapeZeroPulseCycles;
 ImGuiUIState imgui_state;
 
 // Forward declarations
-static void tape_scan_blocks();
+void tape_scan_blocks();
 static void imgui_render_menubar();
 static void imgui_render_topbar();
 static void imgui_render_menu();
@@ -562,7 +562,7 @@ static void close_menu()
 
 // safe_read_word/dword moved to imgui_ui_testable.h
 
-static void tape_scan_blocks()
+void tape_scan_blocks()
 {
   imgui_state.tape_block_offsets.clear();
   imgui_state.tape_current_block = 0;

--- a/src/imgui_ui.cpp
+++ b/src/imgui_ui.cpp
@@ -2617,6 +2617,21 @@ static void imgui_render_vkeyboard()
   float x0 = ImGui::GetCursorPosX();
   float y0 = ImGui::GetCursorPosY();
 
+  // Helper: check if a CPC key is currently pressed in the keyboard matrix
+  auto cpc_key_down = [](byte cpc_key) -> bool {
+    extern byte keyboard_matrix[];
+    extern byte bit_values[];
+    return !(keyboard_matrix[cpc_key >> 4] & bit_values[cpc_key & 7]);
+  };
+  // Helper: draw blue overlay on last ImGui item if CPC key is pressed
+  auto highlight_if_pressed = [&](byte cpc_key) {
+    if (cpc_key_down(cpc_key)) {
+      ImVec2 rmin = ImGui::GetItemRectMin();
+      ImVec2 rmax = ImGui::GetItemRectMax();
+      ImGui::GetWindowDrawList()->AddRectFilled(rmin, rmax, IM_COL32(50, 120, 220, 100), 3.0f);
+    }
+  };
+
   // Width multipliers for special keys
   const float W_TAB    = 1.3f;
   const float W_CAPS   = 1.4f;
@@ -2632,164 +2647,121 @@ static void imgui_render_vkeyboard()
   // Numpad starts after a gap from main keyboard right edge
   float np_x = main_end_x + S * 4;
 
-  // Helper for function keys
+  // ── Key dispatch: render Button, emit keypress, highlight if held ──
+  // vk() renders a single CPC key button with pressed-key overlay.
   char fkey_emit[2] = { '\a', 0 };
+  auto vk = [&](const char* label, float w, const char* es, byte cpc_key) {
+    if (ImGui::Button(label, ImVec2(w, H))) emit_key(es);
+    highlight_if_pressed(cpc_key);
+    ImGui::SameLine(0, S);
+  };
+  // vk_end() — same but no SameLine (end of row)
+  auto vk_end = [&](const char* label, float w, const char* es, byte cpc_key) {
+    if (ImGui::Button(label, ImVec2(w, H))) emit_key(es);
+    highlight_if_pressed(cpc_key);
+  };
+  // vk_fkey() — function key (emit via \a prefix)
+  auto vk_fkey = [&](const char* label, float w, byte cpc_key, bool end = false) {
+    fkey_emit[1] = static_cast<char>(cpc_key);
+    if (ImGui::Button(label, ImVec2(w, H))) emit_key(fkey_emit);
+    highlight_if_pressed(cpc_key);
+    if (!end) ImGui::SameLine(0, S);
+  };
 
-  // ═══════════════════════════════════════════════════════════════════
-  // ROW 0: ESC 1 2 3 4 5 6 7 8 9 0 - ^ CLR DEL | F7 F8 F9
-  // ═══════════════════════════════════════════════════════════════════
+  // ═══════════════════ ROW 0 ═══════════════════
   ImGui::SetCursorPos(ImVec2(x0, y0));
-  if (ImGui::Button("ESC", ImVec2(K, H))) { emit_key("\a\xbb"); } ImGui::SameLine(0, S);
-  if (ImGui::Button("!\n1", ImVec2(K, H))) { emit_key("1"); } ImGui::SameLine(0, S);
-  if (ImGui::Button("\"\n2", ImVec2(K, H))) { emit_key("2"); } ImGui::SameLine(0, S);
-  if (ImGui::Button("#\n3", ImVec2(K, H))) { emit_key("3"); } ImGui::SameLine(0, S);
-  if (ImGui::Button("$\n4", ImVec2(K, H))) { emit_key("4"); } ImGui::SameLine(0, S);
-  if (ImGui::Button("%\n5", ImVec2(K, H))) { emit_key("5"); } ImGui::SameLine(0, S);
-  if (ImGui::Button("&\n6", ImVec2(K, H))) { emit_key("6"); } ImGui::SameLine(0, S);
-  if (ImGui::Button("'\n7", ImVec2(K, H))) { emit_key("7"); } ImGui::SameLine(0, S);
-  if (ImGui::Button("(\n8", ImVec2(K, H))) { emit_key("8"); } ImGui::SameLine(0, S);
-  if (ImGui::Button(")\n9", ImVec2(K, H))) { emit_key("9"); } ImGui::SameLine(0, S);
-  if (ImGui::Button("_\n0", ImVec2(K, H))) { emit_key("0"); } ImGui::SameLine(0, S);
-  if (ImGui::Button("=\n-", ImVec2(K, H))) { emit_key("-"); } ImGui::SameLine(0, S);
-  if (ImGui::Button("\xc2\xa3\n^", ImVec2(K, H))) { emit_key("^"); } ImGui::SameLine(0, S);  // £ over ^
-  if (ImGui::Button("CLR", ImVec2(K, H))) { emit_key("\a\xa5"); } ImGui::SameLine(0, S);
-  if (ImGui::Button("DEL", ImVec2(K, H))) emit_key("\b");
-
-  // Numpad row 0: F7 F8 F9
+  vk("ESC", K, "\a\xbb", CPC_ESC);
+  vk("!\n1", K, "1", CPC_1);      vk("\"\n2", K, "2", CPC_2);
+  vk("#\n3", K, "3", CPC_3);      vk("$\n4", K, "4", CPC_4);
+  vk("%\n5", K, "5", CPC_5);      vk("&\n6", K, "6", CPC_6);
+  vk("'\n7", K, "7", CPC_7);      vk("(\n8", K, "8", CPC_8);
+  vk(")\n9", K, "9", CPC_9);      vk("_\n0", K, "0", CPC_0);
+  vk("=\n-", K, "-", CPC_MINUS);  vk("\xc2\xa3\n^", K, "^", CPC_POWER);
+  vk("CLR", K, "\a\xa5", CPC_CLR);
+  vk_end("DEL", K, "\b", CPC_DEL);
+  // Numpad
   ImGui::SetCursorPos(ImVec2(np_x, y0));
-  fkey_emit[1] = static_cast<char>(CPC_F7);
-  if (ImGui::Button("F7", ImVec2(K, H))) { emit_key(fkey_emit); } ImGui::SameLine(0, S);
-  fkey_emit[1] = static_cast<char>(CPC_F8);
-  if (ImGui::Button("F8", ImVec2(K, H))) { emit_key(fkey_emit); } ImGui::SameLine(0, S);
-  fkey_emit[1] = static_cast<char>(CPC_F9);
-  if (ImGui::Button("F9", ImVec2(K, H))) emit_key(fkey_emit);
+  vk_fkey("F7", K, CPC_F7);  vk_fkey("F8", K, CPC_F8);  vk_fkey("F9", K, CPC_F9, true);
 
-  // ═══════════════════════════════════════════════════════════════════
-  // ROW 1: TAB Q W E R T Y U I O P |/@ {/[  | F4 F5 F6
-  // ═══════════════════════════════════════════════════════════════════
+  // ═══════════════════ ROW 1 ═══════════════════
   ImGui::SetCursorPos(ImVec2(x0, y0 + ROW));
-  if (ImGui::Button("TAB", ImVec2(K*W_TAB, H))) { emit_key("\t"); } ImGui::SameLine(0, S);
-  if (ImGui::Button("Q", ImVec2(K, H))) { emit_key("q"); } ImGui::SameLine(0, S);
-  if (ImGui::Button("W", ImVec2(K, H))) { emit_key("w"); } ImGui::SameLine(0, S);
-  if (ImGui::Button("E", ImVec2(K, H))) { emit_key("e"); } ImGui::SameLine(0, S);
-  if (ImGui::Button("R", ImVec2(K, H))) { emit_key("r"); } ImGui::SameLine(0, S);
-  if (ImGui::Button("T", ImVec2(K, H))) { emit_key("t"); } ImGui::SameLine(0, S);
-  if (ImGui::Button("Y", ImVec2(K, H))) { emit_key("y"); } ImGui::SameLine(0, S);
-  if (ImGui::Button("U", ImVec2(K, H))) { emit_key("u"); } ImGui::SameLine(0, S);
-  if (ImGui::Button("I", ImVec2(K, H))) { emit_key("i"); } ImGui::SameLine(0, S);
-  if (ImGui::Button("O", ImVec2(K, H))) { emit_key("o"); } ImGui::SameLine(0, S);
-  if (ImGui::Button("P", ImVec2(K, H))) { emit_key("p"); } ImGui::SameLine(0, S);
-  if (ImGui::Button("|\n@", ImVec2(K, H))) { emit_key("@"); } ImGui::SameLine(0, S);
-  if (ImGui::Button("{\n[", ImVec2(K, H))) { emit_key("["); } ImGui::SameLine(0, S);
-  // RETURN upper part - at end of row 1
+  vk("TAB", K*W_TAB, "\t", CPC_TAB);
+  vk("Q", K, "q", CPC_Q);  vk("W", K, "w", CPC_W);  vk("E", K, "e", CPC_E);
+  vk("R", K, "r", CPC_R);  vk("T", K, "t", CPC_T);  vk("Y", K, "y", CPC_Y);
+  vk("U", K, "u", CPC_U);  vk("I", K, "i", CPC_I);  vk("O", K, "o", CPC_O);
+  vk("P", K, "p", CPC_P);
+  vk("|\n@", K, "@", CPC_AT);  vk("{\n[", K, "[", CPC_LBRACKET);
+  // RETURN upper part — fills to main_end_x
   float ret_x = ImGui::GetCursorPosX();
   float ret_w = main_end_x - ret_x;
-  if (ImGui::Button("RETURN##1", ImVec2(ret_w, H))) emit_key("\n");
-  // RETURN lower part - starts S after where ] ends in row 2
-  // Row 2: CAPS(1.4K) + 12 keys (A-L + ; : ]) with spacing = K*W_CAPS + S + 12*(K+S)
+  vk_end("RETURN##1", ret_w, "\n", CPC_RETURN);
+  // RETURN lower part (L-shape into row 2)
   float ret2_x = x0 + K*W_CAPS + S + 12*(K + S);
   float ret2_w = main_end_x - ret2_x;
   ImGui::SetCursorPos(ImVec2(ret2_x, y0 + ROW + H));
   if (ImGui::Button("##ret2", ImVec2(ret2_w, ROW))) emit_key("\n");
-
-  // Numpad row 1: F4 F5 F6
+  highlight_if_pressed(CPC_RETURN);
+  // Numpad
   ImGui::SetCursorPos(ImVec2(np_x, y0 + ROW));
-  fkey_emit[1] = static_cast<char>(CPC_F4);
-  if (ImGui::Button("F4", ImVec2(K, H))) { emit_key(fkey_emit); } ImGui::SameLine(0, S);
-  fkey_emit[1] = static_cast<char>(CPC_F5);
-  if (ImGui::Button("F5", ImVec2(K, H))) { emit_key(fkey_emit); } ImGui::SameLine(0, S);
-  fkey_emit[1] = static_cast<char>(CPC_F6);
-  if (ImGui::Button("F6", ImVec2(K, H))) emit_key(fkey_emit);
+  vk_fkey("F4", K, CPC_F4);  vk_fkey("F5", K, CPC_F5);  vk_fkey("F6", K, CPC_F6, true);
 
-  // ═══════════════════════════════════════════════════════════════════
-  // ROW 2: CAPS A S D F G H J K L +/; */: }/] RETURN(wide) | F1 F2 F3
-  // ═══════════════════════════════════════════════════════════════════
+  // ═══════════════════ ROW 2 ═══════════════════
   ImGui::SetCursorPos(ImVec2(x0, y0 + ROW * 2));
   if (caps_on) ImGui::PushStyleColor(ImGuiCol_Button, mod_on_color);
   if (ImGui::Button("CAPS\nLOCK", ImVec2(K*W_CAPS, H))) emit_key("\x01" "CAPS");
   if (caps_on) ImGui::PopStyleColor();
-  ImGui::SameLine(0, S);
-  if (ImGui::Button("A", ImVec2(K, H))) { emit_key("a"); } ImGui::SameLine(0, S);
-  if (ImGui::Button("S", ImVec2(K, H))) { emit_key("s"); } ImGui::SameLine(0, S);
-  if (ImGui::Button("D", ImVec2(K, H))) { emit_key("d"); } ImGui::SameLine(0, S);
-  if (ImGui::Button("F", ImVec2(K, H))) { emit_key("f"); } ImGui::SameLine(0, S);
-  if (ImGui::Button("G", ImVec2(K, H))) { emit_key("g"); } ImGui::SameLine(0, S);
-  if (ImGui::Button("H", ImVec2(K, H))) { emit_key("h"); } ImGui::SameLine(0, S);
-  if (ImGui::Button("J", ImVec2(K, H))) { emit_key("j"); } ImGui::SameLine(0, S);
-  if (ImGui::Button("K", ImVec2(K, H))) { emit_key("k"); } ImGui::SameLine(0, S);
-  if (ImGui::Button("L", ImVec2(K, H))) { emit_key("l"); } ImGui::SameLine(0, S);
-  if (ImGui::Button("+\n;", ImVec2(K, H))) { emit_key(";"); } ImGui::SameLine(0, S);
-  if (ImGui::Button("*\n:", ImVec2(K, H))) { emit_key(":"); } ImGui::SameLine(0, S);
-  if (ImGui::Button("}\n]", ImVec2(K, H))) emit_key("]");
-
-  // Numpad row 2: F1 F2 F3
+  highlight_if_pressed(CPC_CAPSLOCK); ImGui::SameLine(0, S);
+  vk("A", K, "a", CPC_A);  vk("S", K, "s", CPC_S);  vk("D", K, "d", CPC_D);
+  vk("F", K, "f", CPC_F);  vk("G", K, "g", CPC_G);  vk("H", K, "h", CPC_H);
+  vk("J", K, "j", CPC_J);  vk("K", K, "k", CPC_K);  vk("L", K, "l", CPC_L);
+  vk("+\n;", K, ";", CPC_SEMICOLON);  vk("*\n:", K, ":", CPC_COLON);
+  vk_end("}\n]", K, "]", CPC_RBRACKET);
+  // Numpad
   ImGui::SetCursorPos(ImVec2(np_x, y0 + ROW * 2));
-  fkey_emit[1] = static_cast<char>(CPC_F1);
-  if (ImGui::Button("F1", ImVec2(K, H))) { emit_key(fkey_emit); } ImGui::SameLine(0, S);
-  fkey_emit[1] = static_cast<char>(CPC_F2);
-  if (ImGui::Button("F2", ImVec2(K, H))) { emit_key(fkey_emit); } ImGui::SameLine(0, S);
-  fkey_emit[1] = static_cast<char>(CPC_F3);
-  if (ImGui::Button("F3", ImVec2(K, H))) emit_key(fkey_emit);
+  vk_fkey("F1", K, CPC_F1);  vk_fkey("F2", K, CPC_F2);  vk_fkey("F3", K, CPC_F3, true);
 
-  // ═══════════════════════════════════════════════════════════════════
-  // ROW 3: SHIFT Z X C V B N M </,  >/. ?// `/\ SHIFT RETURN | F0 ↑ .
-  // RETURN lower part forms L-shape with row 2 RETURN
-  // ═══════════════════════════════════════════════════════════════════
+  // ═══════════════════ ROW 3 ═══════════════════
   ImGui::SetCursorPos(ImVec2(x0, y0 + ROW * 3));
-  bool shift_highlight = imgui_state.vkeyboard_shift_next;  // highlight both SHIFTs together
+  bool shift_highlight = imgui_state.vkeyboard_shift_next;
   if (shift_highlight) ImGui::PushStyleColor(ImGuiCol_Button, mod_on_color);
   if (ImGui::Button("SHIFT##L", ImVec2(K*W_LSHIFT, H))) emit_key("\x01" "SHIFT");
   if (shift_highlight) ImGui::PopStyleColor();
-  ImGui::SameLine(0, S);
-  if (ImGui::Button("Z", ImVec2(K, H))) { emit_key("z"); } ImGui::SameLine(0, S);
-  if (ImGui::Button("X", ImVec2(K, H))) { emit_key("x"); } ImGui::SameLine(0, S);
-  if (ImGui::Button("C", ImVec2(K, H))) { emit_key("c"); } ImGui::SameLine(0, S);
-  if (ImGui::Button("V", ImVec2(K, H))) { emit_key("v"); } ImGui::SameLine(0, S);
-  if (ImGui::Button("B", ImVec2(K, H))) { emit_key("b"); } ImGui::SameLine(0, S);
-  if (ImGui::Button("N", ImVec2(K, H))) { emit_key("n"); } ImGui::SameLine(0, S);
-  if (ImGui::Button("M", ImVec2(K, H))) { emit_key("m"); } ImGui::SameLine(0, S);
-  if (ImGui::Button("<\n,", ImVec2(K, H))) { emit_key(","); } ImGui::SameLine(0, S);
-  if (ImGui::Button(">\n.##main", ImVec2(K, H))) { emit_key("."); } ImGui::SameLine(0, S);
-  if (ImGui::Button("?\n/", ImVec2(K, H))) { emit_key("/"); } ImGui::SameLine(0, S);
-  if (ImGui::Button("`\n\\", ImVec2(K, H))) { emit_key("\\"); } ImGui::SameLine(0, S);
-  // Right SHIFT - fills to main_end_x (naturally narrower due to wider left SHIFT)
+  highlight_if_pressed(CPC_LSHIFT); ImGui::SameLine(0, S);
+  vk("Z", K, "z", CPC_Z);  vk("X", K, "x", CPC_X);  vk("C", K, "c", CPC_C);
+  vk("V", K, "v", CPC_V);  vk("B", K, "b", CPC_B);  vk("N", K, "n", CPC_N);
+  vk("M", K, "m", CPC_M);
+  vk("<\n,", K, ",", CPC_COMMA);    vk(">\n.##main", K, ".", CPC_PERIOD);
+  vk("?\n/", K, "/", CPC_SLASH);    vk("`\n\\", K, "\\", CPC_BACKSLASH);
+  // Right SHIFT — fills to main_end_x
   float rshift_x = ImGui::GetCursorPosX();
   float rshift_w = main_end_x - rshift_x;
   if (shift_highlight) ImGui::PushStyleColor(ImGuiCol_Button, mod_on_color);
   if (ImGui::Button("SHIFT##R", ImVec2(rshift_w, H))) emit_key("\x01" "SHIFT");
   if (shift_highlight) ImGui::PopStyleColor();
-
-  // Numpad row 3: F0 ↑ .
+  highlight_if_pressed(CPC_RSHIFT);
+  // Numpad
   ImGui::SetCursorPos(ImVec2(np_x, y0 + ROW * 3));
-  fkey_emit[1] = static_cast<char>(CPC_F0);
-  if (ImGui::Button("F0", ImVec2(K, H))) { emit_key(fkey_emit); } ImGui::SameLine(0, S);
-  if (ImGui::Button("\xe2\x86\x91##up", ImVec2(K, H))) { emit_key("\a\xae"); } ImGui::SameLine(0, S);
-  if (ImGui::Button(".##np", ImVec2(K, H))) emit_key(".");
+  vk_fkey("F0", K, CPC_F0);
+  vk("\xe2\x86\x91##up", K, "\a\xae", CPC_CUR_UP);
+  vk_end(".##np", K, ".", CPC_FPERIOD);
 
-  // ═══════════════════════════════════════════════════════════════════
-  // ROW 4: CTRL COPY ====SPACE==== ENTER | ← ↓ →
-  // ═══════════════════════════════════════════════════════════════════
+  // ═══════════════════ ROW 4 ═══════════════════
   ImGui::SetCursorPos(ImVec2(x0, y0 + ROW * 4));
   if (ctrl_on) ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.6f, 0.4f, 0.2f, 1.0f));
   if (ImGui::Button("CTRL", ImVec2(K*W_CTRL, H))) emit_key("\x01" "CTRL");
   if (ctrl_on) ImGui::PopStyleColor();
-  ImGui::SameLine(0, S);
-  if (ImGui::Button("COPY", ImVec2(K*W_COPY, H))) emit_key("\a\xa9");
-  ImGui::SameLine(0, S);
-  // SPACE - fixed width, then ENTER fills to main_end_x
+  highlight_if_pressed(CPC_CONTROL); ImGui::SameLine(0, S);
+  vk("COPY", K*W_COPY, "\a\xa9", CPC_COPY);
   float space_w = K * 8.0f;
-  if (ImGui::Button("SPACE", ImVec2(space_w, H))) emit_key(" ");
-  ImGui::SameLine(0, S);
-  // ENTER - calculate width to reach main_end_x
+  vk("SPACE", space_w, " ", CPC_SPACE);
   float enter_x = ImGui::GetCursorPosX();
   float enter_w = main_end_x - enter_x;
-  if (ImGui::Button("ENTER", ImVec2(enter_w, H))) emit_key("\n");
-
-  // Numpad row 4: ← ↓ →
+  vk_end("ENTER", enter_w, "\n", CPC_ENTER);
+  // Numpad
   ImGui::SetCursorPos(ImVec2(np_x, y0 + ROW * 4));
-  if (ImGui::Button("\xe2\x86\x90##left", ImVec2(K, H))) { emit_key("\a\xaf"); } ImGui::SameLine(0, S);
-  if (ImGui::Button("\xe2\x86\x93##down", ImVec2(K, H))) { emit_key("\a\xb0"); } ImGui::SameLine(0, S);
-  if (ImGui::Button("\xe2\x86\x92##right", ImVec2(K, H))) emit_key("\a\xb1");
+  vk("\xe2\x86\x90##left", K, "\a\xaf", CPC_CUR_LEFT);
+  vk("\xe2\x86\x93##down", K, "\a\xb0", CPC_CUR_DOWN);
+  vk_end("\xe2\x86\x92##right", K, "\a\xb1", CPC_CUR_RIGHT);
 
   // Move cursor below keyboard for the rest
   ImGui::SetCursorPos(ImVec2(x0, y0 + ROW * 5 + S * 2));

--- a/src/imgui_ui.cpp
+++ b/src/imgui_ui.cpp
@@ -2617,11 +2617,15 @@ static void imgui_render_vkeyboard()
   float x0 = ImGui::GetCursorPosX();
   float y0 = ImGui::GetCursorPosY();
 
-  // Helper: check if a CPC key is currently pressed in the keyboard matrix
+  // Helper: check if a CPC key is currently pressed in the keyboard matrix.
+  // CPC_KEYS enum values are NOT matrix positions — must convert via scancode table.
   auto cpc_key_down = [](byte cpc_key) -> bool {
     extern byte keyboard_matrix[];
     extern byte bit_values[];
-    return !(keyboard_matrix[cpc_key >> 4] & bit_values[cpc_key & 7]);
+    CPCScancode sc = CPC.InputMapper->CPCscancodeFromCPCkey(static_cast<CPC_KEYS>(cpc_key));
+    byte row = static_cast<byte>(sc >> 4);
+    byte bit = static_cast<byte>(sc & 7);
+    return row < 16 && !(keyboard_matrix[row] & bit_values[bit]);
   };
   // Helper: draw blue overlay on last ImGui item if CPC key is pressed
   auto highlight_if_pressed = [&](byte cpc_key) {

--- a/src/imgui_ui.cpp
+++ b/src/imgui_ui.cpp
@@ -788,25 +788,25 @@ static void imgui_render_menubar()
       render_mru_section("Disks", CPC.mru_disks, [](const std::string& p) {
         CPC.driveA.file = p;
         auto f = std::filesystem::path(p).filename().string();
-        if (file_load(CPC.driveA) == 0) imgui_toast_success("Drive A: " + f);
+        if (file_load(CPC.driveA) == 0) { imgui_toast_success("Drive A: " + f); mru_push(CPC.mru_disks, p); }
         else imgui_toast_error("Failed: " + f);
       });
       render_mru_section("Tapes", CPC.mru_tapes, [](const std::string& p) {
         CPC.tape.file = p;
         auto f = std::filesystem::path(p).filename().string();
-        if (file_load(CPC.tape) == 0) { imgui_toast_success("Tape: " + f); tape_scan_blocks(); }
+        if (file_load(CPC.tape) == 0) { imgui_toast_success("Tape: " + f); tape_scan_blocks(); mru_push(CPC.mru_tapes, p); }
         else imgui_toast_error("Failed: " + f);
       });
       render_mru_section("Snapshots", CPC.mru_snaps, [](const std::string& p) {
         CPC.snapshot.file = p;
         auto f = std::filesystem::path(p).filename().string();
-        if (file_load(CPC.snapshot) == 0) imgui_toast_success("Snapshot: " + f);
+        if (file_load(CPC.snapshot) == 0) { imgui_toast_success("Snapshot: " + f); mru_push(CPC.mru_snaps, p); }
         else imgui_toast_error("Failed: " + f);
       });
       render_mru_section("Cartridges", CPC.mru_carts, [](const std::string& p) {
         CPC.cartridge.file = p;
         auto f = std::filesystem::path(p).filename().string();
-        if (file_load(CPC.cartridge) == 0) { imgui_toast_success("Cartridge: " + f); emulator_reset(); }
+        if (file_load(CPC.cartridge) == 0) { imgui_toast_success("Cartridge: " + f); emulator_reset(); mru_push(CPC.mru_carts, p); }
         else imgui_toast_error("Failed: " + f);
       });
       ImGui::Separator();

--- a/src/imgui_ui.h
+++ b/src/imgui_ui.h
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <vector>
+#include <deque>
 #include "koncepcja.h"
 
 enum class FileDialogAction {
@@ -83,6 +84,19 @@ struct ImGuiUIState {
   // Layout dropdown (topbar)
   bool show_layout_dropdown = false;
 
+  // Toast notification system
+  enum class ToastLevel { Info, Success, Error };
+  struct Toast {
+    std::string message;
+    ToastLevel level = ToastLevel::Info;
+    float timer = 0.0f;       // seconds remaining
+    float initial = 0.0f;     // initial duration (for fade calc)
+  };
+  std::deque<Toast> toasts;   // rendered bottom-up, newest last
+  static constexpr int MAX_TOASTS = 4;
+  static constexpr float TOAST_DURATION = 3.5f;
+  static constexpr float TOAST_FADE_TIME = 0.5f;
+
 };
 
 extern ImGuiUIState imgui_state;
@@ -90,5 +104,11 @@ extern ImGuiUIState imgui_state;
 void imgui_init_ui();
 void imgui_render_ui();
 int imgui_topbar_height();
+
+// Toast notifications
+void imgui_toast(const std::string& message, ImGuiUIState::ToastLevel level = ImGuiUIState::ToastLevel::Info);
+void imgui_toast_info(const std::string& message);
+void imgui_toast_success(const std::string& message);
+void imgui_toast_error(const std::string& message);
 
 #endif // IMGUI_UI_H

--- a/src/imgui_ui.h
+++ b/src/imgui_ui.h
@@ -110,6 +110,9 @@ void imgui_toast(const std::string& message, ImGuiUIState::ToastLevel level = Im
 
 // MRU (recent files) helper — pushes path to front, deduplicates, caps at MRU_MAX
 void imgui_mru_push(std::vector<std::string>& list, const std::string& path);
+
+// Tape block scanning (called after tape load to populate block offsets)
+void tape_scan_blocks();
 void imgui_toast_info(const std::string& message);
 void imgui_toast_success(const std::string& message);
 void imgui_toast_error(const std::string& message);

--- a/src/imgui_ui.h
+++ b/src/imgui_ui.h
@@ -107,6 +107,9 @@ int imgui_topbar_height();
 
 // Toast notifications
 void imgui_toast(const std::string& message, ImGuiUIState::ToastLevel level = ImGuiUIState::ToastLevel::Info);
+
+// MRU (recent files) helper — pushes path to front, deduplicates, caps at MRU_MAX
+void imgui_mru_push(std::vector<std::string>& list, const std::string& path);
 void imgui_toast_info(const std::string& message);
 void imgui_toast_success(const std::string& message);
 void imgui_toast_error(const std::string& message);

--- a/src/imgui_ui_testable.h
+++ b/src/imgui_ui_testable.h
@@ -138,4 +138,21 @@ inline int format_memory_line(char* buf, size_t buf_size, unsigned int base_addr
   return offset;
 }
 
+// ─────────────────────────────────────────────────
+// MRU (recent files) list management
+// ─────────────────────────────────────────────────
+
+#include <vector>
+#include <string>
+#include <algorithm>
+
+// Push a path to the front of an MRU list, deduplicate, cap at max_size.
+inline void mru_list_push(std::vector<std::string>& list, const std::string& path, int max_size = 10)
+{
+  list.erase(std::remove(list.begin(), list.end(), path), list.end());
+  list.insert(list.begin(), path);
+  if (static_cast<int>(list.size()) > max_size)
+    list.resize(max_size);
+}
+
 #endif // IMGUI_UI_TESTABLE_H

--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -3406,6 +3406,62 @@ int koncpc_main (int argc, char **argv)
          // Feed event to Dear ImGui
          ImGui_ImplSDL3_ProcessEvent(&event);
 
+         // ── Drag-and-drop file loading ──
+         if (event.type == SDL_EVENT_DROP_FILE) {
+           const char* dropped = event.drop.data;
+           if (dropped) {
+             std::string drop_path(dropped);
+             std::string ext;
+             {
+               auto dot = drop_path.rfind('.');
+               if (dot != std::string::npos) {
+                 ext = drop_path.substr(dot);
+                 // lowercase extension
+                 for (auto& c : ext) c = static_cast<char>(tolower(c));
+               }
+             }
+             auto drop_fname = std::filesystem::path(drop_path).filename().string();
+
+             if (ext == ".dsk" || ext == ".ipf" || ext == ".raw") {
+               CPC.driveA.file = drop_path;
+               if (file_load(CPC.driveA) == 0)
+                 imgui_toast_success("Drive A: " + drop_fname);
+               else
+                 imgui_toast_error("Failed to load disk: " + drop_fname);
+             } else if (ext == ".cdt" || ext == ".voc") {
+               CPC.tape.file = drop_path;
+               if (file_load(CPC.tape) == 0)
+                 imgui_toast_success("Tape loaded: " + drop_fname);
+               else
+                 imgui_toast_error("Failed to load tape: " + drop_fname);
+             } else if (ext == ".sna") {
+               CPC.snapshot.file = drop_path;
+               if (file_load(CPC.snapshot) == 0)
+                 imgui_toast_success("Snapshot loaded: " + drop_fname);
+               else
+                 imgui_toast_error("Failed to load snapshot: " + drop_fname);
+             } else if (ext == ".cpr") {
+               CPC.cartridge.file = drop_path;
+               if (file_load(CPC.cartridge) == 0) {
+                 imgui_toast_success("Cartridge loaded: " + drop_fname);
+                 emulator_reset();
+               } else {
+                 imgui_toast_error("Failed to load cartridge: " + drop_fname);
+               }
+             } else if (ext == ".zip") {
+               // Try as disk first (most common zip content)
+               CPC.driveA.file = drop_path;
+               if (file_load(CPC.driveA) == 0)
+                 imgui_toast_success("Drive A: " + drop_fname);
+               else
+                 imgui_toast_error("Unsupported ZIP content: " + drop_fname);
+             } else {
+               imgui_toast_error("Unknown file type: " + drop_fname);
+             }
+           }
+           continue;
+         }
+
          // Check for command palette shortcut (Cmd+K / Ctrl+K)
          if (event.type == SDL_EVENT_KEY_DOWN) {
            bool ctrl = (event.key.mod & SDL_KMOD_CTRL) != 0;

--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -2231,6 +2231,23 @@ void loadConfiguration (t_CPC &CPC, const std::string& configFilename)
    }
    CPC.rom_mf2 = conf.getStringValue("rom", "rom_mf2", "");
 
+   // Load MRU (recent files) lists
+   for (int i = 0; i < t_CPC::MRU_MAX; i++) {
+      char key[16];
+      snprintf(key, sizeof(key), "mru_disk_%02d", i);
+      std::string val = conf.getStringValue("file", key, "");
+      if (!val.empty()) CPC.mru_disks.push_back(val);
+      snprintf(key, sizeof(key), "mru_tape_%02d", i);
+      val = conf.getStringValue("file", key, "");
+      if (!val.empty()) CPC.mru_tapes.push_back(val);
+      snprintf(key, sizeof(key), "mru_snap_%02d", i);
+      val = conf.getStringValue("file", key, "");
+      if (!val.empty()) CPC.mru_snaps.push_back(val);
+      snprintf(key, sizeof(key), "mru_cart_%02d", i);
+      val = conf.getStringValue("file", key, "");
+      if (!val.empty()) CPC.mru_carts.push_back(val);
+   }
+
    CPC.cartridge.file = CPC.rom_path + "/system.cpr"; // Only default path defined. Needed for CPC6128+
 }
 
@@ -2320,6 +2337,19 @@ bool saveConfiguration (t_CPC &CPC, const std::string& configFilename)
       conf.setStringValue("rom", chRomId, CPC.rom_file[iRomNum]);
    }
    conf.setStringValue("rom", "rom_mf2", CPC.rom_mf2);
+
+   // Save MRU (recent files) lists
+   for (int i = 0; i < t_CPC::MRU_MAX; i++) {
+      char key[16];
+      snprintf(key, sizeof(key), "mru_disk_%02d", i);
+      conf.setStringValue("file", key, i < (int)CPC.mru_disks.size() ? CPC.mru_disks[i] : "");
+      snprintf(key, sizeof(key), "mru_tape_%02d", i);
+      conf.setStringValue("file", key, i < (int)CPC.mru_tapes.size() ? CPC.mru_tapes[i] : "");
+      snprintf(key, sizeof(key), "mru_snap_%02d", i);
+      conf.setStringValue("file", key, i < (int)CPC.mru_snaps.size() ? CPC.mru_snaps[i] : "");
+      snprintf(key, sizeof(key), "mru_cart_%02d", i);
+      conf.setStringValue("file", key, i < (int)CPC.mru_carts.size() ? CPC.mru_carts[i] : "");
+   }
 
    return conf.saveToFile(configFilename);
 }
@@ -3424,26 +3454,30 @@ int koncpc_main (int argc, char **argv)
 
              if (ext == ".dsk" || ext == ".ipf" || ext == ".raw") {
                CPC.driveA.file = drop_path;
-               if (file_load(CPC.driveA) == 0)
+               if (file_load(CPC.driveA) == 0) {
                  imgui_toast_success("Drive A: " + drop_fname);
-               else
+                 imgui_mru_push(CPC.mru_disks, drop_path);
+               } else
                  imgui_toast_error("Failed to load disk: " + drop_fname);
              } else if (ext == ".cdt" || ext == ".voc") {
                CPC.tape.file = drop_path;
-               if (file_load(CPC.tape) == 0)
+               if (file_load(CPC.tape) == 0) {
                  imgui_toast_success("Tape loaded: " + drop_fname);
-               else
+                 imgui_mru_push(CPC.mru_tapes, drop_path);
+               } else
                  imgui_toast_error("Failed to load tape: " + drop_fname);
              } else if (ext == ".sna") {
                CPC.snapshot.file = drop_path;
-               if (file_load(CPC.snapshot) == 0)
+               if (file_load(CPC.snapshot) == 0) {
                  imgui_toast_success("Snapshot loaded: " + drop_fname);
-               else
+                 imgui_mru_push(CPC.mru_snaps, drop_path);
+               } else
                  imgui_toast_error("Failed to load snapshot: " + drop_fname);
              } else if (ext == ".cpr") {
                CPC.cartridge.file = drop_path;
                if (file_load(CPC.cartridge) == 0) {
                  imgui_toast_success("Cartridge loaded: " + drop_fname);
+                 imgui_mru_push(CPC.mru_carts, drop_path);
                  emulator_reset();
                } else {
                  imgui_toast_error("Failed to load cartridge: " + drop_fname);
@@ -3451,9 +3485,10 @@ int koncpc_main (int argc, char **argv)
              } else if (ext == ".zip") {
                // Try as disk first (most common zip content)
                CPC.driveA.file = drop_path;
-               if (file_load(CPC.driveA) == 0)
+               if (file_load(CPC.driveA) == 0) {
                  imgui_toast_success("Drive A: " + drop_fname);
-               else
+                 imgui_mru_push(CPC.mru_disks, drop_path);
+               } else
                  imgui_toast_error("Unsupported ZIP content: " + drop_fname);
              } else {
                imgui_toast_error("Unknown file type: " + drop_fname);

--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -17,6 +17,7 @@
 */
 
 #include <algorithm>
+#include <cctype>
 #include <iostream>
 #include <sstream>
 #include <chrono>
@@ -3441,15 +3442,9 @@ int koncpc_main (int argc, char **argv)
            const char* dropped = event.drop.data;
            if (dropped) {
              std::string drop_path(dropped);
-             std::string ext;
-             {
-               auto dot = drop_path.rfind('.');
-               if (dot != std::string::npos) {
-                 ext = drop_path.substr(dot);
-                 // lowercase extension
-                 for (auto& c : ext) c = static_cast<char>(tolower(c));
-               }
-             }
+             std::string ext = std::filesystem::path(drop_path).extension().string();
+             std::transform(ext.begin(), ext.end(), ext.begin(),
+                            [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
              auto drop_fname = std::filesystem::path(drop_path).filename().string();
 
              if (ext == ".dsk" || ext == ".ipf" || ext == ".raw") {
@@ -3464,6 +3459,7 @@ int koncpc_main (int argc, char **argv)
                if (file_load(CPC.tape) == 0) {
                  imgui_toast_success("Tape loaded: " + drop_fname);
                  imgui_mru_push(CPC.mru_tapes, drop_path);
+                 tape_scan_blocks();
                } else
                  imgui_toast_error("Failed to load tape: " + drop_fname);
              } else if (ext == ".sna") {

--- a/src/koncepcja.h
+++ b/src/koncepcja.h
@@ -303,6 +303,13 @@ class t_CPC {
    std::string current_dsk_path;  // Last used disk path in the file dialog.
    std::string current_tape_path; // Last used tape path in the file dialog.
 
+   // Recent files (MRU) — persisted in config [file] section
+   static constexpr int MRU_MAX = 10;
+   std::vector<std::string> mru_disks;
+   std::vector<std::string> mru_tapes;
+   std::vector<std::string> mru_snaps;
+   std::vector<std::string> mru_carts;
+
    class InputMapper *InputMapper;
 };
 

--- a/src/koncepcja.h
+++ b/src/koncepcja.h
@@ -41,7 +41,7 @@ class InputMapper;
 //#define DEBUG_TAPE
 //#define DEBUG_Z80
 
-#define VERSION_STRING "v5.2.3"
+#define VERSION_STRING "v5.3.0"
 
 #ifndef _MAX_PATH
  #ifdef _POSIX_PATH_MAX

--- a/src/workspace_layout.cpp
+++ b/src/workspace_layout.cpp
@@ -132,6 +132,19 @@ void workspace_render_cpc_screen()
             ImGui::GetCursorPos().y + offset_y));
         ImGui::Image(tex, ImVec2(draw_w, draw_h));
 
+        // Focus indicator: green border when keyboard routes to CPC
+        if (imgui_state.cpc_screen_focused) {
+            ImVec2 wmin = ImGui::GetWindowPos();
+            ImVec2 wmax(wmin.x + ImGui::GetWindowSize().x, wmin.y + ImGui::GetWindowSize().y);
+            ImGui::GetWindowDrawList()->AddRect(wmin, wmax, IM_COL32(0, 200, 80, 120), 0, 0, 2.0f);
+        } else {
+            // "Click to focus" hint at bottom center
+            const char* hint = "Click to send keyboard to CPC";
+            ImVec2 tsize = ImGui::CalcTextSize(hint);
+            ImVec2 hpos(p0.x + (avail.x - tsize.x) * 0.5f, p0.y + avail.y - tsize.y - 4.0f);
+            ImGui::GetWindowDrawList()->AddText(hpos, IM_COL32(255, 255, 255, 60), hint);
+        }
+
         // Right-click context menu for scale mode
         if (ImGui::BeginPopupContextWindow("##CPCScreenCtx")) {
             ImGui::TextUnformatted("Scale Mode");

--- a/test/imgui_ui.cpp
+++ b/test/imgui_ui.cpp
@@ -387,3 +387,58 @@ TEST_F(FormatMemoryLineTest, NonPrintableAscii) {
   EXPECT_EQ('.', pipe[4]);  // third non-printable
   EXPECT_EQ(' ', pipe[5]);  // space is printable
 }
+
+// ─────────────────────────────────────────────────
+// MRU list tests
+// ─────────────────────────────────────────────────
+
+TEST(MruList, PushToEmpty) {
+  std::vector<std::string> list;
+  mru_list_push(list, "/path/a.dsk");
+  ASSERT_EQ(1u, list.size());
+  EXPECT_EQ("/path/a.dsk", list[0]);
+}
+
+TEST(MruList, PushMovesToFront) {
+  std::vector<std::string> list = {"/a", "/b", "/c"};
+  mru_list_push(list, "/b");
+  ASSERT_EQ(3u, list.size());
+  EXPECT_EQ("/b", list[0]);
+  EXPECT_EQ("/a", list[1]);
+  EXPECT_EQ("/c", list[2]);
+}
+
+TEST(MruList, PushDeduplicates) {
+  std::vector<std::string> list = {"/a", "/b", "/a"};
+  mru_list_push(list, "/a");
+  ASSERT_EQ(2u, list.size());
+  EXPECT_EQ("/a", list[0]);
+  EXPECT_EQ("/b", list[1]);
+}
+
+TEST(MruList, PushCapsAtMax) {
+  std::vector<std::string> list;
+  for (int i = 0; i < 12; i++) {
+    mru_list_push(list, "/path/" + std::to_string(i), 10);
+  }
+  EXPECT_EQ(10u, list.size());
+  EXPECT_EQ("/path/11", list[0]);  // most recent
+  EXPECT_EQ("/path/2", list[9]);   // oldest kept (0 and 1 were evicted)
+}
+
+TEST(MruList, PushSameTwiceNoGrowth) {
+  std::vector<std::string> list = {"/a"};
+  mru_list_push(list, "/a");
+  ASSERT_EQ(1u, list.size());
+  EXPECT_EQ("/a", list[0]);
+}
+
+TEST(MruList, PushNewToFullList) {
+  std::vector<std::string> list = {"/a", "/b", "/c"};
+  mru_list_push(list, "/d", 3);
+  ASSERT_EQ(3u, list.size());
+  EXPECT_EQ("/d", list[0]);
+  EXPECT_EQ("/a", list[1]);
+  EXPECT_EQ("/b", list[2]);
+  // "/c" was evicted
+}


### PR DESCRIPTION
## Summary

Comprehensive UI/UX improvements identified through a full review of the emulator interface. All planned features implemented.

### Implemented
- **Toast notification system** — fade-in/out overlays for file load/save feedback, errors, and actions
- **Drag-and-drop file loading** — drop .dsk/.cdt/.sna/.cpr/.zip files onto the window
- **Recent Files (MRU) menu** — Open Recent submenu with Disks/Tapes/Snapshots/Cartridges, persisted in config
- **Memory Hex inline editing** — double-click to edit bytes in-place, also via right-click menu
- **Memory Hex search** — find hex bytes or ASCII strings with match highlighting and navigation
- **Conditional breakpoint UI** — Add Breakpoint form with address, condition expression, pass count
- **Keyboard focus indicator** — green border in docked mode when CPC screen has focus
- **Virtual keyboard highlighting** — pressed keys highlighted via keyboard_matrix, refactored to vk() dispatch
- **Disc Tools import/export** — Import host files to disc, Export disc files to host
- **UI polish** — pause menu focus, modal eject popups, memory tool mode indicator, ROM slot lock labels
- **14 new tooltips** — Speed, Scale, Intensity, Aspect Ratio, Save/Apply, Step In/Over/Out
- **Assembler error navigation** — click error to jump to line
- **About dialog fix** — screenshot shortcut corrected to F3
- **Options button clarity** — "OK" renamed to "Apply" with tooltips

### Tests
- 6 new unit tests for MRU list management (dedup, cap, ordering)
- All 782 tests pass (780 pass, 2 pre-existing skips)

## Test plan
- [x] Build: `make -j$(nproc) ARCH=macos` — clean
- [x] Tests: `make debug` — 780 pass
- [ ] Manual: load corrupt .dsk → toast error appears
- [ ] Manual: drag .dsk onto window → loads into Drive A with toast
- [ ] Manual: load 12 disks → MRU shows last 10
- [ ] Manual: double-click byte in Memory Hex → edit in-place
- [ ] Manual: search "C3" in Memory Hex → JP instructions highlighted
- [ ] Manual: add conditional breakpoint A==0x42
- [ ] Manual: docked mode → green border on focused CPC screen
- [ ] Manual: hold key → virtual keyboard button highlights
- [ ] Manual: Disc Tools → Export file, Import file