### PR TITLE
feat: IPC error messages — agent-friendly with context and suggestions

### DIFF
--- a/src/koncepcja_ipc_server.cpp
+++ b/src/koncepcja_ipc_server.cpp
@@ -82,20 +82,43 @@ extern byte *pbROMhi;
 extern byte bit_values[];
 
 // Parse a number from an IPC argument string.
-// Accepts CPC-style hex prefixes ($, &, #) in addition to C-style 0x and bare decimal.
+// Accepts CPC-style hex prefixes ($, &, #), C-style 0x, bare decimal,
+// and bare hex as fallback (e.g. "C004" → 0xC004).
 static unsigned long parse_number(const std::string& s) {
-  if (s.empty()) throw std::invalid_argument("empty number");
+  if (s.empty()) throw std::invalid_argument("empty string");
   if (s[0] == '$' || s[0] == '&' || s[0] == '#')
     return std::stoul(s.substr(1), nullptr, 16);
-  return std::stoul(s, nullptr, 0);
+  // Try base-0 auto-detect first (handles 0x, 0, decimal)
+  try {
+    size_t pos = 0;
+    unsigned long v = std::stoul(s, &pos, 0);
+    if (pos == s.size()) return v;
+  } catch (...) {}
+  // Fallback: try as bare hex (e.g. "C004", "FF")
+  try {
+    size_t pos = 0;
+    unsigned long v = std::stoul(s, &pos, 16);
+    if (pos == s.size()) return v;
+  } catch (...) {}
+  throw std::invalid_argument(s);
 }
 
 // Like parse_number but returns int (for small values like counts, indices).
 static int parse_int(const std::string& s) {
-  if (s.empty()) throw std::invalid_argument("empty number");
+  if (s.empty()) throw std::invalid_argument("empty string");
   if (s[0] == '$' || s[0] == '&' || s[0] == '#')
     return std::stoi(s.substr(1), nullptr, 16);
-  return std::stoi(s, nullptr, 0);
+  try {
+    size_t pos = 0;
+    int v = std::stoi(s, &pos, 0);
+    if (pos == s.size()) return v;
+  } catch (...) {}
+  try {
+    size_t pos = 0;
+    int v = std::stoi(s, &pos, 16);
+    if (pos == s.size()) return v;
+  } catch (...) {}
+  throw std::invalid_argument(s);
 }
 
 // Helper to prevent path traversal via IPC.
@@ -906,6 +929,7 @@ std::string handle_command(const std::string& line) {
     // regs asic → full ASIC state dump
     return "OK\n" + asic_dump_all() + "\n";
   }
+  if (cmd == "reg" || cmd == "regs") return "ERR 400 usage: reg (get|set|crtc|ga|psg|asic) ...\n";
   // Top-level "asic" commands for detailed views
   if (cmd == "asic" && parts.size() >= 2) {
     if (parts[1] == "sprite") {
@@ -1002,6 +1026,7 @@ std::string handle_command(const std::string& line) {
       return rc == 0 ? ok_with_context() : "ERR 500 snapshot-load\n";
     }
   }
+  if (cmd == "snapshot") return "ERR 400 usage: snapshot (save|load) <path>\n";
   if (cmd == "mem" && parts.size() >= 4 && parts[1] == "read") {
     // mem read <addr> <len> [--view=read|write] [--bank=N] [ascii]
     unsigned int addr = parse_number(parts[2]);
@@ -1415,7 +1440,9 @@ std::string handle_command(const std::string& line) {
       resp << "\n";
       return resp.str();
     }
+    return "ERR 400 usage: bp (add <addr> [if <expr>] [pass <N>] | del <addr> | list | clear)\n";
   }
+  if (cmd == "bp") return "ERR 400 usage: bp (add <addr> [if <expr>] [pass <N>] | del <addr> | list | clear)\n";
   if (cmd == "iobp" && parts.size() >= 2) {
     if (parts[1] == "add" && parts.size() >= 3) {
       // iobp add <port> [mask] [in|out|both]
@@ -1508,6 +1535,7 @@ std::string handle_command(const std::string& line) {
     }
     return "ERR 400 bad-iobp-cmd (add|del|clear|list)\n";
   }
+  if (cmd == "iobp") return "ERR 400 usage: iobp (add|del|clear|list)\n";
   if (cmd == "step") {
     cpc_pause();
     // "step in [N]" or "step [N]" — single-step instructions
@@ -1661,6 +1689,7 @@ std::string handle_command(const std::string& line) {
     }
     return "ERR 400 bad-trace-cmd (on|off|dump|on_crash|status)\n";
   }
+  if (cmd == "trace") return "ERR 400 usage: trace (on|off|dump|on_crash|status)\n";
 
   // Frame dumps: frames dump <path_pattern> <count> [delay_cs]
   // If path ends in .gif → animated GIF; otherwise → PNG series
@@ -1858,6 +1887,7 @@ std::string handle_command(const std::string& line) {
     }
     return "ERR 400 bad-input-cmd (keydown|keyup|key|type|joy)\n";
   }
+  if (cmd == "input") return "ERR 400 usage: input (keydown|keyup|key|type|joy)\n";
 
   if (cmd == "wait" && parts.size() >= 2) {
     auto timeout_ms = std::chrono::milliseconds(5000);
@@ -1945,6 +1975,7 @@ std::string handle_command(const std::string& line) {
       return ok_with_context();
     }
   }
+  if (cmd == "wait") return "ERR 400 usage: wait (pc|mem|bp|vbl) ...\n";
 
   // Event system: event on <trigger> <command>, event off <id>, event list
   if (cmd == "event" && parts.size() >= 2) {
@@ -2162,6 +2193,7 @@ std::string handle_command(const std::string& line) {
     }
     return "ERR 400 bad-wp-cmd (add|del|clear|list)\n";
   }
+  if (cmd == "wp") return "ERR 400 usage: wp (add|del|clear|list)\n";
 
   // --- Symbol commands ---
   if (cmd == "sym" && parts.size() >= 2) {
@@ -2219,6 +2251,7 @@ std::string handle_command(const std::string& line) {
     }
     return "ERR 400 bad-sym-cmd (load|add|del|list|lookup)\n";
   }
+  if (cmd == "sym") return "ERR 400 usage: sym (load|add|del|list|lookup)\n";
 
   // --- Memory search ---
   if (cmd == "mem" && parts.size() >= 5 && parts[1] == "find") {
@@ -2334,6 +2367,7 @@ std::string handle_command(const std::string& line) {
     }
     return "ERR 400 bad-find-type (hex|text|asm)\n";
   }
+  if (cmd == "mem") return "ERR 400 usage: mem (read|write|fill|compare|cpu-read|cpu-write|find) ...\n";
 
   // --- Stack command ---
   if (cmd == "stack") {
@@ -2736,6 +2770,7 @@ std::string handle_command(const std::string& line) {
     }
     return "ERR 400 bad-record-cmd (wav|ym|avi)\n";
   }
+  if (cmd == "record") return "ERR 400 usage: record (wav|ym|avi)\n";
 
   // --- Poke commands ---
   if (cmd == "poke" && parts.size() >= 2) {
@@ -3627,12 +3662,46 @@ std::string handle_command(const std::string& line) {
     return "ERR 400 usage: m4 (status|ls|cd|reset|wifi)\n";
   }
 
-  return "ERR 501 not-implemented\n";
+  // Unknown command — find closest match for "did you mean?" suggestion
+  {
+    std::string suggestion;
+    size_t best_dist = SIZE_MAX;
+    for (const auto& [name, _] : g_ipc_commands) {
+      // Levenshtein distance (small strings, O(n*m) is fine)
+      size_t n = cmd.size(), m = name.size();
+      std::vector<size_t> prev(m + 1), curr(m + 1);
+      for (size_t j = 0; j <= m; j++) prev[j] = j;
+      for (size_t i = 1; i <= n; i++) {
+        curr[0] = i;
+        for (size_t j = 1; j <= m; j++) {
+          size_t cost = (cmd[i - 1] == name[j - 1]) ? 0 : 1;
+          curr[j] = std::min({prev[j] + 1, curr[j - 1] + 1, prev[j - 1] + cost});
+        }
+        std::swap(prev, curr);
+      }
+      size_t dist = prev[m];
+      if (dist < best_dist && dist <= 3) {
+        best_dist = dist;
+        suggestion = name;
+      }
+    }
+    std::string msg = "unknown-command: '" + cmd + "' is not recognized";
+    if (!suggestion.empty())
+      msg += ". Did you mean '" + suggestion + "'?";
+    msg += " (Type 'help' for a list of commands)";
+    return "ERR 404 " + msg + "\n";
+  }
 
-  } catch (const std::invalid_argument&) {
-    return "ERR 400 bad-number\n";
-  } catch (const std::out_of_range&) {
-    return "ERR 400 number-out-of-range\n";
+  } catch (const std::invalid_argument& e) {
+    std::string val = e.what();
+    std::string msg = "bad-number";
+    if (!val.empty() && val != "stoi" && val != "stoul")
+      msg += ": '" + val + "' is not a valid number";
+    msg += " (accepted: 0x, $, &, # prefixes, decimal, or bare hex)";
+    return err_with_context(400, msg);
+  } catch (const std::out_of_range& e) {
+    std::string val = e.what();
+    return err_with_context(400, "number-out-of-range: '" + val + "' overflows");
   }
 }
 }

--- a/src/koncepcja_ipc_server.cpp
+++ b/src/koncepcja_ipc_server.cpp
@@ -84,41 +84,33 @@ extern byte bit_values[];
 // Parse a number from an IPC argument string.
 // Accepts CPC-style hex prefixes ($, &, #), C-style 0x, bare decimal,
 // and bare hex as fallback (e.g. "C004" → 0xC004).
-static unsigned long parse_number(const std::string& s) {
+// Throws std::invalid_argument with the original string on failure.
+template<typename T, T(*Conv)(const std::string&, size_t*, int)>
+static T parse_num_impl(const std::string& s) {
   if (s.empty()) throw std::invalid_argument("empty string");
   if (s[0] == '$' || s[0] == '&' || s[0] == '#')
-    return std::stoul(s.substr(1), nullptr, 16);
+    return Conv(s.substr(1), nullptr, 16);
   // Try base-0 auto-detect first (handles 0x, 0, decimal)
   try {
     size_t pos = 0;
-    unsigned long v = std::stoul(s, &pos, 0);
+    T v = Conv(s, &pos, 0);
     if (pos == s.size()) return v;
-  } catch (...) {}
+  } catch (const std::logic_error&) {}
   // Fallback: try as bare hex (e.g. "C004", "FF")
   try {
     size_t pos = 0;
-    unsigned long v = std::stoul(s, &pos, 16);
+    T v = Conv(s, &pos, 16);
     if (pos == s.size()) return v;
-  } catch (...) {}
+  } catch (const std::logic_error&) {}
   throw std::invalid_argument(s);
 }
 
-// Like parse_number but returns int (for small values like counts, indices).
+static unsigned long parse_number(const std::string& s) {
+  return parse_num_impl<unsigned long, std::stoul>(s);
+}
+
 static int parse_int(const std::string& s) {
-  if (s.empty()) throw std::invalid_argument("empty string");
-  if (s[0] == '$' || s[0] == '&' || s[0] == '#')
-    return std::stoi(s.substr(1), nullptr, 16);
-  try {
-    size_t pos = 0;
-    int v = std::stoi(s, &pos, 0);
-    if (pos == s.size()) return v;
-  } catch (...) {}
-  try {
-    size_t pos = 0;
-    int v = std::stoi(s, &pos, 16);
-    if (pos == s.size()) return v;
-  } catch (...) {}
-  throw std::invalid_argument(s);
+  return parse_num_impl<int, std::stoi>(s);
 }
 
 // Helper to prevent path traversal via IPC.
@@ -929,7 +921,7 @@ std::string handle_command(const std::string& line) {
     // regs asic → full ASIC state dump
     return "OK\n" + asic_dump_all() + "\n";
   }
-  if (cmd == "reg" || cmd == "regs") return "ERR 400 usage: reg (get|set|crtc|ga|psg|asic) ...\n";
+  if (cmd == "reg") return "ERR 400 usage: reg (get|set|crtc|ga|psg|asic) ...\n";
   // Top-level "asic" commands for detailed views
   if (cmd == "asic" && parts.size() >= 2) {
     if (parts[1] == "sprite") {
@@ -3666,18 +3658,22 @@ std::string handle_command(const std::string& line) {
   {
     std::string suggestion;
     size_t best_dist = SIZE_MAX;
-    for (const auto& [name, _] : g_ipc_commands) {
-      // Levenshtein distance (small strings, O(n*m) is fine)
+    // Stack-based Levenshtein — command names are short (<20 chars)
+    static constexpr size_t MAX_CMD_LEN = 32;
+    size_t prev[MAX_CMD_LEN + 1], curr[MAX_CMD_LEN + 1];
+    for (const auto& kv : g_ipc_commands) {
+      const std::string& name = kv.first;
       size_t n = cmd.size(), m = name.size();
-      std::vector<size_t> prev(m + 1), curr(m + 1);
+      if (n > MAX_CMD_LEN || m > MAX_CMD_LEN) continue;
       for (size_t j = 0; j <= m; j++) prev[j] = j;
       for (size_t i = 1; i <= n; i++) {
         curr[0] = i;
         for (size_t j = 1; j <= m; j++) {
           size_t cost = (cmd[i - 1] == name[j - 1]) ? 0 : 1;
-          curr[j] = std::min({prev[j] + 1, curr[j - 1] + 1, prev[j - 1] + cost});
+          size_t del = prev[j] + 1, ins = curr[j - 1] + 1, sub = prev[j - 1] + cost;
+          curr[j] = del < ins ? (del < sub ? del : sub) : (ins < sub ? ins : sub);
         }
-        std::swap(prev, curr);
+        for (size_t j = 0; j <= m; j++) prev[j] = curr[j];
       }
       size_t dist = prev[m];
       if (dist < best_dist && dist <= 3) {
@@ -3699,9 +3695,8 @@ std::string handle_command(const std::string& line) {
       msg += ": '" + val + "' is not a valid number";
     msg += " (accepted: 0x, $, &, # prefixes, decimal, or bare hex)";
     return err_with_context(400, msg);
-  } catch (const std::out_of_range& e) {
-    std::string val = e.what();
-    return err_with_context(400, "number-out-of-range: '" + val + "' overflows");
+  } catch (const std::out_of_range&) {
+    return err_with_context(400, "number-out-of-range (value too large for target type)");
   }
 }
 }

--- a/test/ipc_server.cpp
+++ b/test/ipc_server.cpp
@@ -400,4 +400,58 @@ TEST_F(IpcServerTest, MemFindWildcard) {
   EXPECT_TRUE(resp.find("3000") != std::string::npos);
 }
 
+// ─────────────────────────────────────────────────
+// Error message quality tests
+// ─────────────────────────────────────────────────
+
+TEST_F(IpcServerTest, UnknownCommandReturns404WithSuggestion) {
+  auto resp = send_command("totype hello");
+  EXPECT_TRUE(resp.find("ERR 404") != std::string::npos) << resp;
+  EXPECT_TRUE(resp.find("autotype") != std::string::npos) << resp; // "Did you mean..."
+}
+
+TEST_F(IpcServerTest, UnknownCommandReturns404NoSuggestionForGarbage) {
+  auto resp = send_command("xyzzyplugh");
+  EXPECT_TRUE(resp.find("ERR 404") != std::string::npos) << resp;
+  EXPECT_TRUE(resp.find("not recognized") != std::string::npos) << resp;
+}
+
+TEST_F(IpcServerTest, BareHexAddressAccepted) {
+  // "C000" should be parsed as hex, not rejected
+  auto resp = send_command("bp add C000");
+  EXPECT_OK(resp);
+  auto list = send_command("bp list");
+  EXPECT_TRUE(list.find("C000") != std::string::npos) << list;
+}
+
+TEST_F(IpcServerTest, BpWithNoArgsReturnsUsage) {
+  auto resp = send_command("bp");
+  EXPECT_TRUE(resp.find("ERR 400") != std::string::npos) << resp;
+  EXPECT_TRUE(resp.find("usage:") != std::string::npos) << resp;
+}
+
+TEST_F(IpcServerTest, BpAddWithNoAddrReturnsUsage) {
+  auto resp = send_command("bp add");
+  EXPECT_TRUE(resp.find("ERR 400") != std::string::npos) << resp;
+  EXPECT_TRUE(resp.find("usage:") != std::string::npos) << resp;
+}
+
+TEST_F(IpcServerTest, WpWithNoArgsReturnsUsage) {
+  auto resp = send_command("wp");
+  EXPECT_TRUE(resp.find("ERR 400") != std::string::npos) << resp;
+  EXPECT_TRUE(resp.find("usage:") != std::string::npos) << resp;
+}
+
+TEST_F(IpcServerTest, MemWithNoArgsReturnsUsage) {
+  auto resp = send_command("mem");
+  EXPECT_TRUE(resp.find("ERR 400") != std::string::npos) << resp;
+  EXPECT_TRUE(resp.find("usage:") != std::string::npos) << resp;
+}
+
+TEST_F(IpcServerTest, BadNumberIncludesValueInError) {
+  auto resp = send_command("reg set A notanumber");
+  EXPECT_TRUE(resp.find("ERR 400") != std::string::npos) << resp;
+  EXPECT_TRUE(resp.find("notanumber") != std::string::npos) << resp;
+}
+
 }  // namespace


### PR DESCRIPTION
## Summary

Make IPC errors actually helpful for scripts and agents.

- **Bare hex accepted**: `bp add C004` now works (was ERR 400 bad-number)
- **Fuzzy "did you mean?"**: `totype` → `ERR 404 unknown-command: 'totype' is not recognized. Did you mean 'autotype'?`
- **Missing args → usage**: `bp` with no args → `ERR 400 usage: bp (add|del|list|clear)` instead of misleading `ERR 501 not-implemented`
- **Value in errors**: `reg set A notanumber` → `ERR 400 bad-number: 'notanumber' is not a valid number`
- **404 for unknown commands**: Was 501 (HTTP "Not Implemented"), now 404 (semantically correct)
- **Context in catch blocks**: Number parse errors include CPU state via `err_with_context()`
- **10 sub-command guards**: bp, wp, iobp, mem, reg, sym, wait, trace, input, snapshot, record

## Test plan
- [x] 8 new IPC tests (fuzzy match, bare hex, missing args, bad number echo)
- [x] All 788 tests pass
- [x] Manual: `echo "bp add C004" | nc localhost 6543` → OK
- [x] Manual: `echo "totype hello" | nc localhost 6543` → suggests autotype
- [x] Manual: `echo "bp" | nc localhost 6543` → usage hint