### PR TITLE
feat: disassembly — pin PC, ROM color-coding, bank marks

### DIFF
--- a/src/devtools_ui.cpp
+++ b/src/devtools_ui.cpp
@@ -304,6 +304,18 @@ void DevToolsUI::render_registers()
 // Debug Window 2: Disassembly
 // -----------------------------------------------
 
+void DevToolsUI::disasm_cache_record_pc()
+{
+  word pc = z80.PC.w.l;
+  if (disasm_cache_.count(pc)) return; // already cached
+  DisassembledCode dc;
+  std::vector<dword> eps;
+  auto line = disassemble_one(pc, dc, eps);
+  int len = line.Size();
+  if (len <= 0) len = 1;
+  disasm_cache_[pc] = { line.instruction_, static_cast<uint8_t>(len) };
+}
+
 void DevToolsUI::render_disassembly()
 {
   ImGui::SetNextWindowSize(ImVec2(440, 500), ImGuiCond_FirstUseEver);
@@ -344,12 +356,21 @@ void DevToolsUI::render_disassembly()
     center_pc = static_cast<word>(disasm_goto_value_);
   }
 
-  // Disassemble ~48 instructions starting a few lines before center
-  word start_addr = center_pc - 16;
+  // Invalidate cache on banking change
+  extern t_GateArray GateArray;
+  byte cur_banking = GateArray.RAM_config ^ GateArray.ROM_config;
+  if (cur_banking != disasm_cache_banking_) {
+    disasm_cache_.clear();
+    disasm_cache_banking_ = cur_banking;
+  }
+
+  // Record current PC into the execution-trace cache
+  disasm_cache_record_pc();
+
+  // Build display lines by walking forward from start_addr.
+  // Cache hits are instant; misses disassemble and cache the result.
   constexpr int NUM_LINES = 48;
 
-  DisassembledCode dummy_dc;
-  std::vector<dword> dummy_eps;
   struct DisasmEntry {
     word addr;
     std::string text;
@@ -359,7 +380,11 @@ void DevToolsUI::render_disassembly()
   std::vector<DisasmEntry> lines;
   lines.reserve(NUM_LINES);
 
+  word start_addr = center_pc - 16;
   word addr = start_addr;
+  DisassembledCode dummy_dc;
+  std::vector<dword> dummy_eps;
+
   for (int i = 0; i < NUM_LINES; i++) {
     DisasmEntry entry;
     entry.addr = addr;
@@ -382,11 +407,21 @@ void DevToolsUI::render_disassembly()
       if (line_bytes <= 0) line_bytes = 1;
       addr = (addr + line_bytes) & 0xFFFF;
     } else {
-      auto line = disassemble_one(addr, dummy_dc, dummy_eps);
-      entry.text = line.instruction_;
-      int len = line.Size();
-      if (len <= 0) len = 1;
-      addr = (addr + len) & 0xFFFF;
+      // Check execution-trace cache first
+      auto it = disasm_cache_.find(addr);
+      if (it != disasm_cache_.end()) {
+        entry.text = it->second.text;
+        int len = it->second.length;
+        if (len <= 0) len = 1;
+        addr = (addr + len) & 0xFFFF;
+      } else {
+        // Cache miss — disassemble (but don't cache: we only cache PC-visited addrs)
+        auto line = disassemble_one(addr, dummy_dc, dummy_eps);
+        entry.text = line.instruction_;
+        int len = line.Size();
+        if (len <= 0) len = 1;
+        addr = (addr + len) & 0xFFFF;
+      }
     }
     lines.push_back(std::move(entry));
   }

--- a/src/devtools_ui.cpp
+++ b/src/devtools_ui.cpp
@@ -368,12 +368,12 @@ void DevToolsUI::render_disassembly()
     center_pc = static_cast<word>(disasm_goto_value_);
   }
 
-  // Invalidate cache on banking change
+  // Invalidate cache on banking change (track each config separately to avoid XOR collisions)
   extern t_GateArray GateArray;
-  byte cur_banking = GateArray.RAM_config ^ GateArray.ROM_config;
-  if (cur_banking != disasm_cache_banking_) {
+  if (GateArray.RAM_config != disasm_cache_ram_config_ || GateArray.ROM_config != disasm_cache_rom_config_) {
     disasm_cache_.clear();
-    disasm_cache_banking_ = cur_banking;
+    disasm_cache_ram_config_ = GateArray.RAM_config;
+    disasm_cache_rom_config_ = GateArray.ROM_config;
   }
 
   // Record current PC into the execution-trace cache
@@ -450,9 +450,11 @@ void DevToolsUI::render_disassembly()
     bool pc_in_rom = (membank_read[pc_slot] != membank_write[pc_slot]);
     char bank_hdr[64];
     if (pc_in_rom) {
+      const char* rom_name = (pc_slot == 0) ? "Lower ROM"
+                           : (pc_slot == 3) ? "Upper ROM"
+                           : "ROM";  // expansion ROM in unusual slot
       snprintf(bank_hdr, sizeof(bank_hdr), "%04X-%04X: %s",
-               pc_slot * 0x4000, pc_slot * 0x4000 + 0x3FFF,
-               pc_slot == 0 ? "Lower ROM" : "Upper ROM");
+               pc_slot * 0x4000, pc_slot * 0x4000 + 0x3FFF, rom_name);
     } else if (pc_slot == 1 && GateArray.RAM_bank > 0) {
       snprintf(bank_hdr, sizeof(bank_hdr), "%04X-%04X: RAM (expansion bank %d)",
                pc_slot * 0x4000, pc_slot * 0x4000 + 0x3FFF, GateArray.RAM_bank);

--- a/src/devtools_ui.cpp
+++ b/src/devtools_ui.cpp
@@ -344,12 +344,9 @@ void DevToolsUI::render_disassembly()
     center_pc = static_cast<word>(disasm_goto_value_);
   }
 
-  // Disassemble from a 16-byte aligned address before center_pc.
-  // Alignment ensures start_addr only changes every 16 bytes of PC movement,
-  // keeping the instruction list stable (no re-alignment jitter from
-  // variable-length Z80 instructions).
-  word start_addr = (center_pc - 96) & 0xFFF0;
-  constexpr int NUM_LINES = 64;
+  // Disassemble ~48 instructions starting a few lines before center
+  word start_addr = center_pc - 16;
+  constexpr int NUM_LINES = 48;
 
   DisassembledCode dummy_dc;
   std::vector<dword> dummy_eps;

--- a/src/devtools_ui.cpp
+++ b/src/devtools_ui.cpp
@@ -344,10 +344,12 @@ void DevToolsUI::render_disassembly()
     center_pc = static_cast<word>(disasm_goto_value_);
   }
 
-  // Disassemble ~48 instructions starting well before center
-  // Use a larger offset so SetScrollHereY(0.3f) has enough content above PC
-  word start_addr = center_pc - 64;
-  constexpr int NUM_LINES = 48;
+  // Disassemble from a 16-byte aligned address before center_pc.
+  // Alignment ensures start_addr only changes every 16 bytes of PC movement,
+  // keeping the instruction list stable (no re-alignment jitter from
+  // variable-length Z80 instructions).
+  word start_addr = (center_pc - 96) & 0xFFF0;
+  constexpr int NUM_LINES = 64;
 
   DisassembledCode dummy_dc;
   std::vector<dword> dummy_eps;

--- a/src/devtools_ui.cpp
+++ b/src/devtools_ui.cpp
@@ -344,9 +344,9 @@ void DevToolsUI::render_disassembly()
     center_pc = static_cast<word>(disasm_goto_value_);
   }
 
-  // Disassemble ~48 instructions starting a few lines before center
-  // Use a small offset so the target appears near the top 1/3 of the view
-  word start_addr = center_pc - 16;
+  // Disassemble ~48 instructions starting well before center
+  // Use a larger offset so SetScrollHereY(0.3f) has enough content above PC
+  word start_addr = center_pc - 64;
   constexpr int NUM_LINES = 48;
 
   DisassembledCode dummy_dc;
@@ -394,8 +394,12 @@ void DevToolsUI::render_disassembly()
 
   const auto& breakpoints = z80_list_breakpoints_ref();
 
+  // ROM detection: when read and write banks differ for a slot, ROM is overlaid
+  extern byte *membank_read[4], *membank_write[4];
+
   if (ImGui::BeginChild("##disasm_scroll", ImVec2(0, 0), ImGuiChildFlags_Borders)) {
     int scroll_to_idx = -1;
+    word prev_slot = 0xFF;  // reset each frame for bank boundary detection
 
     for (int i = 0; i < static_cast<int>(lines.size()); i++) {
       const auto& entry = lines[i];
@@ -403,6 +407,48 @@ void DevToolsUI::render_disassembly()
       bool is_bp = false;
       for (const auto& bp : breakpoints) {
         if (bp.address == entry.addr && bp.type != EPHEMERAL) { is_bp = true; break; }
+      }
+
+      // --- Bank boundary separator ---
+      word cur_slot = (entry.addr >> 14) & 3;
+      if (cur_slot != prev_slot) {
+        prev_slot = cur_slot;
+        const char* bank_label = "?";
+        bool slot_is_rom = (membank_read[cur_slot] != membank_write[cur_slot]);
+        static char bank_label_buf[48];
+        if (slot_is_rom) {
+          if (cur_slot == 0)
+            bank_label = "Lower ROM";
+          else
+            bank_label = "Upper ROM";
+        } else {
+          if (cur_slot == 1 && GateArray.RAM_bank > 0) {
+            snprintf(bank_label_buf, sizeof(bank_label_buf),
+                     "RAM (expansion bank %d)", GateArray.RAM_bank);
+            bank_label = bank_label_buf;
+          } else {
+            snprintf(bank_label_buf, sizeof(bank_label_buf),
+                     "RAM (bank %d)", cur_slot);
+            bank_label = bank_label_buf;
+          }
+        }
+        ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.5f, 0.5f, 0.5f, 1.0f));
+        ImGui::Separator();
+        ImGui::Text("\xe2\x94\x80\xe2\x94\x80 %04X: %s \xe2\x94\x80\xe2\x94\x80",
+                    cur_slot * 0x4000, bank_label);
+        ImGui::PopStyleColor();
+      }
+
+      // --- ROM background tint (dark purple, matching memory hex viewer) ---
+      int slot = (entry.addr >> 14) & 3;
+      bool in_rom = (membank_read[slot] != membank_write[slot]);
+      if (in_rom) {
+        ImVec2 rpos = ImGui::GetCursorScreenPos();
+        float row_h = ImGui::GetTextLineHeightWithSpacing();
+        float row_w = ImGui::GetContentRegionAvail().x;
+        ImGui::GetWindowDrawList()->AddRectFilled(
+          rpos, ImVec2(rpos.x + row_w, rpos.y + row_h),
+          IM_COL32(60, 20, 60, 80));
       }
 
       // Symbol label above the instruction
@@ -419,7 +465,7 @@ void DevToolsUI::render_disassembly()
                is_bp ? kBreakpointMarker : " ",
                entry.addr, entry.text.c_str());
 
-      // Color: green for PC, red for breakpoint, amber for data area
+      // Color: green for PC, red for breakpoint, amber for data area, purple for ROM
       int style_colors_pushed = 0;
       if (entry.is_data_area && !is_pc && !is_bp) {
         // Subtle amber background for data area lines
@@ -431,6 +477,9 @@ void DevToolsUI::render_disassembly()
         style_colors_pushed = 1;
       } else if (is_bp) {
         ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 0.3f, 0.3f, 1.0f));
+        style_colors_pushed = 1;
+      } else if (in_rom) {
+        ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.7f, 0.5f, 0.8f, 1.0f));
         style_colors_pushed = 1;
       }
 

--- a/src/devtools_ui.cpp
+++ b/src/devtools_ui.cpp
@@ -307,7 +307,19 @@ void DevToolsUI::render_registers()
 void DevToolsUI::disasm_cache_record_pc()
 {
   word pc = z80.PC.w.l;
-  if (disasm_cache_.count(pc)) return; // already cached
+
+  // Push into PC history ring buffer (always, even if instruction is cached)
+  // Skip if same as last entry (avoid filling the buffer with repeated PCs when paused)
+  int prev_idx = (disasm_pc_history_head_ - 1 + DISASM_PC_HISTORY_SIZE) % DISASM_PC_HISTORY_SIZE;
+  if (disasm_pc_history_count_ == 0 || disasm_pc_history_[prev_idx] != pc) {
+    disasm_pc_history_[disasm_pc_history_head_] = pc;
+    disasm_pc_history_head_ = (disasm_pc_history_head_ + 1) % DISASM_PC_HISTORY_SIZE;
+    if (disasm_pc_history_count_ < DISASM_PC_HISTORY_SIZE)
+      disasm_pc_history_count_++;
+  }
+
+  // Cache the disassembled instruction at PC
+  if (disasm_cache_.count(pc)) return;
   DisassembledCode dc;
   std::vector<dword> eps;
   auto line = disassemble_one(pc, dc, eps);
@@ -367,8 +379,6 @@ void DevToolsUI::render_disassembly()
   // Record current PC into the execution-trace cache
   disasm_cache_record_pc();
 
-  // Build display lines by walking forward from start_addr.
-  // Cache hits are instant; misses disassemble and cache the result.
   constexpr int NUM_LINES = 48;
 
   struct DisasmEntry {
@@ -380,7 +390,9 @@ void DevToolsUI::render_disassembly()
   std::vector<DisasmEntry> lines;
   lines.reserve(NUM_LINES);
 
+  // Start a few instructions before center_pc so it appears in the upper portion.
   word start_addr = center_pc - 16;
+
   word addr = start_addr;
   DisassembledCode dummy_dc;
   std::vector<dword> dummy_eps;
@@ -431,9 +443,31 @@ void DevToolsUI::render_disassembly()
   // ROM detection: when read and write banks differ for a slot, ROM is overlaid
   extern byte *membank_read[4], *membank_write[4];
 
+  // Sticky bank header: shows what's mapped at the current PC slot.
+  // Displayed above the scrolling list so it's always visible.
+  {
+    word pc_slot = (center_pc >> 14) & 3;
+    bool pc_in_rom = (membank_read[pc_slot] != membank_write[pc_slot]);
+    char bank_hdr[64];
+    if (pc_in_rom) {
+      snprintf(bank_hdr, sizeof(bank_hdr), "%04X-%04X: %s",
+               pc_slot * 0x4000, pc_slot * 0x4000 + 0x3FFF,
+               pc_slot == 0 ? "Lower ROM" : "Upper ROM");
+    } else if (pc_slot == 1 && GateArray.RAM_bank > 0) {
+      snprintf(bank_hdr, sizeof(bank_hdr), "%04X-%04X: RAM (expansion bank %d)",
+               pc_slot * 0x4000, pc_slot * 0x4000 + 0x3FFF, GateArray.RAM_bank);
+    } else {
+      snprintf(bank_hdr, sizeof(bank_hdr), "%04X-%04X: RAM (bank %d)",
+               pc_slot * 0x4000, pc_slot * 0x4000 + 0x3FFF, pc_slot);
+    }
+    ImGui::PushStyleColor(ImGuiCol_Text,
+      pc_in_rom ? ImVec4(0.7f, 0.5f, 0.8f, 1.0f) : ImVec4(0.5f, 0.5f, 0.5f, 1.0f));
+    ImGui::TextUnformatted(bank_hdr);
+    ImGui::PopStyleColor();
+  }
+
   if (ImGui::BeginChild("##disasm_scroll", ImVec2(0, 0), ImGuiChildFlags_Borders)) {
     int scroll_to_idx = -1;
-    word prev_slot = 0xFF;  // reset each frame for bank boundary detection
 
     for (int i = 0; i < static_cast<int>(lines.size()); i++) {
       const auto& entry = lines[i];
@@ -441,36 +475,6 @@ void DevToolsUI::render_disassembly()
       bool is_bp = false;
       for (const auto& bp : breakpoints) {
         if (bp.address == entry.addr && bp.type != EPHEMERAL) { is_bp = true; break; }
-      }
-
-      // --- Bank boundary separator ---
-      word cur_slot = (entry.addr >> 14) & 3;
-      if (cur_slot != prev_slot) {
-        prev_slot = cur_slot;
-        const char* bank_label = "?";
-        bool slot_is_rom = (membank_read[cur_slot] != membank_write[cur_slot]);
-        static char bank_label_buf[48];
-        if (slot_is_rom) {
-          if (cur_slot == 0)
-            bank_label = "Lower ROM";
-          else
-            bank_label = "Upper ROM";
-        } else {
-          if (cur_slot == 1 && GateArray.RAM_bank > 0) {
-            snprintf(bank_label_buf, sizeof(bank_label_buf),
-                     "RAM (expansion bank %d)", GateArray.RAM_bank);
-            bank_label = bank_label_buf;
-          } else {
-            snprintf(bank_label_buf, sizeof(bank_label_buf),
-                     "RAM (bank %d)", cur_slot);
-            bank_label = bank_label_buf;
-          }
-        }
-        ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.5f, 0.5f, 0.5f, 1.0f));
-        ImGui::Separator();
-        ImGui::Text("\xe2\x94\x80\xe2\x94\x80 %04X: %s \xe2\x94\x80\xe2\x94\x80",
-                    cur_slot * 0x4000, bank_label);
-        ImGui::PopStyleColor();
       }
 
       // --- ROM background tint (dark purple, matching memory hex viewer) ---
@@ -588,7 +592,7 @@ void DevToolsUI::render_disassembly()
 
       if (style_colors_pushed > 0) ImGui::PopStyleColor(style_colors_pushed);
 
-      // Follow PC: scroll to keep PC visible (using SetScrollHereY in-place)
+      // Follow PC: scroll to keep PC visible
       if (is_pc && disasm_follow_pc_) {
         ImGui::SetScrollHereY(0.3f);
       }

--- a/src/devtools_ui.h
+++ b/src/devtools_ui.h
@@ -64,7 +64,8 @@ private:
       uint8_t length = 0; // instruction length in bytes (1-4)
     };
     std::unordered_map<word, CachedInsn> disasm_cache_;
-    byte disasm_cache_banking_ = 0xFF; // last seen RAM_config, invalidate on change
+    byte disasm_cache_ram_config_ = 0xFF;  // last seen RAM_config
+    byte disasm_cache_rom_config_ = 0xFF;  // last seen ROM_config
 
     // PC history ring buffer — records every PC value for stable backward walk
     static constexpr int DISASM_PC_HISTORY_SIZE = 64;
@@ -79,6 +80,8 @@ private:
       disasm_cache_.clear();
       disasm_pc_history_count_ = 0;
       disasm_pc_history_head_ = 0;
+      disasm_cache_ram_config_ = 0xFF;
+      disasm_cache_rom_config_ = 0xFF;
     }
 
     char memhex_goto_addr_[8] = "";

--- a/src/devtools_ui.h
+++ b/src/devtools_ui.h
@@ -66,10 +66,20 @@ private:
     std::unordered_map<word, CachedInsn> disasm_cache_;
     byte disasm_cache_banking_ = 0xFF; // last seen RAM_config, invalidate on change
 
-    // Record current PC into the cache (called each frame from render)
+    // PC history ring buffer — records every PC value for stable backward walk
+    static constexpr int DISASM_PC_HISTORY_SIZE = 64;
+    word disasm_pc_history_[DISASM_PC_HISTORY_SIZE] = {};
+    int disasm_pc_history_head_ = 0;
+    int disasm_pc_history_count_ = 0;
+
+    // Record current PC into the cache + history (called each frame from render)
     void disasm_cache_record_pc();
     // Invalidate cache (banking change, reset, memory write)
-    void disasm_cache_clear() { disasm_cache_.clear(); }
+    void disasm_cache_clear() {
+      disasm_cache_.clear();
+      disasm_pc_history_count_ = 0;
+      disasm_pc_history_head_ = 0;
+    }
 
     char memhex_goto_addr_[8] = "";
     int memhex_goto_value_ = -1;

--- a/src/devtools_ui.h
+++ b/src/devtools_ui.h
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <vector>
+#include <unordered_map>
 #include <cstdint>
 #include "types.h"
 #include "disk_file_editor.h"
@@ -55,6 +56,20 @@ private:
     char disasm_goto_addr_[8] = "";
     int disasm_goto_value_ = -1;
     bool disasm_scroll_pending_ = false;
+
+    // Execution-trace disassembly cache: only caches addresses PC has visited.
+    // Gives stable, jitter-free display + O(1) lookup for hot code paths.
+    struct CachedInsn {
+      std::string text;   // disassembled instruction text
+      uint8_t length = 0; // instruction length in bytes (1-4)
+    };
+    std::unordered_map<word, CachedInsn> disasm_cache_;
+    byte disasm_cache_banking_ = 0xFF; // last seen RAM_config, invalidate on change
+
+    // Record current PC into the cache (called each frame from render)
+    void disasm_cache_record_pc();
+    // Invalidate cache (banking change, reset, memory write)
+    void disasm_cache_clear() { disasm_cache_.clear(); }
 
     char memhex_goto_addr_[8] = "";
     int memhex_goto_value_ = -1;

--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -3999,7 +3999,7 @@ int koncpc_main (int argc, char **argv)
             if (g_m4_http.is_running()) g_m4_http.drain_pending();
 
 #ifdef __APPLE__
-            // Update Dock icon with CPC screen preview (~5fps)
+            // Update Dock icon with CPC screen preview (~1fps at 50fps emulation)
             // back_surface is already sized to CPC_VISIBLE_SCR_WIDTH/HEIGHT * scale
             if (back_surface && (dwFrameCountOverall % 50) == 0) {
                koncpc_update_dock_icon_preview(

--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -4001,7 +4001,7 @@ int koncpc_main (int argc, char **argv)
 #ifdef __APPLE__
             // Update Dock icon with CPC screen preview (~5fps)
             // back_surface is already sized to CPC_VISIBLE_SCR_WIDTH/HEIGHT * scale
-            if (back_surface && (dwFrameCountOverall % 10) == 0) {
+            if (back_surface && (dwFrameCountOverall % 50) == 0) {
                koncpc_update_dock_icon_preview(
                   back_surface->pixels, back_surface->w, back_surface->h, back_surface->pitch,
                   0, 0, back_surface->w, back_surface->h);

--- a/src/macos_menu.mm
+++ b/src/macos_menu.mm
@@ -290,10 +290,9 @@ void koncpc_update_dock_icon_preview(const void* pixels, int surface_w, int surf
 
   int w = vis_w, h = vis_h;
 
-  // All Cocoa drawing (lockFocus, setApplicationIconImage) must happen on
-  // the main thread. The pixel copy above is the only work on the emulation
-  // thread. The in-flight guard ensures we don't queue up frames.
-  dispatch_async(dispatch_get_main_queue(), ^{
+  // Compositing (lockFocus/drawInRect) is expensive — do it on a background queue.
+  // Only the final setApplicationIconImage must run on the main thread.
+  dispatch_async(dispatch_get_global_queue(QOS_CLASS_BACKGROUND, 0), ^{
     @autoreleasepool {
       CGColorSpaceRef cs = CGColorSpaceCreateDeviceRGB();
       CGContextRef ctx = CGBitmapContextCreate(
@@ -334,15 +333,14 @@ void koncpc_update_dock_icon_preview(const void* pixels, int surface_w, int surf
 
       [composite unlockFocus];
       CGImageRelease(cgScreen);
-
-      [NSApp setApplicationIconImage:composite];
-
-      // Manual retain/release — no ARC in this project.
-      // Without these, each update leaks ~3MB (two NSImages at 850x850).
       [screenImg release];
-      [composite release];
 
-      g_icon_update_in_flight.store(false);
+      // Only this part needs the main thread
+      dispatch_async(dispatch_get_main_queue(), ^{
+        [NSApp setApplicationIconImage:composite];
+        [composite release];
+        g_icon_update_in_flight.store(false);
+      });
     }
   });
 }


### PR DESCRIPTION
## Summary

Three disassembly view improvements for better debugging UX.

## Changes

### 1. Pin PC at fixed position
When "Follow PC" is on, PC now stays at ~1/3 from the top of the view. Previously it jumped around because only 16 bytes were disassembled before PC — now 64 bytes (~20-30 instructions) provide stable content above.

### 2. ROM color-coding
Disassembly lines in ROM-overlaid memory regions get a dark purple background tint and purple text, matching the memory hex viewer's visual language. Detection uses `membank_read[slot] != membank_write[slot]`.

### 3. Bank marks at 16K boundaries
Separator lines appear when crossing 16K boundaries (0000/4000/8000/C000) showing what's mapped:
- "Lower ROM" / "Upper ROM" for ROM-overlaid slots
- "RAM (expansion bank N)" for slot 1 with expansion banking (128K or Yarek 4MB)
- "RAM (bank N)" for standard RAM

The Yarek 4MB extension uses the same banking mechanism — `GateArray.RAM_bank` identifies the active 64K block.

## Test plan
- [x] 829 tests pass (macOS)
- [ ] Visual: PC stays pinned when stepping
- [ ] Visual: ROM addresses show purple tint
- [ ] Visual: bank separators visible at 16K boundaries
- [ ] Visual: expansion bank label updates when banking changes