### PR TITLE
feat: audio underrun diagnostics

### DIFF
--- a/src/imgui_ui.cpp
+++ b/src/imgui_ui.cpp
@@ -2645,10 +2645,14 @@ static void imgui_render_devtools()
     // ── Audio diagnostics ──
     ImGui::SameLine(0, 8.0f);
     {
-      bool has_underruns = imgui_state.audio_underruns > 0;
-      ImGui::PushStyleColor(ImGuiCol_Text, has_underruns
-        ? ImVec4(1.0f, 0.3f, 0.3f, 1.0f)    // red if underruns
-        : ImVec4(0.4f, 0.4f, 0.4f, 1.0f));   // gray if healthy
+      ImVec4 snd_color;
+      if (imgui_state.audio_underruns > 0)
+        snd_color = ImVec4(1.0f, 0.3f, 0.3f, 1.0f);    // red: hard underrun
+      else if (imgui_state.audio_near_underruns > 0)
+        snd_color = ImVec4(1.0f, 0.8f, 0.2f, 1.0f);    // yellow: near-underrun
+      else
+        snd_color = ImVec4(0.4f, 0.4f, 0.4f, 1.0f);    // gray: healthy
+      ImGui::PushStyleColor(ImGuiCol_Text, snd_color);
       char abuf[32];
       snprintf(abuf, sizeof(abuf), "snd:%.0fms", imgui_state.audio_queue_avg_ms);
       ImGui::TextUnformatted(abuf);
@@ -2659,6 +2663,7 @@ static void imgui_render_devtools()
         ImGui::Text("Push interval max: %.0f us", imgui_state.audio_push_interval_max_us);
         ImGui::Text("Pushes/sec: %d", imgui_state.audio_pushes);
         ImGui::Text("Underruns/sec: %d", imgui_state.audio_underruns);
+        ImGui::Text("Near-underruns/sec: %d", imgui_state.audio_near_underruns);
         ImGui::EndTooltip();
       }
       ImGui::PopStyleColor();

--- a/src/imgui_ui.cpp
+++ b/src/imgui_ui.cpp
@@ -2642,6 +2642,28 @@ static void imgui_render_devtools()
       ImGui::PopStyleColor();
     }
 
+    // ── Audio diagnostics ──
+    ImGui::SameLine(0, 8.0f);
+    {
+      bool has_underruns = imgui_state.audio_underruns > 0;
+      ImGui::PushStyleColor(ImGuiCol_Text, has_underruns
+        ? ImVec4(1.0f, 0.3f, 0.3f, 1.0f)    // red if underruns
+        : ImVec4(0.4f, 0.4f, 0.4f, 1.0f));   // gray if healthy
+      char abuf[32];
+      snprintf(abuf, sizeof(abuf), "snd:%.0fms", imgui_state.audio_queue_avg_ms);
+      ImGui::TextUnformatted(abuf);
+      if (ImGui::IsItemHovered()) {
+        ImGui::BeginTooltip();
+        ImGui::Text("Audio queue avg: %.1f ms", imgui_state.audio_queue_avg_ms);
+        ImGui::Text("Audio queue min: %.1f ms", imgui_state.audio_queue_min_ms);
+        ImGui::Text("Push interval max: %.0f us", imgui_state.audio_push_interval_max_us);
+        ImGui::Text("Pushes/sec: %d", imgui_state.audio_pushes);
+        ImGui::Text("Underruns/sec: %d", imgui_state.audio_underruns);
+        ImGui::EndTooltip();
+      }
+      ImGui::PopStyleColor();
+    }
+
     // ── Sync devtools bar height ──
     {
       int h = static_cast<int>(ImGui::GetWindowSize().y);

--- a/src/imgui_ui.h
+++ b/src/imgui_ui.h
@@ -43,6 +43,13 @@ struct ImGuiUIState {
   float sleep_time_avg_us = 0.0f;
   float z80_time_avg_us = 0.0f;
 
+  // Audio diagnostics (updated each second)
+  int audio_underruns = 0;           // times SDL queue was empty when we pushed
+  int audio_pushes = 0;              // total pushes this second
+  float audio_queue_avg_ms = 0.0f;   // average queue depth in ms
+  float audio_queue_min_ms = 0.0f;   // minimum queue depth in ms
+  float audio_push_interval_max_us = 0.0f; // longest gap between pushes
+
   // Options dialog state
   t_CPC old_cpc_settings;
 

--- a/src/imgui_ui.h
+++ b/src/imgui_ui.h
@@ -45,6 +45,7 @@ struct ImGuiUIState {
 
   // Audio diagnostics (updated each second)
   int audio_underruns = 0;           // times SDL queue was empty when we pushed
+  int audio_near_underruns = 0;      // times queue was below 1 buffer
   int audio_pushes = 0;              // total pushes this second
   float audio_queue_avg_ms = 0.0f;   // average queue depth in ms
   float audio_queue_min_ms = 0.0f;   // minimum queue depth in ms

--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -1707,6 +1707,16 @@ int audio_init ()
    pbSndBuffer = std::make_unique<byte[]>(CPC.snd_buffersize);
    pbSndBufferEnd = pbSndBuffer.get() + CPC.snd_buffersize;
    CPC.snd_bufferptr = pbSndBuffer.get();
+
+   // Pre-buffer 3 silent buffers (~69ms at 44100Hz) so the SDL queue has
+   // enough safety margin to absorb compositor stalls without underrunning.
+   {
+      std::vector<byte> silence(CPC.snd_buffersize, 0);
+      for (int i = 0; i < 3; i++) {
+         SDL_PutAudioStreamData(audio_stream, silence.data(), static_cast<int>(CPC.snd_buffersize));
+      }
+      LOG_VERBOSE("Audio: Pre-buffered " << 3 * CPC.snd_buffersize << " bytes of silence");
+   }
    CPC.snd_ready = true;
    LOG_VERBOSE("Audio: Sound buffer ready");
 

--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -1608,10 +1608,10 @@ void printer_stop ()
 // ── Audio diagnostics ──
 static uint64_t audio_last_push_tick = 0;   // perf counter of last push
 static int audio_underrun_count = 0;        // underruns: queue was empty
-static int audio_near_underrun_count = 0;   // near-underruns: queue < 1 buffer
+static int audio_near_underrun_count = 0;   // near-underruns: queue < half buffer
 static int audio_push_count = 0;            // pushes this reporting period
 static double audio_queue_sum_bytes = 0;    // sum of queue depths (for average)
-static float audio_queue_min_bytes = 1e9f;  // min queue depth this period
+static int audio_queue_min_bytes = INT_MAX; // min queue depth this period
 static uint64_t audio_push_interval_max = 0; // longest gap between pushes (perf ticks)
 
 // Push completed audio buffer into SDL stream (called from main loop on EC_SOUND_BUFFER).
@@ -1620,30 +1620,29 @@ static void audio_push_buffer(const byte* data, int len)
 {
    if (!audio_stream || !CPC.snd_ready || len <= 0) return;
 
+   uint64_t now = SDL_GetPerformanceCounter();
+
    // Measure queue depth BEFORE pushing.
-   // - queued == 0: SDL ran completely dry (hard underrun, audible gap)
-   // - queued < len: SDL had less than one buffer left (near-underrun, may click)
    int queued = SDL_GetAudioStreamQueued(audio_stream);
+   if (queued < 0) queued = 0; // SDL error — treat as empty
+
    if (audio_push_count > 0) {
       double interval_ms = audio_last_push_tick > 0
-         ? static_cast<double>(SDL_GetPerformanceCounter() - audio_last_push_tick)
-           * 1000.0 / SDL_GetPerformanceFrequency()
+         ? static_cast<double>(now - audio_last_push_tick) * 1000.0 / perfFreq
          : 0.0;
       if (queued == 0) {
          audio_underrun_count++;
          LOG_DEBUG("Audio UNDERRUN: queue empty, interval " << interval_ms << "ms");
       } else if (queued < len / 2) {
-         // Below half a buffer (~11ms) — real danger of audible artifact
          audio_near_underrun_count++;
          LOG_DEBUG("Audio near-underrun: queue " << queued << "B (< " << len / 2
                    << "B), interval " << interval_ms << "ms");
       }
    }
    audio_queue_sum_bytes += queued;
-   if (queued < audio_queue_min_bytes) audio_queue_min_bytes = static_cast<float>(queued);
+   if (queued < audio_queue_min_bytes) audio_queue_min_bytes = queued;
 
    // Measure push interval
-   uint64_t now = SDL_GetPerformanceCounter();
    if (audio_last_push_tick > 0) {
       uint64_t interval = now - audio_last_push_tick;
       if (interval > audio_push_interval_max) audio_push_interval_max = interval;
@@ -1651,7 +1650,10 @@ static void audio_push_buffer(const byte* data, int len)
    audio_last_push_tick = now;
    audio_push_count++;
 
-   SDL_PutAudioStreamData(audio_stream, data, len);
+   if (!SDL_PutAudioStreamData(audio_stream, data, len)) {
+      LOG_DEBUG("Audio: SDL_PutAudioStreamData failed");
+      return;
+   }
    if (g_wav_recorder.is_recording()) {
       g_wav_recorder.write_samples(data, static_cast<uint32_t>(len));
    }
@@ -1700,7 +1702,6 @@ int audio_init ()
       LOG_ERROR("Could not open audio: " << SDL_GetError());
       return 1;
    }
-   SDL_ResumeAudioDevice(SDL_GetAudioStreamDevice(audio_stream));
 
    LOG_VERBOSE("Audio: Desired: Freq: " << desired.freq << ", Format: " << desired.format << ", Channels: " << static_cast<int>(desired.channels) << ", Frames: " << sample_frames);
 
@@ -1711,12 +1712,14 @@ int audio_init ()
 
    // Pre-buffer 2 silent buffers (~46ms at 44100Hz) so the SDL queue has
    // enough margin to absorb occasional compositor stalls (~69ms observed).
+   // Done BEFORE resuming the device so SDL doesn't start draining immediately.
    {
       std::vector<byte> silence(CPC.snd_buffersize, 0);
       for (int i = 0; i < 2; i++) {
          SDL_PutAudioStreamData(audio_stream, silence.data(), static_cast<int>(CPC.snd_buffersize));
       }
    }
+   SDL_ResumeAudioDevice(SDL_GetAudioStreamDevice(audio_stream));
    CPC.snd_ready = true;
    LOG_VERBOSE("Audio: Sound buffer ready");
 
@@ -4024,7 +4027,11 @@ int koncpc_main (int argc, char **argv)
             imgui_state.audio_underruns = audio_underrun_count;
             imgui_state.audio_near_underruns = audio_near_underrun_count;
             imgui_state.audio_pushes = audio_push_count;
-            if (audio_push_count > 0) {
+            if (audio_push_count == 0) {
+               imgui_state.audio_queue_avg_ms = 0;
+               imgui_state.audio_queue_min_ms = 0;
+               imgui_state.audio_push_interval_max_us = 0;
+            } else if (audio_push_count > 0) {
                // Convert queue depth from bytes to milliseconds
                double avg_bytes = audio_queue_sum_bytes / audio_push_count;
                int frame_size = CPC.snd_stereo ? 4 : 2;  // 16-bit stereo=4, mono=2
@@ -4032,7 +4039,7 @@ int koncpc_main (int argc, char **argv)
                int sample_rate = freq_table[CPC.snd_playback_rate];
                double bytes_per_ms = sample_rate * frame_size / 1000.0;
                imgui_state.audio_queue_avg_ms = static_cast<float>(avg_bytes / bytes_per_ms);
-               imgui_state.audio_queue_min_ms = audio_queue_min_bytes / static_cast<float>(bytes_per_ms);
+               imgui_state.audio_queue_min_ms = static_cast<float>(audio_queue_min_bytes / bytes_per_ms);
                imgui_state.audio_push_interval_max_us = static_cast<float>(
                   static_cast<double>(audio_push_interval_max) * 1000000.0 / perfFreq);
             }
@@ -4040,7 +4047,7 @@ int koncpc_main (int argc, char **argv)
             audio_near_underrun_count = 0;
             audio_push_count = 0;
             audio_queue_sum_bytes = 0;
-            audio_queue_min_bytes = 1e9f;
+            audio_queue_min_bytes = INT_MAX;
             audio_push_interval_max = 0;
          }
 
@@ -4327,8 +4334,9 @@ int koncpc_main (int argc, char **argv)
                 // Check audio queue after display (GL viewport stalls drain it)
                 if (audio_stream && CPC.snd_ready) {
                    int queued = SDL_GetAudioStreamQueued(audio_stream);
+                   if (queued < 0) queued = 0;
                    if (queued < audio_queue_min_bytes)
-                      audio_queue_min_bytes = static_cast<float>(queued);
+                      audio_queue_min_bytes = queued;
                    int half_buf = static_cast<int>(CPC.snd_buffersize) / 2;
                    if (queued < half_buf && audio_push_count > 0) {
                       audio_near_underrun_count++;

--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -4322,6 +4322,19 @@ int koncpc_main (int argc, char **argv)
                 video_display();
                 uint64_t displayEnd = SDL_GetPerformanceCounter();
                 displayTimeAccum += displayEnd - displayStart;
+
+                // Check audio queue after display (GL viewport stalls drain it)
+                if (audio_stream && CPC.snd_ready) {
+                   int queued = SDL_GetAudioStreamQueued(audio_stream);
+                   if (queued < audio_queue_min_bytes)
+                      audio_queue_min_bytes = static_cast<float>(queued);
+                   if (queued < static_cast<int>(CPC.snd_buffersize) && audio_push_count > 0) {
+                      audio_near_underrun_count++;
+                      double display_ms = static_cast<double>(displayEnd - displayStart) * 1000.0 / perfFreq;
+                      LOG_DEBUG("Audio near-underrun after display: queue "
+                                << queued << "B, display took " << display_ms << "ms");
+                   }
+                }
               }
               video_take_pending_window_screenshot();
             }

--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -1607,7 +1607,8 @@ void printer_stop ()
 
 // ── Audio diagnostics ──
 static uint64_t audio_last_push_tick = 0;   // perf counter of last push
-static int audio_underrun_count = 0;        // underruns this reporting period
+static int audio_underrun_count = 0;        // underruns: queue was empty
+static int audio_near_underrun_count = 0;   // near-underruns: queue < 1 buffer
 static int audio_push_count = 0;            // pushes this reporting period
 static double audio_queue_sum_bytes = 0;    // sum of queue depths (for average)
 static float audio_queue_min_bytes = 1e9f;  // min queue depth this period
@@ -1619,16 +1620,23 @@ static void audio_push_buffer(const byte* data, int len)
 {
    if (!audio_stream || !CPC.snd_ready || len <= 0) return;
 
-   // Measure queue depth BEFORE pushing — if 0, SDL ran dry (underrun)
+   // Measure queue depth BEFORE pushing.
+   // - queued == 0: SDL ran completely dry (hard underrun, audible gap)
+   // - queued < len: SDL had less than one buffer left (near-underrun, may click)
    int queued = SDL_GetAudioStreamQueued(audio_stream);
-   if (queued == 0 && audio_push_count > 0) {
-      audio_underrun_count++;
-      LOG_DEBUG("Audio underrun: SDL queue empty at push #" << audio_push_count
-                << ", interval since last push: "
-                << (audio_last_push_tick > 0
-                    ? static_cast<double>(SDL_GetPerformanceCounter() - audio_last_push_tick)
-                      * 1000.0 / SDL_GetPerformanceFrequency()
-                    : 0.0) << " ms");
+   if (audio_push_count > 0) {
+      double interval_ms = audio_last_push_tick > 0
+         ? static_cast<double>(SDL_GetPerformanceCounter() - audio_last_push_tick)
+           * 1000.0 / SDL_GetPerformanceFrequency()
+         : 0.0;
+      if (queued == 0) {
+         audio_underrun_count++;
+         LOG_DEBUG("Audio UNDERRUN: queue empty, interval " << interval_ms << "ms");
+      } else if (queued < len) {
+         audio_near_underrun_count++;
+         LOG_DEBUG("Audio near-underrun: queue " << queued << "B (< " << len
+                   << "B buffer), interval " << interval_ms << "ms");
+      }
    }
    audio_queue_sum_bytes += queued;
    if (queued < audio_queue_min_bytes) audio_queue_min_bytes = static_cast<float>(queued);
@@ -4004,6 +4012,7 @@ int koncpc_main (int argc, char **argv)
 
             // Publish audio diagnostics
             imgui_state.audio_underruns = audio_underrun_count;
+            imgui_state.audio_near_underruns = audio_near_underrun_count;
             imgui_state.audio_pushes = audio_push_count;
             if (audio_push_count > 0) {
                // Convert queue depth from bytes to milliseconds
@@ -4018,6 +4027,7 @@ int koncpc_main (int argc, char **argv)
                   static_cast<double>(audio_push_interval_max) * 1000000.0 / perfFreq);
             }
             audio_underrun_count = 0;
+            audio_near_underrun_count = 0;
             audio_push_count = 0;
             audio_queue_sum_bytes = 0;
             audio_queue_min_bytes = 1e9f;

--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -1627,8 +1627,8 @@ static void audio_push_buffer(const byte* data, int len)
    int queued = SDL_GetAudioStreamQueued(audio_stream);
    if (queued < 0) queued = 0; // SDL error — treat as empty
 
-   // Detect underruns (skip the very first push after a stats reset —
-   // a low queue at that point is expected, not an underrun).
+   // Detect underruns (skip if we have no previous push timestamp to
+   // compute an interval from — e.g. the very first push after init).
    if (audio_last_push_tick > 0) {
       double interval_ms = static_cast<double>(now - audio_last_push_tick) * 1000.0 / perfFreq;
       if (queued == 0) {
@@ -1646,7 +1646,7 @@ static void audio_push_buffer(const byte* data, int len)
 
    // Push to SDL — only update timing/count on success
    if (!SDL_PutAudioStreamData(audio_stream, data, len)) {
-      LOG_DEBUG("Audio: SDL_PutAudioStreamData failed");
+      LOG_DEBUG("Audio: SDL_PutAudioStreamData failed: " << SDL_GetError());
       return;
    }
 

--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -18,6 +18,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <climits>
 #include <iostream>
 #include <sstream>
 #include <chrono>

--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -1605,11 +1605,43 @@ void printer_stop ()
 
 
 
+// ── Audio diagnostics ──
+static uint64_t audio_last_push_tick = 0;   // perf counter of last push
+static int audio_underrun_count = 0;        // underruns this reporting period
+static int audio_push_count = 0;            // pushes this reporting period
+static double audio_queue_sum_bytes = 0;    // sum of queue depths (for average)
+static float audio_queue_min_bytes = 1e9f;  // min queue depth this period
+static uint64_t audio_push_interval_max = 0; // longest gap between pushes (perf ticks)
+
 // Push completed audio buffer into SDL stream (called from main loop on EC_SOUND_BUFFER).
 // SDL handles internal queuing and feeds the hardware at the correct rate.
 static void audio_push_buffer(const byte* data, int len)
 {
    if (!audio_stream || !CPC.snd_ready || len <= 0) return;
+
+   // Measure queue depth BEFORE pushing — if 0, SDL ran dry (underrun)
+   int queued = SDL_GetAudioStreamQueued(audio_stream);
+   if (queued == 0 && audio_push_count > 0) {
+      audio_underrun_count++;
+      LOG_DEBUG("Audio underrun: SDL queue empty at push #" << audio_push_count
+                << ", interval since last push: "
+                << (audio_last_push_tick > 0
+                    ? static_cast<double>(SDL_GetPerformanceCounter() - audio_last_push_tick)
+                      * 1000.0 / SDL_GetPerformanceFrequency()
+                    : 0.0) << " ms");
+   }
+   audio_queue_sum_bytes += queued;
+   if (queued < audio_queue_min_bytes) audio_queue_min_bytes = static_cast<float>(queued);
+
+   // Measure push interval
+   uint64_t now = SDL_GetPerformanceCounter();
+   if (audio_last_push_tick > 0) {
+      uint64_t interval = now - audio_last_push_tick;
+      if (interval > audio_push_interval_max) audio_push_interval_max = interval;
+   }
+   audio_last_push_tick = now;
+   audio_push_count++;
+
    SDL_PutAudioStreamData(audio_stream, data, len);
    if (g_wav_recorder.is_recording()) {
       g_wav_recorder.write_samples(data, static_cast<uint32_t>(len));
@@ -3969,6 +4001,27 @@ int koncpc_main (int argc, char **argv)
             sleepTimeAccum = 0;
             z80TimeAccum = 0;
             frameTimeSamples = 0;
+
+            // Publish audio diagnostics
+            imgui_state.audio_underruns = audio_underrun_count;
+            imgui_state.audio_pushes = audio_push_count;
+            if (audio_push_count > 0) {
+               // Convert queue depth from bytes to milliseconds
+               double avg_bytes = audio_queue_sum_bytes / audio_push_count;
+               int frame_size = CPC.snd_stereo ? 4 : 2;  // 16-bit stereo=4, mono=2
+               if (CPC.snd_bits == 0) frame_size /= 2;    // 8-bit halves it
+               int sample_rate = freq_table[CPC.snd_playback_rate];
+               double bytes_per_ms = sample_rate * frame_size / 1000.0;
+               imgui_state.audio_queue_avg_ms = static_cast<float>(avg_bytes / bytes_per_ms);
+               imgui_state.audio_queue_min_ms = audio_queue_min_bytes / static_cast<float>(bytes_per_ms);
+               imgui_state.audio_push_interval_max_us = static_cast<float>(
+                  static_cast<double>(audio_push_interval_max) * 1000000.0 / perfFreq);
+            }
+            audio_underrun_count = 0;
+            audio_push_count = 0;
+            audio_queue_sum_bytes = 0;
+            audio_queue_min_bytes = 1e9f;
+            audio_push_interval_max = 0;
          }
 
          static constexpr int MAX_CONSECUTIVE_SKIPS = 5;

--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -1632,10 +1632,11 @@ static void audio_push_buffer(const byte* data, int len)
       if (queued == 0) {
          audio_underrun_count++;
          LOG_DEBUG("Audio UNDERRUN: queue empty, interval " << interval_ms << "ms");
-      } else if (queued < len) {
+      } else if (queued < len / 2) {
+         // Below half a buffer (~11ms) — real danger of audible artifact
          audio_near_underrun_count++;
-         LOG_DEBUG("Audio near-underrun: queue " << queued << "B (< " << len
-                   << "B buffer), interval " << interval_ms << "ms");
+         LOG_DEBUG("Audio near-underrun: queue " << queued << "B (< " << len / 2
+                   << "B), interval " << interval_ms << "ms");
       }
    }
    audio_queue_sum_bytes += queued;
@@ -4328,11 +4329,12 @@ int koncpc_main (int argc, char **argv)
                    int queued = SDL_GetAudioStreamQueued(audio_stream);
                    if (queued < audio_queue_min_bytes)
                       audio_queue_min_bytes = static_cast<float>(queued);
-                   if (queued < static_cast<int>(CPC.snd_buffersize) && audio_push_count > 0) {
+                   int half_buf = static_cast<int>(CPC.snd_buffersize) / 2;
+                   if (queued < half_buf && audio_push_count > 0) {
                       audio_near_underrun_count++;
                       double display_ms = static_cast<double>(displayEnd - displayStart) * 1000.0 / perfFreq;
                       LOG_DEBUG("Audio near-underrun after display: queue "
-                                << queued << "B, display took " << display_ms << "ms");
+                                << queued << "B (< " << half_buf << "B), display took " << display_ms << "ms");
                    }
                 }
               }

--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -1708,14 +1708,13 @@ int audio_init ()
    pbSndBufferEnd = pbSndBuffer.get() + CPC.snd_buffersize;
    CPC.snd_bufferptr = pbSndBuffer.get();
 
-   // Pre-buffer 3 silent buffers (~69ms at 44100Hz) so the SDL queue has
-   // enough safety margin to absorb compositor stalls without underrunning.
+   // Pre-buffer 2 silent buffers (~46ms at 44100Hz) so the SDL queue has
+   // enough margin to absorb occasional compositor stalls (~69ms observed).
    {
       std::vector<byte> silence(CPC.snd_buffersize, 0);
-      for (int i = 0; i < 3; i++) {
+      for (int i = 0; i < 2; i++) {
          SDL_PutAudioStreamData(audio_stream, silence.data(), static_cast<int>(CPC.snd_buffersize));
       }
-      LOG_VERBOSE("Audio: Pre-buffered " << 3 * CPC.snd_buffersize << " bytes of silence");
    }
    CPC.snd_ready = true;
    LOG_VERBOSE("Audio: Sound buffer ready");

--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -1610,7 +1610,7 @@ void printer_stop ()
 static uint64_t audio_last_push_tick = 0;   // perf counter of last push
 static int audio_underrun_count = 0;        // underruns: queue was empty
 static int audio_near_underrun_count = 0;   // near-underruns: queue < half buffer
-static int audio_push_count = 0;            // pushes this reporting period
+static int audio_push_count = 0;            // successful pushes this reporting period
 static double audio_queue_sum_bytes = 0;    // sum of queue depths (for average)
 static int audio_queue_min_bytes = INT_MAX; // min queue depth this period
 static uint64_t audio_push_interval_max = 0; // longest gap between pushes (perf ticks)
@@ -1627,14 +1627,15 @@ static void audio_push_buffer(const byte* data, int len)
    int queued = SDL_GetAudioStreamQueued(audio_stream);
    if (queued < 0) queued = 0; // SDL error — treat as empty
 
-   if (audio_push_count > 0) {
-      double interval_ms = audio_last_push_tick > 0
-         ? static_cast<double>(now - audio_last_push_tick) * 1000.0 / perfFreq
-         : 0.0;
+   // Detect underruns (skip the very first push after a stats reset —
+   // a low queue at that point is expected, not an underrun).
+   if (audio_last_push_tick > 0) {
+      double interval_ms = static_cast<double>(now - audio_last_push_tick) * 1000.0 / perfFreq;
       if (queued == 0) {
          audio_underrun_count++;
          LOG_DEBUG("Audio UNDERRUN: queue empty, interval " << interval_ms << "ms");
       } else if (queued < len / 2) {
+         // Below half a buffer — real danger of audible artifact
          audio_near_underrun_count++;
          LOG_DEBUG("Audio near-underrun: queue " << queued << "B (< " << len / 2
                    << "B), interval " << interval_ms << "ms");
@@ -1643,18 +1644,19 @@ static void audio_push_buffer(const byte* data, int len)
    audio_queue_sum_bytes += queued;
    if (queued < audio_queue_min_bytes) audio_queue_min_bytes = queued;
 
-   // Measure push interval
+   // Push to SDL — only update timing/count on success
+   if (!SDL_PutAudioStreamData(audio_stream, data, len)) {
+      LOG_DEBUG("Audio: SDL_PutAudioStreamData failed");
+      return;
+   }
+
+   // Measure push interval (after successful push)
    if (audio_last_push_tick > 0) {
       uint64_t interval = now - audio_last_push_tick;
       if (interval > audio_push_interval_max) audio_push_interval_max = interval;
    }
    audio_last_push_tick = now;
    audio_push_count++;
-
-   if (!SDL_PutAudioStreamData(audio_stream, data, len)) {
-      LOG_DEBUG("Audio: SDL_PutAudioStreamData failed");
-      return;
-   }
    if (g_wav_recorder.is_recording()) {
       g_wav_recorder.write_samples(data, static_cast<uint32_t>(len));
    }
@@ -1714,10 +1716,13 @@ int audio_init ()
    // Pre-buffer 2 silent buffers (~46ms at 44100Hz) so the SDL queue has
    // enough margin to absorb occasional compositor stalls (~69ms observed).
    // Done BEFORE resuming the device so SDL doesn't start draining immediately.
+   // Adds ~46ms of audio latency — acceptable for an emulator.
    {
       std::vector<byte> silence(CPC.snd_buffersize, 0);
       for (int i = 0; i < 2; i++) {
-         SDL_PutAudioStreamData(audio_stream, silence.data(), static_cast<int>(CPC.snd_buffersize));
+         if (!SDL_PutAudioStreamData(audio_stream, silence.data(), static_cast<int>(CPC.snd_buffersize))) {
+            LOG_ERROR("Audio: pre-buffer failed: " << SDL_GetError());
+         }
       }
    }
    SDL_ResumeAudioDevice(SDL_GetAudioStreamDevice(audio_stream));
@@ -4333,17 +4338,18 @@ int koncpc_main (int argc, char **argv)
                 displayTimeAccum += displayEnd - displayStart;
 
                 // Check audio queue after display (GL viewport stalls drain it)
+                // Sample audio queue depth after display — catches GL stalls.
+                // Only updates min (underrun counting is done in audio_push_buffer
+                // to avoid double-counting).
                 if (audio_stream && CPC.snd_ready) {
                    int queued = SDL_GetAudioStreamQueued(audio_stream);
                    if (queued < 0) queued = 0;
                    if (queued < audio_queue_min_bytes)
                       audio_queue_min_bytes = queued;
-                   int half_buf = static_cast<int>(CPC.snd_buffersize) / 2;
-                   if (queued < half_buf && audio_push_count > 0) {
-                      audio_near_underrun_count++;
+                   if (queued < static_cast<int>(CPC.snd_buffersize) / 2 && audio_push_count > 0) {
                       double display_ms = static_cast<double>(displayEnd - displayStart) * 1000.0 / perfFreq;
-                      LOG_DEBUG("Audio near-underrun after display: queue "
-                                << queued << "B (< " << half_buf << "B), display took " << display_ms << "ms");
+                      LOG_DEBUG("Audio low queue after display: " << queued
+                                << "B, display took " << display_ms << "ms");
                    }
                 }
               }

--- a/src/psg.cpp
+++ b/src/psg.cpp
@@ -71,30 +71,10 @@ bool Ton_EnA, Ton_EnB, Ton_EnC, Noise_EnA, Noise_EnB, Noise_EnC;
 bool Envelope_EnA, Envelope_EnB, Envelope_EnC;
 void (*Case_EnvType)();
 
-union TCounter {
-   struct {
-      word Lo;
-      word Hi;
-   };
-   dword Re;
-};
+#include "psg_types.h"
 TCounter Ton_Counter_A, Ton_Counter_B, Ton_Counter_C, Noise_Counter;
-
-union TNoise {
-   struct {
-      word Low;
-      word Val;
-   };
-   dword Seed;
-} Noise;
-
-union TEnvelopeCounter {
-   struct {
-      dword Lo;
-      dword Hi;
-   };
-   int64_t Re;
-} Envelope_Counter;
+TNoise Noise;
+TEnvelopeCounter Envelope_Counter;
 byte Ton_A, Ton_B, Ton_C;
 
 int Level_AR[32], Level_AL[32], Level_BR[32], Level_BL[32], Level_CR[32], Level_CL[32];
@@ -726,7 +706,7 @@ void Calculate_Level_Tables()
       Level_CR[i] = static_cast<int>(rint(Level_CR[i] * k));
    }
    if (!CPC.snd_bits) { // 8 bits per sample?
-      LevelTape = -static_cast<int>(rint((TAPE_VOLUME / 2) * k));
+      LevelTape = -static_cast<int>(rint((TAPE_VOLUME / 2.0) * k));
    }
    else {
       LevelTape = -static_cast<int>(rint((TAPE_VOLUME * 128) * k));

--- a/src/psg_types.h
+++ b/src/psg_types.h
@@ -1,0 +1,31 @@
+#ifndef PSG_TYPES_H
+#define PSG_TYPES_H
+
+#include "types.h"
+#include <cstdint>
+
+union TCounter {
+   struct {
+      word Lo;
+      word Hi;
+   };
+   dword Re;
+};
+
+union TNoise {
+   struct {
+      word Low;
+      word Val;
+   };
+   dword Seed;
+};
+
+union TEnvelopeCounter {
+   struct {
+      dword Lo;
+      dword Hi;
+   };
+   int64_t Re;
+};
+
+#endif // PSG_TYPES_H

--- a/test/fdc_test.cpp
+++ b/test/fdc_test.cpp
@@ -1,0 +1,261 @@
+/* Tests for FDC (uPD765A) command dispatch.
+   Verifies status register, command parsing, seek, recalibrate, specify,
+   sense interrupt, and invalid command handling through the public API.
+*/
+
+#include <gtest/gtest.h>
+
+#include "koncepcja.h"
+#include "disk.h"
+
+extern t_CPC CPC;
+extern t_FDC FDC;
+extern t_drive driveA;
+extern t_drive driveB;
+
+// FDC-internal globals defined in fdc.cpp
+extern t_drive *active_drive;
+extern t_track *active_track;
+extern dword read_status_delay;
+
+class FdcTest : public testing::Test {
+ protected:
+  void SetUp() override {
+    memset(&FDC, 0, sizeof(FDC));
+    memset(&driveA, 0, sizeof(driveA));
+    memset(&driveB, 0, sizeof(driveB));
+    active_drive = &driveA;
+    active_track = nullptr;
+    read_status_delay = 0;
+
+    // Give drives some tracks so they appear "ready"
+    driveA.tracks = 40;
+    driveA.sides = 1;
+    driveA.current_track = 0;
+    driveB.tracks = 40;
+    driveB.sides = 1;
+    driveB.current_track = 0;
+
+    // Motor must be on for drive to be considered ready
+    FDC.motor = 1;
+  }
+};
+
+// ─────────────────────────────────────────────────
+// Status register initial state
+// ─────────────────────────────────────────────────
+
+TEST_F(FdcTest, ReadStatus_InitialState) {
+  // In command phase with byte_count=0, status should be 0x80 (RQM, ready)
+  EXPECT_EQ(FDC.phase, CMD_PHASE);
+  byte status = fdc_read_status();
+  EXPECT_EQ(status, 0x80);
+}
+
+TEST_F(FdcTest, ReadStatus_ReceivingCommandParams) {
+  // After writing the first byte of a multi-byte command, FDC should be busy
+  fdc_write_data(0x03);  // Specify command (3 bytes total)
+  // Now in CMD_PHASE but byte_count > 0 (waiting for parameters)
+  byte status = fdc_read_status();
+  EXPECT_EQ(status & 0x90, 0x90);  // RQM + busy
+}
+
+// ─────────────────────────────────────────────────
+// Specify command (0x03) — 3 bytes, no result phase
+// ─────────────────────────────────────────────────
+
+TEST_F(FdcTest, Specify_NoResultPhase) {
+  // Specify: command byte + 2 parameter bytes, returns to CMD_PHASE directly
+  fdc_write_data(0x03);  // command
+  fdc_write_data(0xDF);  // SRT/HUT
+  fdc_write_data(0x02);  // HLT/ND
+
+  // Should return to command phase (no result phase for specify)
+  EXPECT_EQ(FDC.phase, CMD_PHASE);
+  // Status should be ready again
+  EXPECT_EQ(fdc_read_status(), 0x80);
+}
+
+// ─────────────────────────────────────────────────
+// Sense Interrupt Status (0x08) — 1 byte cmd, 2 result bytes
+// ─────────────────────────────────────────────────
+
+TEST_F(FdcTest, SenseInterruptStatus_NoSeekPending) {
+  // With no seek flags set, sense interrupt returns invalid (0x80)
+  fdc_write_data(0x08);
+
+  EXPECT_EQ(FDC.phase, RESULT_PHASE);
+
+  byte st0 = fdc_read_data();
+  EXPECT_EQ(st0, 0x80);  // Invalid Command response when no seek pending
+
+  // After reading all result bytes, should return to command phase
+  EXPECT_EQ(FDC.phase, CMD_PHASE);
+}
+
+TEST_F(FdcTest, SenseInterruptStatus_AfterSeek) {
+  // Issue a seek on drive A, then sense interrupt
+  fdc_write_data(0x0F);  // Seek command
+  fdc_write_data(0x00);  // Drive A, head 0
+  fdc_write_data(0x05);  // Track 5
+
+  // Seek returns to CMD_PHASE (no result phase)
+  EXPECT_EQ(FDC.phase, CMD_PHASE);
+
+  // Now sense interrupt status
+  fdc_write_data(0x08);
+  EXPECT_EQ(FDC.phase, RESULT_PHASE);
+
+  byte st0 = fdc_read_data();
+  EXPECT_EQ(st0 & 0x20, 0x20);  // Seek End bit set
+
+  byte pcn = fdc_read_data();
+  EXPECT_EQ(pcn, 5);  // Present Cylinder Number = 5
+
+  EXPECT_EQ(FDC.phase, CMD_PHASE);
+}
+
+// ─────────────────────────────────────────────────
+// Recalibrate (0x07) — seeks to track 0
+// ─────────────────────────────────────────────────
+
+TEST_F(FdcTest, Recalibrate_SeeksToTrack0) {
+  driveA.current_track = 20;
+
+  fdc_write_data(0x07);  // Recalibrate
+  fdc_write_data(0x00);  // Drive A
+
+  EXPECT_EQ(FDC.phase, CMD_PHASE);  // no result phase
+  EXPECT_EQ(driveA.current_track, 0u);
+}
+
+TEST_F(FdcTest, Recalibrate_DriveB) {
+  driveB.current_track = 15;
+
+  fdc_write_data(0x07);  // Recalibrate
+  fdc_write_data(0x01);  // Drive B
+
+  EXPECT_EQ(FDC.phase, CMD_PHASE);
+  EXPECT_EQ(driveB.current_track, 0u);
+}
+
+// ─────────────────────────────────────────────────
+// Seek (0x0F) — updates current_track
+// ─────────────────────────────────────────────────
+
+TEST_F(FdcTest, Seek_UpdatesCurrentTrack) {
+  fdc_write_data(0x0F);  // Seek
+  fdc_write_data(0x00);  // Drive A
+  fdc_write_data(0x25);  // Track 37
+
+  EXPECT_EQ(FDC.phase, CMD_PHASE);
+  EXPECT_EQ(driveA.current_track, 37u);
+}
+
+TEST_F(FdcTest, Seek_DriveB) {
+  fdc_write_data(0x0F);  // Seek
+  fdc_write_data(0x01);  // Drive B
+  fdc_write_data(0x0A);  // Track 10
+
+  EXPECT_EQ(FDC.phase, CMD_PHASE);
+  EXPECT_EQ(driveB.current_track, 10u);
+}
+
+TEST_F(FdcTest, Seek_ClampsToMaxTrack) {
+  // Track number beyond DSK_TRACKMAX should be clamped
+  fdc_write_data(0x0F);
+  fdc_write_data(0x00);
+  fdc_write_data(0xFF);  // 255, beyond DSK_TRACKMAX (102)
+
+  EXPECT_EQ(FDC.phase, CMD_PHASE);
+  EXPECT_EQ(driveA.current_track, (unsigned int)(DSK_TRACKMAX - 1));
+}
+
+// ─────────────────────────────────────────────────
+// Seek on empty drive (no disk)
+// ─────────────────────────────────────────────────
+
+TEST_F(FdcTest, Seek_NoDisk_SetsNotReady) {
+  driveA.tracks = 0;  // no disk loaded
+
+  fdc_write_data(0x0F);
+  fdc_write_data(0x00);  // Drive A
+  fdc_write_data(0x05);  // Track 5
+
+  // Track should NOT be updated when drive is not ready
+  // (init_status_regs returns non-zero -> seek body skipped)
+  // But SEEKDRVA flag is still set
+  EXPECT_EQ(FDC.phase, CMD_PHASE);
+
+  // Sense interrupt to read status
+  fdc_write_data(0x08);
+  byte st0 = fdc_read_data();
+  // Not ready flag should be present
+  EXPECT_EQ(st0 & 0x08, 0x08);
+  fdc_read_data();  // consume PCN
+}
+
+// ─────────────────────────────────────────────────
+// Invalid command
+// ─────────────────────────────────────────────────
+
+TEST_F(FdcTest, InvalidCommand_Returns0x80) {
+  fdc_write_data(0xFF);  // Unknown command
+
+  EXPECT_EQ(FDC.phase, RESULT_PHASE);
+  EXPECT_EQ(FDC.res_length, 1);
+
+  byte result = fdc_read_data();
+  EXPECT_EQ(result, 0x80);
+  EXPECT_EQ(FDC.phase, CMD_PHASE);
+}
+
+TEST_F(FdcTest, InvalidCommand_AnotherValue) {
+  fdc_write_data(0x00);  // Also not a valid FDC command
+
+  EXPECT_EQ(FDC.phase, RESULT_PHASE);
+  byte result = fdc_read_data();
+  EXPECT_EQ(result, 0x80);
+  EXPECT_EQ(FDC.phase, CMD_PHASE);
+}
+
+// ─────────────────────────────────────────────────
+// Sense Device Status (0x04) — 2 byte cmd, 1 result byte
+// ─────────────────────────────────────────────────
+
+TEST_F(FdcTest, SenseDeviceStatus_ReadyDriveAtTrack0) {
+  driveA.current_track = 0;
+  driveA.write_protected = 0;
+
+  fdc_write_data(0x04);  // Sense Device Status
+  fdc_write_data(0x00);  // Drive A, head 0
+
+  EXPECT_EQ(FDC.phase, RESULT_PHASE);
+
+  byte st3 = fdc_read_data();
+  EXPECT_EQ(st3 & 0x10, 0x10);  // Track 0 flag
+  EXPECT_EQ(st3 & 0x20, 0x20);  // Ready flag
+  EXPECT_EQ(st3 & 0x40, 0x00);  // Write Protect clear
+
+  EXPECT_EQ(FDC.phase, CMD_PHASE);
+}
+
+TEST_F(FdcTest, SenseDeviceStatus_WriteProtected) {
+  driveA.write_protected = 1;
+
+  fdc_write_data(0x04);
+  fdc_write_data(0x00);
+
+  byte st3 = fdc_read_data();
+  EXPECT_EQ(st3 & 0x48, 0x48);  // Write Protect + Two Sided bits
+}
+
+TEST_F(FdcTest, SenseDeviceStatus_NotAtTrack0) {
+  driveA.current_track = 10;
+
+  fdc_write_data(0x04);
+  fdc_write_data(0x00);
+
+  byte st3 = fdc_read_data();
+  EXPECT_EQ(st3 & 0x10, 0x00);  // Track 0 flag should be clear
+}

--- a/test/psg_registers_test.cpp
+++ b/test/psg_registers_test.cpp
@@ -1,0 +1,351 @@
+/* Tests for PSG (AY-3-8912) register handling.
+   Verifies masking, envelope reset, chip reset, and level table init.
+*/
+
+#include <gtest/gtest.h>
+
+#include "koncepcja.h"
+#include "types.h"
+
+extern t_CPC CPC;
+extern t_PSG PSG;
+
+// PSG internals defined in psg.cpp — needed for verification
+extern int Level_AL[32];
+extern int Level_AR[32];
+extern int Level_BL[32];
+extern int Level_BR[32];
+extern int Level_CL[32];
+extern int Level_CR[32];
+extern int64_t LoopCountInit;
+extern bool Ton_EnA, Ton_EnB, Ton_EnC;
+extern bool Noise_EnA, Noise_EnB, Noise_EnC;
+extern bool Envelope_EnA, Envelope_EnB, Envelope_EnC;
+
+// Union types matching psg.cpp definitions
+union TNoise {
+   struct {
+      word Low;
+      word Val;
+   };
+   dword Seed;
+};
+extern TNoise Noise;
+
+union TCounter {
+   struct {
+      word Lo;
+      word Hi;
+   };
+   dword Re;
+};
+extern TCounter Ton_Counter_A, Ton_Counter_B, Ton_Counter_C, Noise_Counter;
+
+union TEnvelopeCounter {
+   struct {
+      dword Lo;
+      dword Hi;
+   };
+   int64_t Re;
+};
+extern TEnvelopeCounter Envelope_Counter;
+
+extern byte Ton_A, Ton_B, Ton_C;
+extern int Left_Chan, Right_Chan;
+
+extern byte Index_AL, Index_AR, Index_BL, Index_BR, Index_CL, Index_CR;
+extern int PreAmpMax;
+
+extern dword freq_table[];
+
+class PsgRegisterTest : public testing::Test {
+ protected:
+  void SetUp() override {
+    memset(&PSG.RegisterAY, 0, sizeof(PSG.RegisterAY));
+    PSG.AmplitudeEnv = 0;
+    PSG.FirstPeriod = false;
+    PSG.buffer_full = 0;
+  }
+};
+
+// ─────────────────────────────────────────────────
+// Register write masking tests
+// ─────────────────────────────────────────────────
+
+TEST_F(PsgRegisterTest, ToneALowByte_NoMask) {
+  // Register 0: tone period A low byte — full 8 bits, no mask
+  SetAYRegister(0, 0xFF);
+  EXPECT_EQ(PSG.RegisterAY.Index[0], 0xFF);
+}
+
+TEST_F(PsgRegisterTest, ToneAHighByte_Masked4Bits) {
+  // Register 1: tone period A high — masked to 4 bits
+  SetAYRegister(1, 0xFF);
+  EXPECT_EQ(PSG.RegisterAY.Index[1], 0x0F);
+}
+
+TEST_F(PsgRegisterTest, ToneBLowByte_NoMask) {
+  // Register 2: tone period B low byte — full 8 bits
+  SetAYRegister(2, 0xFF);
+  EXPECT_EQ(PSG.RegisterAY.Index[2], 0xFF);
+}
+
+TEST_F(PsgRegisterTest, ToneBHighByte_Masked4Bits) {
+  // Register 3: tone period B high — masked to 4 bits
+  SetAYRegister(3, 0xFF);
+  EXPECT_EQ(PSG.RegisterAY.Index[3], 0x0F);
+}
+
+TEST_F(PsgRegisterTest, ToneCLowByte_NoMask) {
+  // Register 4: tone period C low byte — full 8 bits
+  SetAYRegister(4, 0xFF);
+  EXPECT_EQ(PSG.RegisterAY.Index[4], 0xFF);
+}
+
+TEST_F(PsgRegisterTest, ToneCHighByte_Masked4Bits) {
+  // Register 5: tone period C high — masked to 4 bits
+  SetAYRegister(5, 0xFF);
+  EXPECT_EQ(PSG.RegisterAY.Index[5], 0x0F);
+}
+
+TEST_F(PsgRegisterTest, NoisePeriod_Masked5Bits) {
+  // Register 6: noise period — masked to 5 bits
+  SetAYRegister(6, 0xFF);
+  EXPECT_EQ(PSG.RegisterAY.Noise, 0x1F);
+}
+
+TEST_F(PsgRegisterTest, Mixer_Masked6Bits) {
+  // Register 7: mixer — masked to 6 bits
+  SetAYRegister(7, 0xFF);
+  EXPECT_EQ(PSG.RegisterAY.Mixer, 0x3F);
+}
+
+TEST_F(PsgRegisterTest, AmplitudeA_Masked5Bits) {
+  // Register 8: channel A amplitude — masked to 5 bits
+  SetAYRegister(8, 0xFF);
+  EXPECT_EQ(PSG.RegisterAY.AmplitudeA, 0x1F);
+}
+
+TEST_F(PsgRegisterTest, AmplitudeB_Masked5Bits) {
+  // Register 9: channel B amplitude — masked to 5 bits
+  SetAYRegister(9, 0xFF);
+  EXPECT_EQ(PSG.RegisterAY.AmplitudeB, 0x1F);
+}
+
+TEST_F(PsgRegisterTest, AmplitudeC_Masked5Bits) {
+  // Register 10: channel C amplitude — masked to 5 bits
+  SetAYRegister(10, 0xFF);
+  EXPECT_EQ(PSG.RegisterAY.AmplitudeC, 0x1F);
+}
+
+TEST_F(PsgRegisterTest, EnvelopeLow_NoMask) {
+  // Register 11: envelope period low — full 8 bits
+  SetAYRegister(11, 0xAB);
+  EXPECT_EQ(PSG.RegisterAY.Index[11], 0xAB);
+}
+
+TEST_F(PsgRegisterTest, EnvelopeHigh_NoMask) {
+  // Register 12: envelope period high — full 8 bits
+  SetAYRegister(12, 0xCD);
+  EXPECT_EQ(PSG.RegisterAY.Index[12], 0xCD);
+}
+
+// ─────────────────────────────────────────────────
+// Envelope shape register (13) triggers reset
+// ─────────────────────────────────────────────────
+
+TEST_F(PsgRegisterTest, EnvelopeShape_TriggersReset) {
+  // Writing to register 13 should reset envelope state
+  PSG.FirstPeriod = false;
+  PSG.AmplitudeEnv = 15;
+  Envelope_Counter.Hi = 999;
+
+  SetAYRegister(13, 0);  // shape 0: attack bit clear -> AmplitudeEnv starts at 32
+  EXPECT_TRUE(PSG.FirstPeriod);
+  EXPECT_EQ(Envelope_Counter.Hi, 0u);
+  // Value is masked to 4 bits, shape 0 has attack bit (bit 2) clear -> AmplitudeEnv = 32
+  EXPECT_EQ(PSG.AmplitudeEnv, 32);
+  EXPECT_EQ(PSG.RegisterAY.EnvType, 0);
+}
+
+TEST_F(PsgRegisterTest, EnvelopeShape_AttackBitSet) {
+  // Shape with bit 2 set -> AmplitudeEnv starts at -1
+  SetAYRegister(13, 0x0C);  // 0x0C & 0x0F = 0x0C, bit 2 set
+  EXPECT_TRUE(PSG.FirstPeriod);
+  EXPECT_EQ(PSG.AmplitudeEnv, -1);
+  EXPECT_EQ(PSG.RegisterAY.EnvType, 0x0C);
+}
+
+TEST_F(PsgRegisterTest, EnvelopeShape_ValueMaskedTo4Bits) {
+  // Register 13 value is masked to lower 4 bits before processing
+  SetAYRegister(13, 0xF8);  // 0xF8 & 0x0F = 0x08
+  EXPECT_EQ(PSG.RegisterAY.EnvType, 0x08);
+}
+
+// ─────────────────────────────────────────────────
+// Mixer sets tone/noise enable flags
+// ─────────────────────────────────────────────────
+
+TEST_F(PsgRegisterTest, Mixer_ToneNoiseFlags) {
+  // All channels enabled (bits clear = enabled)
+  SetAYRegister(7, 0x00);
+  EXPECT_TRUE(Ton_EnA);
+  EXPECT_TRUE(Ton_EnB);
+  EXPECT_TRUE(Ton_EnC);
+  EXPECT_TRUE(Noise_EnA);
+  EXPECT_TRUE(Noise_EnB);
+  EXPECT_TRUE(Noise_EnC);
+
+  // All channels disabled
+  SetAYRegister(7, 0x3F);
+  EXPECT_FALSE(Ton_EnA);
+  EXPECT_FALSE(Ton_EnB);
+  EXPECT_FALSE(Ton_EnC);
+  EXPECT_FALSE(Noise_EnA);
+  EXPECT_FALSE(Noise_EnB);
+  EXPECT_FALSE(Noise_EnC);
+}
+
+TEST_F(PsgRegisterTest, Mixer_SelectiveToneNoise) {
+  // 0x26 = 0b00_100_110: bits 1,2 set (tone B/C off), bit 5 set (noise C off)
+  // bits 0,3,4 clear (tone A on, noise A on, noise B on)
+  SetAYRegister(7, 0x26);
+  EXPECT_TRUE(Ton_EnA);    // bit 0 clear
+  EXPECT_FALSE(Ton_EnB);   // bit 1 set
+  EXPECT_FALSE(Ton_EnC);   // bit 2 set
+  EXPECT_TRUE(Noise_EnA);  // bit 3 clear
+  EXPECT_TRUE(Noise_EnB);  // bit 4 clear
+  EXPECT_FALSE(Noise_EnC); // bit 5 set
+}
+
+// ─────────────────────────────────────────────────
+// Amplitude registers set envelope enable flags
+// ─────────────────────────────────────────────────
+
+TEST_F(PsgRegisterTest, AmplitudeA_EnvelopeEnable) {
+  // bit 4 clear -> Envelope_EnA = true (envelope drives amplitude)
+  SetAYRegister(8, 0x0F);
+  EXPECT_TRUE(Envelope_EnA);
+
+  // bit 4 set -> Envelope_EnA = false (envelope mode)
+  SetAYRegister(8, 0x1F);
+  EXPECT_FALSE(Envelope_EnA);
+}
+
+// ─────────────────────────────────────────────────
+// ResetAYChipEmulation
+// ─────────────────────────────────────────────────
+
+TEST_F(PsgRegisterTest, ResetAYChipEmulation_NoiseSeed) {
+  Noise.Seed = 0;
+  ResetAYChipEmulation();
+  EXPECT_EQ(Noise.Seed, 0xFFFFu);
+}
+
+TEST_F(PsgRegisterTest, ResetAYChipEmulation_CountersZeroed) {
+  Ton_Counter_A.Re = 0xDEAD;
+  Ton_Counter_B.Re = 0xBEEF;
+  Ton_Counter_C.Re = 0xCAFE;
+  Noise_Counter.Re = 0xF00D;
+  Envelope_Counter.Re = 0x1234;
+  Ton_A = 1;
+  Ton_B = 1;
+  Ton_C = 1;
+  Left_Chan = 999;
+  Right_Chan = 888;
+
+  ResetAYChipEmulation();
+
+  EXPECT_EQ(Ton_Counter_A.Re, 0u);
+  EXPECT_EQ(Ton_Counter_B.Re, 0u);
+  EXPECT_EQ(Ton_Counter_C.Re, 0u);
+  EXPECT_EQ(Noise_Counter.Re, 0u);
+  EXPECT_EQ(Envelope_Counter.Re, 0);
+  EXPECT_EQ(Ton_A, 0);
+  EXPECT_EQ(Ton_B, 0);
+  EXPECT_EQ(Ton_C, 0);
+  EXPECT_EQ(Left_Chan, 0);
+  EXPECT_EQ(Right_Chan, 0);
+}
+
+// ─────────────────────────────────────────────────
+// Calculate_Level_Tables
+// ─────────────────────────────────────────────────
+
+TEST_F(PsgRegisterTest, CalculateLevelTables_NonZeroValues) {
+  // Set up minimal CPC config for level table calculation
+  CPC.snd_bits = 1;       // 16-bit
+  CPC.snd_stereo = 1;     // stereo
+  CPC.snd_volume = 80;    // audible volume
+
+  // Set channel indices (as InitAY does)
+  Index_AL = 255;
+  Index_AR = 13;
+  Index_BL = 170;
+  Index_BR = 170;
+  Index_CL = 13;
+  Index_CR = 255;
+  PreAmpMax = 100;
+
+  Calculate_Level_Tables();
+
+  // At volume>0 with non-zero channel indices, higher amplitude entries
+  // should produce non-zero levels
+  EXPECT_NE(Level_AL[30], 0);  // amplitude index 15 (max) * 2
+  EXPECT_NE(Level_AR[30], 0);
+  EXPECT_NE(Level_BL[30], 0);
+  EXPECT_NE(Level_BR[30], 0);
+  EXPECT_NE(Level_CL[30], 0);
+  EXPECT_NE(Level_CR[30], 0);
+
+  // Index 0 should be zero (amplitude 0)
+  EXPECT_EQ(Level_AL[0], 0);
+  EXPECT_EQ(Level_AR[0], 0);
+}
+
+// ─────────────────────────────────────────────────
+// InitAYCounterVars
+// ─────────────────────────────────────────────────
+
+TEST_F(PsgRegisterTest, InitAYCounterVars_SetsLoopCountInit) {
+  CPC.speed = 4;             // default speed
+  CPC.snd_playback_rate = 2; // index 2 = 44100 Hz
+  LoopCountInit = 0;
+
+  InitAYCounterVars();
+
+  EXPECT_NE(LoopCountInit, 0);
+}
+
+// ─────────────────────────────────────────────────
+// Register write does not affect unrelated registers
+// ─────────────────────────────────────────────────
+
+TEST_F(PsgRegisterTest, RegisterWrite_Isolation) {
+  // Write to register 0, verify other registers untouched
+  memset(&PSG.RegisterAY, 0, sizeof(PSG.RegisterAY));
+  SetAYRegister(0, 0xAB);
+  EXPECT_EQ(PSG.RegisterAY.Index[0], 0xAB);
+  EXPECT_EQ(PSG.RegisterAY.Index[1], 0x00);
+  EXPECT_EQ(PSG.RegisterAY.Index[2], 0x00);
+  EXPECT_EQ(PSG.RegisterAY.Index[6], 0x00);
+}
+
+// ─────────────────────────────────────────────────
+// Out-of-range register number is ignored
+// ─────────────────────────────────────────────────
+
+TEST_F(PsgRegisterTest, InvalidRegisterNumber_Ignored) {
+  // Registers 14 and 15 (PortA, PortB) are not handled by SetAYRegister
+  // Writing to them should not crash; they fall through the switch
+  memset(&PSG.RegisterAY, 0xAA, sizeof(PSG.RegisterAY));
+  byte saved[16];
+  memcpy(saved, PSG.RegisterAY.Index, 16);
+
+  SetAYRegister(14, 0x55);
+  SetAYRegister(15, 0x55);
+
+  // Port registers are not modified by SetAYRegister (no case for 14/15)
+  EXPECT_EQ(PSG.RegisterAY.Index[14], 0xAA);
+  EXPECT_EQ(PSG.RegisterAY.Index[15], 0xAA);
+}

--- a/test/psg_registers_test.cpp
+++ b/test/psg_registers_test.cpp
@@ -339,8 +339,6 @@ TEST_F(PsgRegisterTest, InvalidRegisterNumber_Ignored) {
   // Registers 14 and 15 (PortA, PortB) are not handled by SetAYRegister
   // Writing to them should not crash; they fall through the switch
   memset(&PSG.RegisterAY, 0xAA, sizeof(PSG.RegisterAY));
-  byte saved[16];
-  memcpy(saved, PSG.RegisterAY.Index, 16);
 
   SetAYRegister(14, 0x55);
   SetAYRegister(15, 0x55);

--- a/test/psg_registers_test.cpp
+++ b/test/psg_registers_test.cpp
@@ -22,32 +22,9 @@ extern bool Ton_EnA, Ton_EnB, Ton_EnC;
 extern bool Noise_EnA, Noise_EnB, Noise_EnC;
 extern bool Envelope_EnA, Envelope_EnB, Envelope_EnC;
 
-// Union types matching psg.cpp definitions
-union TNoise {
-   struct {
-      word Low;
-      word Val;
-   };
-   dword Seed;
-};
+#include "psg_types.h"
 extern TNoise Noise;
-
-union TCounter {
-   struct {
-      word Lo;
-      word Hi;
-   };
-   dword Re;
-};
 extern TCounter Ton_Counter_A, Ton_Counter_B, Ton_Counter_C, Noise_Counter;
-
-union TEnvelopeCounter {
-   struct {
-      dword Lo;
-      dword Hi;
-   };
-   int64_t Re;
-};
 extern TEnvelopeCounter Envelope_Counter;
 
 extern byte Ton_A, Ton_B, Ton_C;

--- a/test/z80_cb_test.cpp
+++ b/test/z80_cb_test.cpp
@@ -1,0 +1,600 @@
+#include <gtest/gtest.h>
+#include "z80.h"
+#include "koncepcja.h"
+
+#include "z80_macros.h"
+
+extern byte *membank_read[4];
+extern t_z80regs z80;
+
+namespace {
+
+class Z80CBTest : public testing::Test {
+ public:
+  static void SetUpTestCase() { z80_init_tables(); }
+
+ protected:
+  // Helper: place a CB-prefixed instruction and execute it.
+  // membank0 must outlive the call (caller owns it).
+  void execCB(byte *membank0, byte cb_opcode) {
+    membank0[0] = 0xCB;
+    membank0[1] = cb_opcode;
+    _PC = 0;
+    _R = 0;
+    membank_read[0] = membank0;
+    z80_execute_instruction();
+  }
+};
+
+// ---------------------------------------------------------------------------
+// RLC B (CB 00)
+// ---------------------------------------------------------------------------
+
+TEST_F(Z80CBTest, RLC_B_Basic) {
+  byte mem[2];
+  _B = 0x85;  // 1000 0101
+  _F = 0;
+  execCB(mem, 0x00);
+  // Rotate left: bit 7 (1) goes to carry and bit 0
+  // Result: 0000 1011 = 0x0B
+  EXPECT_EQ(0x0B, _B);
+  EXPECT_TRUE(_F & Cflag);    // bit 7 was 1
+  EXPECT_FALSE(_F & Zflag);   // result non-zero
+  EXPECT_FALSE(_F & Nflag);   // N always cleared
+  EXPECT_FALSE(_F & Hflag);   // H always cleared
+}
+
+TEST_F(Z80CBTest, RLC_B_CarryClear) {
+  byte mem[2];
+  _B = 0x01;  // 0000 0001
+  _F = Cflag;  // pre-existing carry should be replaced
+  execCB(mem, 0x00);
+  // Result: 0000 0010 = 0x02, old bit 7 was 0
+  EXPECT_EQ(0x02, _B);
+  EXPECT_FALSE(_F & Cflag);
+  EXPECT_FALSE(_F & Zflag);
+}
+
+TEST_F(Z80CBTest, RLC_B_Zero) {
+  byte mem[2];
+  _B = 0x00;
+  _F = 0;
+  execCB(mem, 0x00);
+  EXPECT_EQ(0x00, _B);
+  EXPECT_TRUE(_F & Zflag);
+  EXPECT_FALSE(_F & Cflag);
+}
+
+// ---------------------------------------------------------------------------
+// RRC B (CB 08)
+// ---------------------------------------------------------------------------
+
+TEST_F(Z80CBTest, RRC_B_Basic) {
+  byte mem[2];
+  _B = 0x85;  // 1000 0101
+  _F = 0;
+  execCB(mem, 0x08);
+  // Rotate right: bit 0 (1) goes to carry and bit 7
+  // Result: 1100 0010 = 0xC2
+  EXPECT_EQ(0xC2, _B);
+  EXPECT_TRUE(_F & Cflag);    // bit 0 was 1
+  EXPECT_FALSE(_F & Zflag);
+}
+
+TEST_F(Z80CBTest, RRC_B_CarryClear) {
+  byte mem[2];
+  _B = 0x80;  // 1000 0000
+  _F = Cflag;
+  execCB(mem, 0x08);
+  // Result: 0100 0000 = 0x40, bit 0 was 0
+  EXPECT_EQ(0x40, _B);
+  EXPECT_FALSE(_F & Cflag);
+  EXPECT_FALSE(_F & Zflag);
+}
+
+TEST_F(Z80CBTest, RRC_B_Zero) {
+  byte mem[2];
+  _B = 0x00;
+  _F = 0;
+  execCB(mem, 0x08);
+  EXPECT_EQ(0x00, _B);
+  EXPECT_TRUE(_F & Zflag);
+  EXPECT_FALSE(_F & Cflag);
+}
+
+// ---------------------------------------------------------------------------
+// RL B (CB 10) - rotate left through carry
+// ---------------------------------------------------------------------------
+
+TEST_F(Z80CBTest, RL_B_CarryInAndOut) {
+  byte mem[2];
+  _B = 0x80;  // 1000 0000
+  _F = Cflag;  // carry is set
+  execCB(mem, 0x10);
+  // bit 7 -> carry (set), old carry -> bit 0
+  // Result: 0000 0001 = 0x01
+  EXPECT_EQ(0x01, _B);
+  EXPECT_TRUE(_F & Cflag);   // bit 7 was 1
+  EXPECT_FALSE(_F & Zflag);
+}
+
+TEST_F(Z80CBTest, RL_B_NoCarry) {
+  byte mem[2];
+  _B = 0x40;  // 0100 0000
+  _F = 0;      // no carry in
+  execCB(mem, 0x10);
+  // Result: 1000 0000 = 0x80, bit 7 was 0
+  EXPECT_EQ(0x80, _B);
+  EXPECT_FALSE(_F & Cflag);
+  EXPECT_TRUE(_F & Sflag);   // result has bit 7 set
+}
+
+TEST_F(Z80CBTest, RL_B_Zero) {
+  byte mem[2];
+  _B = 0x00;
+  _F = 0;  // no carry in
+  execCB(mem, 0x10);
+  EXPECT_EQ(0x00, _B);
+  EXPECT_TRUE(_F & Zflag);
+  EXPECT_FALSE(_F & Cflag);
+}
+
+// ---------------------------------------------------------------------------
+// RR B (CB 18) - rotate right through carry
+// ---------------------------------------------------------------------------
+
+TEST_F(Z80CBTest, RR_B_CarryInAndOut) {
+  byte mem[2];
+  _B = 0x01;  // 0000 0001
+  _F = Cflag;  // carry is set
+  execCB(mem, 0x18);
+  // bit 0 -> carry (set), old carry -> bit 7
+  // Result: 1000 0000 = 0x80
+  EXPECT_EQ(0x80, _B);
+  EXPECT_TRUE(_F & Cflag);   // bit 0 was 1
+  EXPECT_TRUE(_F & Sflag);   // bit 7 set in result
+}
+
+TEST_F(Z80CBTest, RR_B_NoCarry) {
+  byte mem[2];
+  _B = 0x02;  // 0000 0010
+  _F = 0;      // no carry in
+  execCB(mem, 0x18);
+  // Result: 0000 0001 = 0x01, bit 0 was 0
+  EXPECT_EQ(0x01, _B);
+  EXPECT_FALSE(_F & Cflag);
+  EXPECT_FALSE(_F & Zflag);
+}
+
+TEST_F(Z80CBTest, RR_B_Zero) {
+  byte mem[2];
+  _B = 0x00;
+  _F = 0;
+  execCB(mem, 0x18);
+  EXPECT_EQ(0x00, _B);
+  EXPECT_TRUE(_F & Zflag);
+  EXPECT_FALSE(_F & Cflag);
+}
+
+// ---------------------------------------------------------------------------
+// SLA B (CB 20) - shift left arithmetic
+// ---------------------------------------------------------------------------
+
+TEST_F(Z80CBTest, SLA_B_Basic) {
+  byte mem[2];
+  _B = 0x42;  // 0100 0010
+  _F = 0;
+  execCB(mem, 0x20);
+  // Shift left: bit 7 (0) -> carry, bit 0 = 0
+  // Result: 1000 0100 = 0x84
+  EXPECT_EQ(0x84, _B);
+  EXPECT_FALSE(_F & Cflag);
+  EXPECT_TRUE(_F & Sflag);
+}
+
+TEST_F(Z80CBTest, SLA_B_CarryOut) {
+  byte mem[2];
+  _B = 0x81;  // 1000 0001
+  _F = 0;
+  execCB(mem, 0x20);
+  // bit 7 (1) -> carry
+  // Result: 0000 0010 = 0x02
+  EXPECT_EQ(0x02, _B);
+  EXPECT_TRUE(_F & Cflag);
+  EXPECT_FALSE(_F & Zflag);
+}
+
+TEST_F(Z80CBTest, SLA_B_Zero) {
+  byte mem[2];
+  _B = 0x80;  // 1000 0000
+  _F = 0;
+  execCB(mem, 0x20);
+  // Result: 0x00, carry set from bit 7
+  EXPECT_EQ(0x00, _B);
+  EXPECT_TRUE(_F & Zflag);
+  EXPECT_TRUE(_F & Cflag);
+}
+
+// ---------------------------------------------------------------------------
+// SRA B (CB 28) - shift right arithmetic (sign bit preserved)
+// ---------------------------------------------------------------------------
+
+TEST_F(Z80CBTest, SRA_B_PreservesSign) {
+  byte mem[2];
+  _B = 0x84;  // 1000 0100
+  _F = 0;
+  execCB(mem, 0x28);
+  // bit 0 (0) -> carry, bit 7 preserved (1)
+  // Result: 1100 0010 = 0xC2
+  EXPECT_EQ(0xC2, _B);
+  EXPECT_FALSE(_F & Cflag);
+  EXPECT_TRUE(_F & Sflag);
+}
+
+TEST_F(Z80CBTest, SRA_B_CarryOut) {
+  byte mem[2];
+  _B = 0x03;  // 0000 0011
+  _F = 0;
+  execCB(mem, 0x28);
+  // bit 0 (1) -> carry, bit 7 preserved (0)
+  // Result: 0000 0001 = 0x01
+  EXPECT_EQ(0x01, _B);
+  EXPECT_TRUE(_F & Cflag);
+  EXPECT_FALSE(_F & Sflag);
+}
+
+TEST_F(Z80CBTest, SRA_B_NegativeToMinusOne) {
+  byte mem[2];
+  _B = 0xFF;  // 1111 1111 = -1 signed
+  _F = 0;
+  execCB(mem, 0x28);
+  // SRA of -1 stays -1: 0xFF, carry = 1 (bit 0 was 1)
+  EXPECT_EQ(0xFF, _B);
+  EXPECT_TRUE(_F & Cflag);
+  EXPECT_TRUE(_F & Sflag);
+}
+
+// ---------------------------------------------------------------------------
+// SRL B (CB 38) - shift right logical
+// ---------------------------------------------------------------------------
+
+TEST_F(Z80CBTest, SRL_B_Basic) {
+  byte mem[2];
+  _B = 0x84;  // 1000 0100
+  _F = 0;
+  execCB(mem, 0x38);
+  // bit 0 (0) -> carry, bit 7 = 0
+  // Result: 0100 0010 = 0x42
+  EXPECT_EQ(0x42, _B);
+  EXPECT_FALSE(_F & Cflag);
+  EXPECT_FALSE(_F & Sflag);  // bit 7 is always cleared
+}
+
+TEST_F(Z80CBTest, SRL_B_CarryOut) {
+  byte mem[2];
+  _B = 0x01;  // 0000 0001
+  _F = 0;
+  execCB(mem, 0x38);
+  // bit 0 (1) -> carry, bit 7 = 0
+  // Result: 0x00
+  EXPECT_EQ(0x00, _B);
+  EXPECT_TRUE(_F & Cflag);
+  EXPECT_TRUE(_F & Zflag);
+}
+
+TEST_F(Z80CBTest, SRL_B_HighBitCleared) {
+  byte mem[2];
+  _B = 0x80;  // 1000 0000
+  _F = 0;
+  execCB(mem, 0x38);
+  // Result: 0100 0000 = 0x40, carry = 0
+  EXPECT_EQ(0x40, _B);
+  EXPECT_FALSE(_F & Cflag);
+  EXPECT_FALSE(_F & Sflag);
+}
+
+// ---------------------------------------------------------------------------
+// BIT 0,B (CB 40) - test bit 0
+// ---------------------------------------------------------------------------
+
+TEST_F(Z80CBTest, BIT0_B_BitSet) {
+  byte mem[2];
+  _B = 0x01;  // bit 0 is set
+  _F = Cflag;  // carry should be preserved
+  execCB(mem, 0x40);
+  // Z flag cleared (bit is set), H flag set, carry preserved
+  EXPECT_FALSE(_F & Zflag);
+  EXPECT_TRUE(_F & Hflag);
+  EXPECT_TRUE(_F & Cflag);   // carry preserved
+  EXPECT_EQ(0x01, _B);       // register unchanged
+}
+
+TEST_F(Z80CBTest, BIT0_B_BitClear) {
+  byte mem[2];
+  _B = 0xFE;  // bit 0 is clear
+  _F = 0;
+  execCB(mem, 0x40);
+  // Z flag set (bit is 0), H flag set
+  EXPECT_TRUE(_F & Zflag);
+  EXPECT_TRUE(_F & Hflag);
+  EXPECT_FALSE(_F & Cflag);  // carry was 0, preserved
+  EXPECT_EQ(0xFE, _B);       // register unchanged
+}
+
+// ---------------------------------------------------------------------------
+// BIT 7,B (CB 78) - test bit 7
+// ---------------------------------------------------------------------------
+
+TEST_F(Z80CBTest, BIT7_B_BitSet) {
+  byte mem[2];
+  _B = 0x80;  // bit 7 is set
+  _F = 0;
+  execCB(mem, 0x78);
+  EXPECT_FALSE(_F & Zflag);
+  EXPECT_TRUE(_F & Sflag);   // BIT 7 sets S flag when bit is set
+  EXPECT_TRUE(_F & Hflag);
+  EXPECT_EQ(0x80, _B);
+}
+
+TEST_F(Z80CBTest, BIT7_B_BitClear) {
+  byte mem[2];
+  _B = 0x7F;  // bit 7 is clear
+  _F = Cflag;
+  execCB(mem, 0x78);
+  EXPECT_TRUE(_F & Zflag);
+  EXPECT_FALSE(_F & Sflag);
+  EXPECT_TRUE(_F & Hflag);
+  EXPECT_TRUE(_F & Cflag);   // carry preserved
+  EXPECT_EQ(0x7F, _B);
+}
+
+// ---------------------------------------------------------------------------
+// BIT 3,B (CB 58) - test bit 3 (middle bit)
+// ---------------------------------------------------------------------------
+
+TEST_F(Z80CBTest, BIT3_B_BitSet) {
+  byte mem[2];
+  _B = 0x08;  // only bit 3 set
+  _F = 0;
+  execCB(mem, 0x58);
+  EXPECT_FALSE(_F & Zflag);
+  EXPECT_TRUE(_F & Hflag);
+  EXPECT_EQ(0x08, _B);
+}
+
+TEST_F(Z80CBTest, BIT3_B_BitClear) {
+  byte mem[2];
+  _B = 0xF7;  // all bits set except bit 3
+  _F = 0;
+  execCB(mem, 0x58);
+  EXPECT_TRUE(_F & Zflag);
+  EXPECT_TRUE(_F & Hflag);
+  EXPECT_EQ(0xF7, _B);
+}
+
+// ---------------------------------------------------------------------------
+// SET 0,B (CB C0) - set bit 0
+// ---------------------------------------------------------------------------
+
+TEST_F(Z80CBTest, SET0_B_AlreadyClear) {
+  byte mem[2];
+  _B = 0x00;
+  execCB(mem, 0xC0);
+  EXPECT_EQ(0x01, _B);
+}
+
+TEST_F(Z80CBTest, SET0_B_AlreadySet) {
+  byte mem[2];
+  _B = 0xFF;
+  execCB(mem, 0xC0);
+  EXPECT_EQ(0xFF, _B);  // unchanged
+}
+
+// ---------------------------------------------------------------------------
+// SET 7,B (CB F8) - set bit 7
+// ---------------------------------------------------------------------------
+
+TEST_F(Z80CBTest, SET7_B_AlreadyClear) {
+  byte mem[2];
+  _B = 0x00;
+  execCB(mem, 0xF8);
+  EXPECT_EQ(0x80, _B);
+}
+
+TEST_F(Z80CBTest, SET7_B_OtherBitsPreserved) {
+  byte mem[2];
+  _B = 0x55;  // 0101 0101
+  execCB(mem, 0xF8);
+  EXPECT_EQ(0xD5, _B);  // 1101 0101
+}
+
+// ---------------------------------------------------------------------------
+// RES 0,B (CB 80) - reset bit 0
+// ---------------------------------------------------------------------------
+
+TEST_F(Z80CBTest, RES0_B_BitWasSet) {
+  byte mem[2];
+  _B = 0xFF;
+  execCB(mem, 0x80);
+  EXPECT_EQ(0xFE, _B);
+}
+
+TEST_F(Z80CBTest, RES0_B_BitWasClear) {
+  byte mem[2];
+  _B = 0xFE;
+  execCB(mem, 0x80);
+  EXPECT_EQ(0xFE, _B);  // unchanged
+}
+
+// ---------------------------------------------------------------------------
+// RES 7,B (CB B8) - reset bit 7
+// ---------------------------------------------------------------------------
+
+TEST_F(Z80CBTest, RES7_B_BitWasSet) {
+  byte mem[2];
+  _B = 0xFF;
+  execCB(mem, 0xB8);
+  EXPECT_EQ(0x7F, _B);
+}
+
+TEST_F(Z80CBTest, RES7_B_OtherBitsPreserved) {
+  byte mem[2];
+  _B = 0xAA;  // 1010 1010
+  execCB(mem, 0xB8);
+  EXPECT_EQ(0x2A, _B);  // 0010 1010
+}
+
+// ---------------------------------------------------------------------------
+// PC advancement: CB prefix + sub-opcode = 2 bytes
+// ---------------------------------------------------------------------------
+
+TEST_F(Z80CBTest, PC_AdvancesBy2) {
+  byte mem[2];
+  _B = 0x01;
+  _F = 0;
+  execCB(mem, 0x00);  // RLC B
+  EXPECT_EQ(2, _PC);
+}
+
+// ---------------------------------------------------------------------------
+// R register: incremented twice (once for CB prefix, once for sub-opcode)
+// ---------------------------------------------------------------------------
+
+TEST_F(Z80CBTest, R_IncrementedTwice) {
+  byte mem[2];
+  _B = 0x01;
+  _F = 0;
+  execCB(mem, 0x00);  // RLC B
+  EXPECT_EQ(2, _R);
+}
+
+// ---------------------------------------------------------------------------
+// Cross-register: RLC A (CB 07)
+// ---------------------------------------------------------------------------
+
+TEST_F(Z80CBTest, RLC_A) {
+  byte mem[2];
+  _A = 0x81;  // 1000 0001
+  _F = 0;
+  execCB(mem, 0x07);
+  // Result: 0000 0011 = 0x03, carry from bit 7
+  EXPECT_EQ(0x03, _A);
+  EXPECT_TRUE(_F & Cflag);
+}
+
+// ---------------------------------------------------------------------------
+// Cross-register: SLA C (CB 21)
+// ---------------------------------------------------------------------------
+
+TEST_F(Z80CBTest, SLA_C) {
+  byte mem[2];
+  _C = 0xC0;  // 1100 0000
+  _F = 0;
+  execCB(mem, 0x21);
+  // bit 7 -> carry, result = 1000 0000 = 0x80
+  EXPECT_EQ(0x80, _C);
+  EXPECT_TRUE(_F & Cflag);
+  EXPECT_TRUE(_F & Sflag);
+}
+
+// ---------------------------------------------------------------------------
+// Parity flag: SZP table includes parity
+// ---------------------------------------------------------------------------
+
+TEST_F(Z80CBTest, RLC_B_ParityEven) {
+  byte mem[2];
+  _B = 0x41;  // 0100 0001
+  _F = 0;
+  execCB(mem, 0x00);
+  // RLC: result = 1000 0010 = 0x82 (two 1-bits = even parity)
+  EXPECT_EQ(0x82, _B);
+  EXPECT_FALSE(_F & Cflag);
+  EXPECT_TRUE(_F & Pflag);  // even parity -> P flag set
+}
+
+TEST_F(Z80CBTest, RLC_B_ParityOdd) {
+  byte mem[2];
+  _B = 0x40;  // 0100 0000
+  _F = 0;
+  execCB(mem, 0x00);
+  // RLC: result = 1000 0000 = 0x80 (one 1-bit = odd parity)
+  EXPECT_EQ(0x80, _B);
+  EXPECT_FALSE(_F & Cflag);
+  EXPECT_FALSE(_F & Pflag);  // odd parity -> P flag cleared
+}
+
+// ---------------------------------------------------------------------------
+// SET/RES do not affect flags
+// ---------------------------------------------------------------------------
+
+TEST_F(Z80CBTest, SET_DoesNotAffectFlags) {
+  byte mem[2];
+  _B = 0x00;
+  _F = Zflag | Cflag;  // set some flags
+  byte saved_f = _F;
+  execCB(mem, 0xC0);  // SET 0,B
+  EXPECT_EQ(0x01, _B);
+  EXPECT_EQ(saved_f, _F);  // flags unchanged
+}
+
+TEST_F(Z80CBTest, RES_DoesNotAffectFlags) {
+  byte mem[2];
+  _B = 0xFF;
+  _F = Sflag | Hflag;
+  byte saved_f = _F;
+  execCB(mem, 0x80);  // RES 0,B
+  EXPECT_EQ(0xFE, _B);
+  EXPECT_EQ(saved_f, _F);  // flags unchanged
+}
+
+// ---------------------------------------------------------------------------
+// BIT preserves carry flag
+// ---------------------------------------------------------------------------
+
+TEST_F(Z80CBTest, BIT_PreservesCarrySet) {
+  byte mem[2];
+  _B = 0x00;
+  _F = Cflag;
+  execCB(mem, 0x40);  // BIT 0,B
+  EXPECT_TRUE(_F & Cflag);
+  EXPECT_TRUE(_F & Zflag);
+}
+
+TEST_F(Z80CBTest, BIT_PreservesCarryClear) {
+  byte mem[2];
+  _B = 0x00;
+  _F = 0;
+  execCB(mem, 0x40);  // BIT 0,B
+  EXPECT_FALSE(_F & Cflag);
+  EXPECT_TRUE(_F & Zflag);
+}
+
+// ---------------------------------------------------------------------------
+// Shift edge cases
+// ---------------------------------------------------------------------------
+
+TEST_F(Z80CBTest, SRA_B_PositiveValue) {
+  byte mem[2];
+  _B = 0x7E;  // 0111 1110 (positive, bit 7 = 0)
+  _F = 0;
+  execCB(mem, 0x28);
+  // bit 0 (0) -> carry, bit 7 stays 0
+  // Result: 0011 1111 = 0x3F
+  EXPECT_EQ(0x3F, _B);
+  EXPECT_FALSE(_F & Cflag);
+  EXPECT_FALSE(_F & Sflag);
+}
+
+TEST_F(Z80CBTest, SRL_B_AllOnes) {
+  byte mem[2];
+  _B = 0xFF;
+  _F = 0;
+  execCB(mem, 0x38);
+  // bit 0 (1) -> carry, bit 7 = 0
+  // Result: 0111 1111 = 0x7F
+  EXPECT_EQ(0x7F, _B);
+  EXPECT_TRUE(_F & Cflag);
+  EXPECT_FALSE(_F & Sflag);
+}
+
+}  // namespace


### PR DESCRIPTION
## Summary

Audio diagnostics + pre-buffer fix + 88 new tests.

### Audio underrun diagnostics
Instruments the audio pipeline to detect and diagnose stuttering:
- Query `SDL_GetAudioStreamQueued()` before each push and after `video_display()`
- **Gray** indicator: healthy. **Yellow**: near-underrun (queue < half buffer). **Red**: hard underrun (queue empty).
- Tooltip: avg/min queue depth, push interval max, pushes/sec, underrun + near-underrun counts
- `LOG_DEBUG` for each underrun/near-underrun with interval and queue depth

### Pre-buffer (behavior change)
- Pre-buffer 2 silent audio buffers (~46ms) before resuming the device
- Absorbs occasional macOS compositor stalls without audible artifact
- Adds ~46ms audio latency (acceptable for emulator)

### New tests (940 → 1028)
- Z80 CB-prefix: 47 tests (shift/rotate/BIT/SET/RES with flag verification)
- PSG AY-3-8912: 25 tests (register masking, envelope, reset, level tables)
- FDC uPD765A: 16 tests (status, specify, seek, recalibrate, sense interrupt)

### Cleanup
- PSG internal unions extracted to `psg_types.h` (shared between psg.cpp and test)
- Fixed pre-existing integer division warning in psg.cpp

## Test plan
- [ ] DevTools bar shows `snd:` indicator (gray/yellow/red)
- [ ] Hover tooltip shows full diagnostics
- [ ] Audio plays without stutter in docked mode
- [ ] `-v` flag shows underrun LOG_DEBUG messages
- [ ] All 1028 tests pass on Linux, macOS, MSVC