### PR TITLE
fix: remove ImGuiConfigFlags_ViewportsEnable — eliminate multi-viewport bugs

### DIFF
--- a/src/imgui_ui.cpp
+++ b/src/imgui_ui.cpp
@@ -301,12 +301,6 @@ void imgui_init_ui()
   c[ImGuiCol_SliderGrabActive]= ImVec4(0.650f, 0.520f, 0.130f, 1.00f);
   c[ImGuiCol_Separator]       = ImVec4(0.300f, 0.300f, 0.350f, 0.50f);
 
-  // When viewports are enabled, platform windows should not have rounded corners
-  if (io.ConfigFlags & ImGuiConfigFlags_ViewportsEnable) {
-    style.WindowRounding = 0.0f;
-    c[ImGuiCol_WindowBg].w = 1.0f;
-  }
-
   // Register command palette entries from menu actions
   g_command_palette.clear_commands();
   for (const auto& ma : koncpc_menu_actions()) {

--- a/src/macos_menu.h
+++ b/src/macos_menu.h
@@ -4,7 +4,6 @@ void koncpc_setup_macos_menu();
 void koncpc_disable_app_nap();
 void koncpc_enable_app_nap();
 void koncpc_activate_app();
-void koncpc_order_viewports_above_main();
 // Dock icon: set the app icon from the bundled PNG, optionally with a live CPC screen inset
 void koncpc_set_dock_icon(const char* png_path);
 // pixels: full surface, vis_x/vis_y/vis_w/vis_h: visible CPC screen region within it
@@ -14,7 +13,6 @@ void koncpc_update_dock_icon_preview(const void* pixels, int surface_w, int surf
 inline void koncpc_disable_app_nap() {}
 inline void koncpc_enable_app_nap() {}
 inline void koncpc_activate_app() {}
-inline void koncpc_order_viewports_above_main() {}
 inline void koncpc_set_dock_icon(const char*) {}
 inline void koncpc_update_dock_icon_preview(const void*, int, int, int, int, int, int, int) {}
 #endif

--- a/src/macos_menu.mm
+++ b/src/macos_menu.mm
@@ -187,46 +187,6 @@ static NSWindow* nswindow_from_viewport(ImGuiViewport* vp) {
       SDL_PROP_WINDOW_COCOA_WINDOW_POINTER, NULL);
 }
 
-void koncpc_order_viewports_above_main() {
-  // On macOS, ImGui's SDL3 backend skips SDL_SetWindowParent() because it
-  // breaks multi-monitor support.  Instead we use Cocoa's orderWindow: to
-  // keep ImGui viewport windows above the main emulator window without
-  // making them system-level always-on-top.
-  //
-  // Two tiers:
-  //   1. Tool windows (with title bar) → above main emulator window
-  //   2. Popups/menus/dropdowns (NoTaskBarIcon) → above all tool windows
-  if (!mainSDLWindow) return;
-
-  NSWindow* mainNS = (__bridge NSWindow*)SDL_GetPointerProperty(
-      SDL_GetWindowProperties(mainSDLWindow),
-      SDL_PROP_WINDOW_COCOA_WINDOW_POINTER, NULL);
-  if (!mainNS) return;
-  NSInteger mainNum = [mainNS windowNumber];
-
-  ImGuiPlatformIO& pio = ImGui::GetPlatformIO();
-
-  // Pass 1: tool windows above main emulator
-  for (int i = 1; i < pio.Viewports.Size; i++) {
-    ImGuiViewport* vp = pio.Viewports[i];
-    if (vp->Flags & ImGuiViewportFlags_NoTaskBarIcon) continue;  // popup
-    NSWindow* ns = nswindow_from_viewport(vp);
-    if (ns && [ns windowNumber] != mainNum) {
-      [ns orderWindow:NSWindowAbove relativeTo:mainNum];
-    }
-  }
-
-  // Pass 2: popups/menus above everything (orderFront without stealing focus)
-  for (int i = 1; i < pio.Viewports.Size; i++) {
-    ImGuiViewport* vp = pio.Viewports[i];
-    if (!(vp->Flags & ImGuiViewportFlags_NoTaskBarIcon)) continue;  // tool
-    NSWindow* ns = nswindow_from_viewport(vp);
-    if (ns) {
-      [ns orderFront:nil];
-    }
-  }
-}
-
 // ── Dock icon ──────────────────────────────────────────────
 
 static NSImage* g_icon_overlay = nil;  // CRT overlay (translucent screen area)

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -49,7 +49,6 @@
 #include "imgui_impl_opengl3.h"
 #include "imgui_impl_sdlrenderer3.h"
 #include "imgui_ui.h"
-#include "macos_menu.h"
 
 #ifdef __APPLE__
 #include <OpenGL/gl3.h>
@@ -318,7 +317,6 @@ SDL_Surface* direct_init(video_plugin* t, int scale, bool fs)
   io.IniFilename = imgui_ini_path();
   io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;
   io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;
-  io.ConfigFlags |= ImGuiConfigFlags_ViewportsEnable;
   ImGui::StyleColorsDark();
   imgui_init_ui();
   ImGui_ImplSDL3_InitForOpenGL(mainSDLWindow, glcontext);
@@ -412,26 +410,9 @@ void direct_flip_a(video_plugin* t)
   video_capture_if_pending();
 }
 
-// Phase B: floating ImGui viewports + window swap (0-60ms depending on viewport count).
-// Runs after audio push so GL stalls don't starve the audio queue.
+// Phase B: window swap.
 void direct_flip_b([[maybe_unused]] video_plugin* t)
 {
-  // Multi-viewport: update and render platform windows.
-  // Only render when there are actual platform viewports (floating devtools, popups, submenus).
-  // When only the main viewport exists (Viewports.Size == 1), skip — saves GL context
-  // switches and SDL_GL_SwapWindow calls that block on macOS compositor.
-  ImGuiIO& io = ImGui::GetIO();
-  if (io.ConfigFlags & ImGuiConfigFlags_ViewportsEnable) {
-    SDL_Window* backup_window = SDL_GL_GetCurrentWindow();
-    SDL_GLContext backup_context = SDL_GL_GetCurrentContext();
-    ImGui::UpdatePlatformWindows();
-    if (ImGui::GetPlatformIO().Viewports.Size > 1) {
-      koncpc_order_viewports_above_main();
-      ImGui::RenderPlatformWindowsDefault();
-    }
-    SDL_GL_MakeCurrent(backup_window, backup_context);
-  }
-
   SDL_GL_SwapWindow(mainSDLWindow);
 }
 
@@ -1077,7 +1058,6 @@ SDL_Surface* sdlr_init(video_plugin* t, int scale, bool fs)
   io.IniFilename = imgui_ini_path();
   io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;
   io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;
-  // ViewportsEnable not supported by SDL_Renderer backend
   ImGui::StyleColorsDark();
   imgui_init_ui();
   if (!ImGui_ImplSDL3_InitForSDLRenderer(mainSDLWindow, renderer)) {
@@ -1856,7 +1836,6 @@ SDL_Surface* swscale_init(video_plugin* t, int scale, bool fs)
   io.IniFilename = imgui_ini_path();
   io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;
   io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;
-  io.ConfigFlags |= ImGuiConfigFlags_ViewportsEnable;
   ImGui::StyleColorsDark();
   imgui_init_ui();
   ImGui_ImplSDL3_InitForOpenGL(mainSDLWindow, glcontext);
@@ -1961,25 +1940,11 @@ void swscale_blit_a(video_plugin* t)
   video_capture_if_pending();
 }
 
-// Phase B: floating ImGui viewports + window swap.
+// Phase B: window swap.
 // SDL_Renderer path already completed everything in swscale_blit_a — return early.
 void swscale_blit_b([[maybe_unused]] video_plugin* t)
 {
   if (using_sdl_renderer) return;
-
-  // Multi-viewport: render platform windows only when they exist
-  ImGuiIO& io = ImGui::GetIO();
-  if (io.ConfigFlags & ImGuiConfigFlags_ViewportsEnable) {
-    SDL_Window* backup_window = SDL_GL_GetCurrentWindow();
-    SDL_GLContext backup_context = SDL_GL_GetCurrentContext();
-    ImGui::UpdatePlatformWindows();
-    if (ImGui::GetPlatformIO().Viewports.Size > 1) {
-      koncpc_order_viewports_above_main();
-      ImGui::RenderPlatformWindowsDefault();
-    }
-    SDL_GL_MakeCurrent(backup_window, backup_context);
-  }
-
   SDL_GL_SwapWindow(mainSDLWindow);
 }
 


### PR DESCRIPTION
## Summary

- Removes `ImGuiConfigFlags_ViewportsEnable` from all backend inits
- Deletes `UpdatePlatformWindows`/`RenderPlatformWindowsDefault` blocks from `direct_flip_b` and `swscale_blit_b`
- Removes `koncpc_order_viewports_above_main()` (the Cocoa `NSWindowAbove` workaround — dead code once no secondary OS windows are created)
- Cleans up associated style tweak and `macos_menu.h` include in `video.cpp`

## Why

`ViewportsEnable` was root-caused as responsible for 9 of 12 catalogued SDL/ImGui stability bugs:
- Black screen from missing GL context restore after `UpdatePlatformWindows`
- Crash on viewport flag toggle mid-frame
- UI bars auto-promoted to floating platform viewports
- Mouse buttons stuck after drag (`SDL_CaptureMouse` is a no-op on macOS Cocoa)
- Window order fights (`orderWindow:NSWindowAbove` confuses macOS mouse-up delivery)
- Stale viewport reads from async `SDL_SetWindowSize`

The existing `workspace_render_dockspace()` already provides `DockingEnable` + `PassthruCentralNode` — all docked layout features remain intact with no platform viewport machinery.

## Test plan

- [ ] Launch emulator — UI renders, topbar/statusbar visible, no black screen
- [ ] Open DevTools (F12) — panels dock correctly inside the main window
- [ ] Drag a DevTools panel — docking works, no floating OS windows created
- [ ] Click Menu (F1) — opens/closes cleanly, no keyboard focus stuck after
- [ ] Open file dialog (load disk) — focus returns to emulator after dismiss
- [ ] Click and drag inside CPC screen — no stuck mouse buttons after releasing
- [ ] Resize main window — UI reflows correctly