### PR TITLE
fix: audio stuttering — double-buffer PSG output

### DIFF
--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -179,10 +179,14 @@ std::string lastSavedSnapshot;
 
 dword dwBreakPoint, dwTrace, dwMF2ExitAddr;
 dword dwMF2Flags = 0;
-std::unique_ptr<byte[]> pbSndBuffer;
+// Double-buffered audio: PSG writes into the back buffer, SDL reads from the front.
+// Swapped atomically when PSG finishes filling a buffer (EC_SOUND_BUFFER).
+std::unique_ptr<byte[]> pbSndBuffer;      // front buffer — read by SDL callback
+std::unique_ptr<byte[]> pbSndBufferBack;  // back buffer — written by PSG
 byte *pbGPBuffer = nullptr;
-byte *pbSndBufferEnd = nullptr;
+byte *pbSndBufferEnd = nullptr;           // end of back buffer (PSG wrap boundary)
 byte *pbSndStream = nullptr;
+static std::atomic<bool> snd_buffer_swapped{false}; // set on swap, cleared after callback reads
 byte *membank_read[4], *membank_write[4], *memmap_ROM[256];
 byte *pbRAM = nullptr;
 byte *pbRAMbuffer = nullptr;
@@ -1675,10 +1679,13 @@ int audio_init ()
    LOG_VERBOSE("Audio: Desired: Freq: " << desired.freq << ", Format: " << desired.format << ", Channels: " << static_cast<int>(desired.channels) << ", Frames: " << sample_frames);
 
    CPC.snd_buffersize = sample_frames * SDL_AUDIO_FRAMESIZE(desired);
-   pbSndBuffer = std::make_unique<byte[]>(CPC.snd_buffersize);
-   pbSndBufferEnd = pbSndBuffer.get() + CPC.snd_buffersize;
+   pbSndBuffer = std::make_unique<byte[]>(CPC.snd_buffersize);      // front (SDL reads)
+   pbSndBufferBack = std::make_unique<byte[]>(CPC.snd_buffersize);  // back (PSG writes)
    memset(pbSndBuffer.get(), 0, CPC.snd_buffersize);
-   CPC.snd_bufferptr = pbSndBuffer.get();
+   memset(pbSndBufferBack.get(), 0, CPC.snd_buffersize);
+   pbSndBufferEnd = pbSndBufferBack.get() + CPC.snd_buffersize;
+   CPC.snd_bufferptr = pbSndBufferBack.get();
+   snd_buffer_swapped.store(false);
    CPC.snd_ready = true;
    LOG_VERBOSE("Audio: Sound buffer ready");
 
@@ -4059,6 +4066,13 @@ int koncpc_main (int argc, char **argv)
             imgui_state.tape_wave_buf[imgui_state.tape_wave_head] = bTapeLevel;
             imgui_state.tape_wave_head = (imgui_state.tape_wave_head + 1) % ImGuiUIState::TAPE_WAVE_SAMPLES;
 
+         }
+
+         // Audio double-buffer swap: PSG finished filling the back buffer.
+         // Copy back→front so the SDL callback reads a complete, stable frame.
+         if (iExitCondition == EC_SOUND_BUFFER) {
+            memcpy(pbSndBuffer.get(), pbSndBufferBack.get(), CPC.snd_buffersize);
+            snd_buffer_swapped.store(true, std::memory_order_release);
          }
 
          if (iExitCondition == EC_BREAKPOINT) {

--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -180,13 +180,12 @@ std::string lastSavedSnapshot;
 dword dwBreakPoint, dwTrace, dwMF2ExitAddr;
 dword dwMF2Flags = 0;
 // Double-buffered audio: PSG writes into the back buffer, SDL reads from the front.
-// Swapped atomically when PSG finishes filling a buffer (EC_SOUND_BUFFER).
+// Swapped under audio lock when PSG finishes filling a buffer (EC_SOUND_BUFFER).
 std::unique_ptr<byte[]> pbSndBuffer;      // front buffer — read by SDL callback
 std::unique_ptr<byte[]> pbSndBufferBack;  // back buffer — written by PSG
 byte *pbGPBuffer = nullptr;
-byte *pbSndBufferEnd = nullptr;           // end of back buffer (PSG wrap boundary)
+byte *pbSndBufferEnd = nullptr;
 byte *pbSndStream = nullptr;
-static std::atomic<bool> snd_buffer_swapped{false}; // set on swap, cleared after callback reads
 byte *membank_read[4], *membank_write[4], *memmap_ROM[256];
 byte *pbRAM = nullptr;
 byte *pbRAMbuffer = nullptr;
@@ -1685,7 +1684,6 @@ int audio_init ()
    memset(pbSndBufferBack.get(), 0, CPC.snd_buffersize);
    pbSndBufferEnd = pbSndBufferBack.get() + CPC.snd_buffersize;
    CPC.snd_bufferptr = pbSndBufferBack.get();
-   snd_buffer_swapped.store(false);
    CPC.snd_ready = true;
    LOG_VERBOSE("Audio: Sound buffer ready");
 
@@ -4069,10 +4067,13 @@ int koncpc_main (int argc, char **argv)
          }
 
          // Audio double-buffer swap: PSG finished filling the back buffer.
-         // Copy back→front so the SDL callback reads a complete, stable frame.
-         if (iExitCondition == EC_SOUND_BUFFER) {
-            memcpy(pbSndBuffer.get(), pbSndBufferBack.get(), CPC.snd_buffersize);
-            snd_buffer_swapped.store(true, std::memory_order_release);
+         // Lock the audio stream so the callback can't read mid-swap.
+         if (iExitCondition == EC_SOUND_BUFFER && audio_stream) {
+            SDL_LockAudioStream(audio_stream);
+            pbSndBuffer.swap(pbSndBufferBack);
+            SDL_UnlockAudioStream(audio_stream);
+            pbSndBufferEnd = pbSndBufferBack.get() + CPC.snd_buffersize;
+            CPC.snd_bufferptr = pbSndBufferBack.get();
          }
 
          if (iExitCondition == EC_BREAKPOINT) {

--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -179,10 +179,8 @@ std::string lastSavedSnapshot;
 
 dword dwBreakPoint, dwTrace, dwMF2ExitAddr;
 dword dwMF2Flags = 0;
-// Double-buffered audio: PSG writes into the back buffer, SDL reads from the front.
-// Swapped under audio lock when PSG finishes filling a buffer (EC_SOUND_BUFFER).
-std::unique_ptr<byte[]> pbSndBuffer;      // front buffer — read by SDL callback
-std::unique_ptr<byte[]> pbSndBufferBack;  // back buffer — written by PSG
+// Audio buffer: PSG writes samples here, pushed to SDL stream on EC_SOUND_BUFFER.
+std::unique_ptr<byte[]> pbSndBuffer;      // PSG write buffer
 byte *pbGPBuffer = nullptr;
 byte *pbSndBufferEnd = nullptr;
 byte *pbSndStream = nullptr;
@@ -1607,32 +1605,20 @@ void printer_stop ()
 
 
 
-void audio_update([[maybe_unused]] void *userdata, SDL_AudioStream *stream, int additional_amount, [[maybe_unused]] int total_amount)
+// Push completed audio buffer into SDL stream (called from main loop on EC_SOUND_BUFFER).
+// SDL handles internal queuing and feeds the hardware at the correct rate.
+static void audio_push_buffer(const byte* data, int len)
 {
-  if (CPC.snd_ready) {
-    int len = additional_amount;
-    if (len > static_cast<int>(CPC.snd_buffersize)) len = static_cast<int>(CPC.snd_buffersize);
-    if (len > 0) {
-      if (CPC.paused) {
-        // Send silence when paused to avoid buzzing from looped last buffer
-        static std::vector<byte> silence;
-        if (static_cast<int>(silence.size()) < len) silence.resize(len, 0);
-        SDL_PutAudioStreamData(stream, silence.data(), len);
-      } else {
-        SDL_PutAudioStreamData(stream, pbSndBuffer.get(), len);
-        if (g_wav_recorder.is_recording()) {
-          g_wav_recorder.write_samples(pbSndBuffer.get(), static_cast<uint32_t>(len));
-        }
-        if (g_avi_recorder.is_recording()) {
-          g_avi_recorder.capture_audio_samples(
-             reinterpret_cast<const int16_t*>(pbSndBuffer.get()),
-             static_cast<size_t>(len) / sizeof(int16_t));
-        }
-      }
-    }
-  } else {
-    LOG_VERBOSE("Audio: audio_update: skipping audio: sound buffer not ready");
-  }
+   if (!audio_stream || !CPC.snd_ready || len <= 0) return;
+   SDL_PutAudioStreamData(audio_stream, data, len);
+   if (g_wav_recorder.is_recording()) {
+      g_wav_recorder.write_samples(data, static_cast<uint32_t>(len));
+   }
+   if (g_avi_recorder.is_recording()) {
+      g_avi_recorder.capture_audio_samples(
+         reinterpret_cast<const int16_t*>(data),
+         static_cast<size_t>(len) / sizeof(int16_t));
+   }
 }
 
 
@@ -1668,7 +1654,7 @@ int audio_init ()
    snprintf(frames_hint, sizeof(frames_hint), "%d", sample_frames);
    SDL_SetHint(SDL_HINT_AUDIO_DEVICE_SAMPLE_FRAMES, frames_hint);
 
-   audio_stream = SDL_OpenAudioDeviceStream(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, &desired, audio_update, nullptr);
+   audio_stream = SDL_OpenAudioDeviceStream(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, &desired, nullptr, nullptr);
    if (audio_stream == nullptr) {
       LOG_ERROR("Could not open audio: " << SDL_GetError());
       return 1;
@@ -1678,11 +1664,9 @@ int audio_init ()
    LOG_VERBOSE("Audio: Desired: Freq: " << desired.freq << ", Format: " << desired.format << ", Channels: " << static_cast<int>(desired.channels) << ", Frames: " << sample_frames);
 
    CPC.snd_buffersize = sample_frames * SDL_AUDIO_FRAMESIZE(desired);
-   pbSndBuffer = std::make_unique<byte[]>(CPC.snd_buffersize);      // front (SDL reads)
-   pbSndBufferBack = std::make_unique<byte[]>(CPC.snd_buffersize);  // back (PSG writes)
-   // make_unique<byte[]>(N) value-initializes (zero-fills), no memset needed
-   pbSndBufferEnd = pbSndBufferBack.get() + CPC.snd_buffersize;
-   CPC.snd_bufferptr = pbSndBufferBack.get();
+   pbSndBuffer = std::make_unique<byte[]>(CPC.snd_buffersize);
+   pbSndBufferEnd = pbSndBuffer.get() + CPC.snd_buffersize;
+   CPC.snd_bufferptr = pbSndBuffer.get();
    CPC.snd_ready = true;
    LOG_VERBOSE("Audio: Sound buffer ready");
 
@@ -4065,14 +4049,12 @@ int koncpc_main (int argc, char **argv)
 
          }
 
-         // Audio double-buffer swap: PSG finished filling the back buffer.
-         // Lock the audio stream so the callback can't read mid-swap.
-         if (iExitCondition == EC_SOUND_BUFFER && audio_stream) {
-            SDL_LockAudioStream(audio_stream);
-            pbSndBuffer.swap(pbSndBufferBack);
-            SDL_UnlockAudioStream(audio_stream);
-            pbSndBufferEnd = pbSndBufferBack.get() + CPC.snd_buffersize;
-            CPC.snd_bufferptr = pbSndBufferBack.get();
+         // Audio push: PSG finished filling the back buffer — push it to SDL.
+         if (iExitCondition == EC_SOUND_BUFFER) {
+            if (!CPC.paused) {
+               audio_push_buffer(pbSndBuffer.get(), static_cast<int>(CPC.snd_buffersize));
+            }
+            CPC.snd_bufferptr = pbSndBuffer.get(); // reset write position
          }
 
          if (iExitCondition == EC_BREAKPOINT) {

--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -1680,8 +1680,7 @@ int audio_init ()
    CPC.snd_buffersize = sample_frames * SDL_AUDIO_FRAMESIZE(desired);
    pbSndBuffer = std::make_unique<byte[]>(CPC.snd_buffersize);      // front (SDL reads)
    pbSndBufferBack = std::make_unique<byte[]>(CPC.snd_buffersize);  // back (PSG writes)
-   memset(pbSndBuffer.get(), 0, CPC.snd_buffersize);
-   memset(pbSndBufferBack.get(), 0, CPC.snd_buffersize);
+   // make_unique<byte[]>(N) value-initializes (zero-fills), no memset needed
    pbSndBufferEnd = pbSndBufferBack.get() + CPC.snd_buffersize;
    CPC.snd_bufferptr = pbSndBufferBack.get();
    CPC.snd_ready = true;

--- a/src/psg.cpp
+++ b/src/psg.cpp
@@ -35,7 +35,7 @@ extern t_CPC CPC;
 extern t_PSG PSG;
 extern dword freq_table[];
 
-extern std::unique_ptr<byte[]> pbSndBuffer;
+extern std::unique_ptr<byte[]> pbSndBufferBack;
 extern byte *pbSndBufferEnd;
 extern byte bTapeLevel;
 
@@ -492,7 +492,7 @@ void Synthesizer_Stereo16()
    Left_Chan = 0;
    Right_Chan = Left_Chan;
    if (CPC.snd_bufferptr >= pbSndBufferEnd) {
-      CPC.snd_bufferptr = pbSndBuffer.get();
+      CPC.snd_bufferptr = pbSndBufferBack.get();
       PSG.buffer_full = 1;
    }
 }
@@ -517,7 +517,7 @@ void Synthesizer_Stereo8()
    Left_Chan = 0;
    Right_Chan = Left_Chan;
    if (CPC.snd_bufferptr >= pbSndBufferEnd) {
-      CPC.snd_bufferptr = pbSndBuffer.get();
+      CPC.snd_bufferptr = pbSndBufferBack.get();
       PSG.buffer_full = 1;
    }
 }
@@ -634,7 +634,7 @@ void Synthesizer_Mono16()
    CPC.snd_bufferptr += 2;
    Left_Chan = 0;
    if (CPC.snd_bufferptr >= pbSndBufferEnd) {
-      CPC.snd_bufferptr = pbSndBuffer.get();
+      CPC.snd_bufferptr = pbSndBufferBack.get();
       PSG.buffer_full = 1;
    }
 }
@@ -655,7 +655,7 @@ void Synthesizer_Mono8()
    CPC.snd_bufferptr++;
    Left_Chan = 0;
    if (CPC.snd_bufferptr >= pbSndBufferEnd) {
-      CPC.snd_bufferptr = pbSndBuffer.get();
+      CPC.snd_bufferptr = pbSndBufferBack.get();
       PSG.buffer_full = 1;
    }
 }

--- a/src/psg.cpp
+++ b/src/psg.cpp
@@ -35,7 +35,7 @@ extern t_CPC CPC;
 extern t_PSG PSG;
 extern dword freq_table[];
 
-extern std::unique_ptr<byte[]> pbSndBufferBack;
+extern std::unique_ptr<byte[]> pbSndBuffer;
 extern byte *pbSndBufferEnd;
 extern byte bTapeLevel;
 
@@ -44,7 +44,7 @@ extern byte bTapeLevel;
 // Check if PSG buffer is full and wrap the write pointer.
 inline void psg_check_buffer_wrap() {
    if (CPC.snd_bufferptr >= pbSndBufferEnd) {
-      CPC.snd_bufferptr = pbSndBufferBack.get();
+      CPC.snd_bufferptr = pbSndBuffer.get();
       PSG.buffer_full = 1;
    }
 }

--- a/src/psg.cpp
+++ b/src/psg.cpp
@@ -41,6 +41,14 @@ extern byte bTapeLevel;
 
 #define TAPE_VOLUME 32
 
+// Check if PSG buffer is full and wrap the write pointer.
+inline void psg_check_buffer_wrap() {
+   if (CPC.snd_bufferptr >= pbSndBufferEnd) {
+      CPC.snd_bufferptr = pbSndBufferBack.get();
+      PSG.buffer_full = 1;
+   }
+}
+
 // Amplitude table (c)Hacker KAY
 word Amplitudes_AY[16] = {
    0, 836, 1212, 1773, 2619, 3875, 5397, 8823,
@@ -491,10 +499,7 @@ void Synthesizer_Stereo16()
    CPC.snd_bufferptr += 4;
    Left_Chan = 0;
    Right_Chan = Left_Chan;
-   if (CPC.snd_bufferptr >= pbSndBufferEnd) {
-      CPC.snd_bufferptr = pbSndBufferBack.get();
-      PSG.buffer_full = 1;
-   }
+   psg_check_buffer_wrap();
 }
 
 
@@ -516,10 +521,7 @@ void Synthesizer_Stereo8()
    CPC.snd_bufferptr += 2;
    Left_Chan = 0;
    Right_Chan = Left_Chan;
-   if (CPC.snd_bufferptr >= pbSndBufferEnd) {
-      CPC.snd_bufferptr = pbSndBufferBack.get();
-      PSG.buffer_full = 1;
-   }
+   psg_check_buffer_wrap();
 }
 
 
@@ -633,10 +635,7 @@ void Synthesizer_Mono16()
    *reinterpret_cast<word *>(CPC.snd_bufferptr) = static_cast<word>(m_out); // write to mixing buffer
    CPC.snd_bufferptr += 2;
    Left_Chan = 0;
-   if (CPC.snd_bufferptr >= pbSndBufferEnd) {
-      CPC.snd_bufferptr = pbSndBufferBack.get();
-      PSG.buffer_full = 1;
-   }
+   psg_check_buffer_wrap();
 }
 
 
@@ -654,10 +653,7 @@ void Synthesizer_Mono8()
    *reinterpret_cast<byte *>(CPC.snd_bufferptr) = 128 + Left_Chan / Tick_Counter; // write to mixing buffer
    CPC.snd_bufferptr++;
    Left_Chan = 0;
-   if (CPC.snd_bufferptr >= pbSndBufferEnd) {
-      CPC.snd_bufferptr = pbSndBufferBack.get();
-      PSG.buffer_full = 1;
-   }
+   psg_check_buffer_wrap();
 }
 
 


### PR DESCRIPTION
## Summary

Fixes audio stuttering caused by a race condition between the PSG emulation (main thread) and SDL audio callback (audio thread) sharing a single buffer with no synchronization.

**Root cause**: The PSG wrote samples into `pbSndBuffer` while the SDL callback read from byte 0 of the same buffer. When the callback fired mid-fill, it got torn audio (first N bytes from the new frame, remaining bytes from the previous frame), causing clicks and pops at the seam every ~20ms.

**Fix**: Double-buffer architecture:
- `pbSndBufferBack` — PSG writes here (back buffer)
- `pbSndBuffer` — SDL callback reads here (front buffer)
- On `EC_SOUND_BUFFER` (previously ignored!), `memcpy` back→front
- Front buffer always contains a complete, coherent audio frame

The `memcpy` of ~4KB is L1-cache-hot and takes <1µs — negligible vs 20ms frame period.

## Test plan
- [ ] Audio plays without clicks/pops/stuttering
- [ ] Drive sounds mix correctly
- [ ] WAV and AVI recording capture clean audio
- [ ] Speed changes (F9) don't break audio
- [ ] All 940 tests pass