### PR TITLE
feat(gpu): Phase 2 — GPU device scaffold

### DIFF
--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -51,6 +51,7 @@ static inline Uint32 MapRGBSurface(SDL_Surface* surface, Uint8 r, Uint8 g, Uint8
 #include "disk.h"
 #include "tape.h"
 #include "video.h"
+#include "video_gpu.h"
 #include "z80.h"
 #include "configuration.h"
 #include "memutils.h"
@@ -2028,6 +2029,17 @@ int video_init ()
       }
    }
 
+   // Phase 2 scaffold: initialize GPU device alongside GL path.
+   // Does not affect rendering — plugins still use GL.  Passes the CPC
+   // framebuffer dimensions so the GPU texture/transfer buffer match.
+   if (mainSDLWindow && back_surface) {
+      if (!video_gpu_init(mainSDLWindow,
+                          static_cast<uint32_t>(back_surface->w),
+                          static_cast<uint32_t>(back_surface->h))) {
+         LOG_INFO("GPU device init skipped (no backend available)");
+      }
+   }
+
    {
       const SDL_PixelFormatDetails* fmt = SDL_GetPixelFormatDetails(back_surface->format);
       CPC.scr_bpp = fmt ? fmt->bits_per_pixel : 0; // bit depth of the surface
@@ -2068,6 +2080,7 @@ int video_init ()
 
 void video_shutdown ()
 {
+   video_gpu_shutdown();   // safe no-op if not initialized
    vid_plugin->close();
 }
 

--- a/src/video_gpu.cpp
+++ b/src/video_gpu.cpp
@@ -60,9 +60,6 @@ bool video_gpu_init(SDL_Window* window, uint32_t fb_w, uint32_t fb_h)
         info.address_mode_v   = SDL_GPU_SAMPLERADDRESSMODE_CLAMP_TO_EDGE;
         info.address_mode_w   = SDL_GPU_SAMPLERADDRESSMODE_CLAMP_TO_EDGE;
         g_gpu.linear_sampler  = SDL_CreateGPUSampler(g_gpu.device, &info);
-        if (!g_gpu.linear_sampler) {
-            LOG_ERROR("Failed to create linear sampler: " << SDL_GetError());
-        }
     }
     {
         SDL_GPUSamplerCreateInfo info{};
@@ -72,14 +69,13 @@ bool video_gpu_init(SDL_Window* window, uint32_t fb_w, uint32_t fb_h)
         info.address_mode_v   = SDL_GPU_SAMPLERADDRESSMODE_CLAMP_TO_EDGE;
         info.address_mode_w   = SDL_GPU_SAMPLERADDRESSMODE_CLAMP_TO_EDGE;
         g_gpu.nearest_sampler = SDL_CreateGPUSampler(g_gpu.device, &info);
-        if (!g_gpu.nearest_sampler) {
-            LOG_ERROR("Failed to create nearest sampler: " << SDL_GetError());
-        }
     }
 
     // ── 5. Create CPC framebuffer texture ─────────────────────────────
     // RGBA8, dimensions match the CPU-side render surface (768×540 at scale=2).
     // Usage: sampled in the blit pass, written by texture upload copy pass.
+    // Note: SDL3 GPU has no COPY_DST flag — UploadToGPUTexture works on any
+    // texture regardless of usage flags (see SDL_render_gpu.c for precedent).
     {
         SDL_GPUTextureCreateInfo info{};
         info.type                  = SDL_GPU_TEXTURETYPE_2D;
@@ -91,9 +87,6 @@ bool video_gpu_init(SDL_Window* window, uint32_t fb_w, uint32_t fb_h)
         info.usage                 = SDL_GPU_TEXTUREUSAGE_SAMPLER
                                    | SDL_GPU_TEXTUREUSAGE_COLOR_TARGET;
         g_gpu.cpc_texture = SDL_CreateGPUTexture(g_gpu.device, &info);
-        if (!g_gpu.cpc_texture) {
-            LOG_ERROR("Failed to create CPC GPU texture: " << SDL_GetError());
-        }
         g_gpu.cpc_tex_w = fb_w;
         g_gpu.cpc_tex_h = fb_h;
     }
@@ -104,9 +97,14 @@ bool video_gpu_init(SDL_Window* window, uint32_t fb_w, uint32_t fb_h)
         info.usage = SDL_GPU_TRANSFERBUFFERUSAGE_UPLOAD;
         info.size  = fb_w * fb_h * 4;   // RGBA8 = 4 bytes/pixel
         g_gpu.cpc_upload = SDL_CreateGPUTransferBuffer(g_gpu.device, &info);
-        if (!g_gpu.cpc_upload) {
-            LOG_ERROR("Failed to create CPC transfer buffer: " << SDL_GetError());
-        }
+    }
+
+    // ── Verify all mandatory resources were created ───────────────────
+    if (!g_gpu.linear_sampler || !g_gpu.nearest_sampler ||
+        !g_gpu.cpc_texture   || !g_gpu.cpc_upload) {
+        LOG_ERROR("GPU resource creation failed — rolling back");
+        video_gpu_shutdown();
+        return false;
     }
 
     g_gpu.initialized = true;
@@ -118,9 +116,8 @@ bool video_gpu_init(SDL_Window* window, uint32_t fb_w, uint32_t fb_h)
 
 void video_gpu_shutdown()
 {
-    if (!g_gpu.initialized) return;
-
-    // Release resources in reverse creation order.
+    // No `initialized` guard — this function doubles as cleanup after a
+    // partially-failed init.  All branches null-check before releasing.
     if (g_gpu.device) {
         if (g_gpu.cpc_upload) {
             SDL_ReleaseGPUTransferBuffer(g_gpu.device, g_gpu.cpc_upload);

--- a/src/video_gpu.cpp
+++ b/src/video_gpu.cpp
@@ -1,0 +1,154 @@
+/* konCePCja — SDL3 GPU API scaffolding (Phase 2 of P1.2b)
+ *
+ * Creates and owns the GPU device, swapchain claim, samplers, and CPC
+ * framebuffer texture + transfer buffer.  Coexists alongside the GL
+ * rendering path until Phase 4 wires plugins to gpu_flip_a / gpu_flip_b.
+ */
+
+#include "video_gpu.h"
+#include "log.h"
+
+#include <SDL3/SDL.h>
+#include <cstring>
+
+GpuState g_gpu;
+
+bool video_gpu_init(SDL_Window* window, uint32_t fb_w, uint32_t fb_h)
+{
+    if (g_gpu.initialized) return true;   // idempotent
+    if (!window) return false;
+
+    // ── 1. Create GPU device ──────────────────────────────────────────
+    // Accept any backend (Metal on macOS, Vulkan on Linux, D3D12 on Windows).
+    g_gpu.device = SDL_CreateGPUDevice(
+        SDL_GPU_SHADERFORMAT_SPIRV
+          | SDL_GPU_SHADERFORMAT_MSL
+          | SDL_GPU_SHADERFORMAT_METALLIB
+          | SDL_GPU_SHADERFORMAT_DXIL,
+        /*debug_mode=*/false,
+        /*name=*/nullptr);
+
+    if (!g_gpu.device) {
+        LOG_INFO("SDL_CreateGPUDevice failed: " << SDL_GetError());
+        return false;
+    }
+
+    const char* driver = SDL_GetGPUDeviceDriver(g_gpu.device);
+    LOG_INFO("GPU device created — driver: " << (driver ? driver : "(null)"));
+
+    // ── 2. Claim window for GPU ───────────────────────────────────────
+    // Must happen before any swapchain acquire (landmine #13).
+    if (!SDL_ClaimWindowForGPUDevice(g_gpu.device, window)) {
+        LOG_ERROR("SDL_ClaimWindowForGPUDevice failed: " << SDL_GetError());
+        SDL_DestroyGPUDevice(g_gpu.device);
+        g_gpu.device = nullptr;
+        return false;
+    }
+    g_gpu.window = window;
+
+    // ── 3. Query swapchain format ─────────────────────────────────────
+    // Needed later for pipeline creation (landmine #5).
+    g_gpu.swapchain_fmt = SDL_GetGPUSwapchainTextureFormat(g_gpu.device, window);
+    LOG_INFO("GPU swapchain format: " << static_cast<int>(g_gpu.swapchain_fmt));
+
+    // ── 4. Create samplers ────────────────────────────────────────────
+    {
+        SDL_GPUSamplerCreateInfo info{};
+        info.min_filter       = SDL_GPU_FILTER_LINEAR;
+        info.mag_filter       = SDL_GPU_FILTER_LINEAR;
+        info.address_mode_u   = SDL_GPU_SAMPLERADDRESSMODE_CLAMP_TO_EDGE;
+        info.address_mode_v   = SDL_GPU_SAMPLERADDRESSMODE_CLAMP_TO_EDGE;
+        info.address_mode_w   = SDL_GPU_SAMPLERADDRESSMODE_CLAMP_TO_EDGE;
+        g_gpu.linear_sampler  = SDL_CreateGPUSampler(g_gpu.device, &info);
+        if (!g_gpu.linear_sampler) {
+            LOG_ERROR("Failed to create linear sampler: " << SDL_GetError());
+        }
+    }
+    {
+        SDL_GPUSamplerCreateInfo info{};
+        info.min_filter       = SDL_GPU_FILTER_NEAREST;
+        info.mag_filter       = SDL_GPU_FILTER_NEAREST;
+        info.address_mode_u   = SDL_GPU_SAMPLERADDRESSMODE_CLAMP_TO_EDGE;
+        info.address_mode_v   = SDL_GPU_SAMPLERADDRESSMODE_CLAMP_TO_EDGE;
+        info.address_mode_w   = SDL_GPU_SAMPLERADDRESSMODE_CLAMP_TO_EDGE;
+        g_gpu.nearest_sampler = SDL_CreateGPUSampler(g_gpu.device, &info);
+        if (!g_gpu.nearest_sampler) {
+            LOG_ERROR("Failed to create nearest sampler: " << SDL_GetError());
+        }
+    }
+
+    // ── 5. Create CPC framebuffer texture ─────────────────────────────
+    // RGBA8, dimensions match the CPU-side render surface (768×540 at scale=2).
+    // Usage: sampled in the blit pass, written by texture upload copy pass.
+    {
+        SDL_GPUTextureCreateInfo info{};
+        info.type                  = SDL_GPU_TEXTURETYPE_2D;
+        info.format                = SDL_GPU_TEXTUREFORMAT_R8G8B8A8_UNORM;
+        info.width                 = fb_w;
+        info.height                = fb_h;
+        info.layer_count_or_depth  = 1;
+        info.num_levels            = 1;
+        info.usage                 = SDL_GPU_TEXTUREUSAGE_SAMPLER
+                                   | SDL_GPU_TEXTUREUSAGE_COLOR_TARGET;
+        g_gpu.cpc_texture = SDL_CreateGPUTexture(g_gpu.device, &info);
+        if (!g_gpu.cpc_texture) {
+            LOG_ERROR("Failed to create CPC GPU texture: " << SDL_GetError());
+        }
+        g_gpu.cpc_tex_w = fb_w;
+        g_gpu.cpc_tex_h = fb_h;
+    }
+
+    // ── 6. Create transfer buffer (staging for CPU→GPU upload) ────────
+    {
+        SDL_GPUTransferBufferCreateInfo info{};
+        info.usage = SDL_GPU_TRANSFERBUFFERUSAGE_UPLOAD;
+        info.size  = fb_w * fb_h * 4;   // RGBA8 = 4 bytes/pixel
+        g_gpu.cpc_upload = SDL_CreateGPUTransferBuffer(g_gpu.device, &info);
+        if (!g_gpu.cpc_upload) {
+            LOG_ERROR("Failed to create CPC transfer buffer: " << SDL_GetError());
+        }
+    }
+
+    g_gpu.initialized = true;
+    LOG_INFO("GPU scaffolding initialized ("
+             << fb_w << "×" << fb_h << ", "
+             << (fb_w * fb_h * 4) << " bytes staging)");
+    return true;
+}
+
+void video_gpu_shutdown()
+{
+    if (!g_gpu.initialized) return;
+
+    // Release resources in reverse creation order.
+    if (g_gpu.device) {
+        if (g_gpu.cpc_upload) {
+            SDL_ReleaseGPUTransferBuffer(g_gpu.device, g_gpu.cpc_upload);
+        }
+        if (g_gpu.cpc_texture) {
+            SDL_ReleaseGPUTexture(g_gpu.device, g_gpu.cpc_texture);
+        }
+        if (g_gpu.blit_pipeline) {
+            SDL_ReleaseGPUGraphicsPipeline(g_gpu.device, g_gpu.blit_pipeline);
+        }
+        if (g_gpu.nearest_sampler) {
+            SDL_ReleaseGPUSampler(g_gpu.device, g_gpu.nearest_sampler);
+        }
+        if (g_gpu.linear_sampler) {
+            SDL_ReleaseGPUSampler(g_gpu.device, g_gpu.linear_sampler);
+        }
+
+        // Wait for all in-flight GPU work before destroying the device
+        // (landmine #20).
+        SDL_WaitForGPUIdle(g_gpu.device);
+
+        if (g_gpu.window) {
+            SDL_ReleaseWindowFromGPUDevice(g_gpu.device, g_gpu.window);
+        }
+
+        SDL_DestroyGPUDevice(g_gpu.device);
+    }
+
+    g_gpu = GpuState{};   // zero all fields, initialized = false
+    LOG_INFO("GPU scaffolding shut down");
+}

--- a/src/video_gpu.h
+++ b/src/video_gpu.h
@@ -1,0 +1,52 @@
+/* konCePCja — SDL3 GPU API scaffolding (Phase 2 of P1.2b)
+ *
+ * Owns the GPU device, swapchain claim, samplers, and CPC framebuffer
+ * upload resources.  Coexists alongside the GL path until Phase 4 wires
+ * plugins to the GPU render loop.
+ */
+
+#ifndef VIDEO_GPU_H
+#define VIDEO_GPU_H
+
+#include <SDL3/SDL_gpu.h>
+#include <cstdint>
+
+struct SDL_Window;
+
+struct GpuState {
+    SDL_GPUDevice*           device          = nullptr;
+    SDL_Window*              window          = nullptr;   // claimed for GPU
+    SDL_GPUTextureFormat     swapchain_fmt   = SDL_GPU_TEXTUREFORMAT_INVALID;
+
+    // Samplers (created once at init, destroyed at shutdown)
+    SDL_GPUSampler*          linear_sampler  = nullptr;   // 4:3 aspect stretch
+    SDL_GPUSampler*          nearest_sampler = nullptr;   // square-pixel mode
+
+    // CPC framebuffer upload path
+    SDL_GPUTexture*          cpc_texture     = nullptr;   // RGBA8 render surface
+    SDL_GPUTransferBuffer*   cpc_upload      = nullptr;   // staging buffer
+    uint32_t                 cpc_tex_w       = 0;
+    uint32_t                 cpc_tex_h       = 0;
+
+    // Pipelines (nullptr until Phase 3 provides shader blobs)
+    SDL_GPUGraphicsPipeline* blit_pipeline   = nullptr;
+
+    // Per-frame command buffer (stashed by flip_a, submitted by flip_b).
+    // Not used until Phase 4 wires plugins to the GPU path.
+    SDL_GPUCommandBuffer*    pending_cmd     = nullptr;
+
+    bool                     initialized     = false;
+};
+
+extern GpuState g_gpu;
+
+// Initialize GPU device, claim window, create samplers + CPC texture/upload
+// buffer.  Called from video_init() after the window exists.
+// Returns true on success.  On failure (no GPU backend), returns false and
+// the caller continues with the GL path.
+bool video_gpu_init(SDL_Window* window, uint32_t fb_w, uint32_t fb_h);
+
+// Destroy all GPU resources in reverse order.  Safe to call if not initialized.
+void video_gpu_shutdown();
+
+#endif // VIDEO_GPU_H

--- a/test/video_gpu_test.cpp
+++ b/test/video_gpu_test.cpp
@@ -50,8 +50,10 @@ TEST_F(VideoGpuTest, InitAndShutdown) {
     SDL_Window* w = make_test_window();
     if (!w) GTEST_SKIP() << "Cannot create window (headless)";
 
-    ASSERT_TRUE(video_gpu_init(w, 768, 540))
-        << "GPU init failed: " << SDL_GetError();
+    if (!video_gpu_init(w, 768, 540)) {
+        SDL_DestroyWindow(w);
+        GTEST_SKIP() << "No GPU backend available: " << SDL_GetError();
+    }
 
     EXPECT_TRUE(g_gpu.initialized);
     EXPECT_NE(g_gpu.device, nullptr);

--- a/test/video_gpu_test.cpp
+++ b/test/video_gpu_test.cpp
@@ -1,0 +1,153 @@
+// Tests for the SDL3 GPU scaffolding (Phase 2 of P1.2b).
+//
+// These tests exercise the GpuState lifecycle: device creation, window claim,
+// sampler/texture/transfer-buffer creation, and orderly shutdown.
+// On headless CI runners without a GPU backend, tests SKIP rather than fail.
+
+#include <gtest/gtest.h>
+
+#include <SDL3/SDL.h>
+#include "video_gpu.h"
+#include <cstring>
+
+namespace {
+
+class VideoGpuTest : public ::testing::Test {
+protected:
+    static void SetUpTestSuite() {
+        SDL_Init(SDL_INIT_VIDEO);
+    }
+    static void TearDownTestSuite() {
+        SDL_Quit();
+    }
+
+    void TearDown() override {
+        // Ensure cleanup even if a test fails partway through.
+        video_gpu_shutdown();
+    }
+
+    // Helper: create a minimal hidden window for GPU testing.
+    // Returns nullptr if the video subsystem can't create windows (headless).
+    SDL_Window* make_test_window() {
+        SDL_Window* w = SDL_CreateWindow("gpu-test", 64, 64, SDL_WINDOW_HIDDEN);
+        return w;
+    }
+
+    // Helper macro: attempt init, skip the test if no GPU backend available.
+    // Must be called directly in the test body (not a helper function) because
+    // GTEST_SKIP() cannot be used in non-void-returning functions.
+    #define TRY_GPU_INIT(w, fb_w, fb_h)                                       \
+        do {                                                                   \
+            if (!video_gpu_init((w), (fb_w), (fb_h))) {                        \
+                video_gpu_shutdown();                                           \
+                SDL_DestroyWindow((w));                                         \
+                GTEST_SKIP() << "No GPU backend available: " << SDL_GetError();\
+            }                                                                  \
+        } while (0)
+};
+
+TEST_F(VideoGpuTest, InitAndShutdown) {
+    SDL_Window* w = make_test_window();
+    if (!w) GTEST_SKIP() << "Cannot create window (headless)";
+
+    ASSERT_TRUE(video_gpu_init(w, 768, 540))
+        << "GPU init failed: " << SDL_GetError();
+
+    EXPECT_TRUE(g_gpu.initialized);
+    EXPECT_NE(g_gpu.device, nullptr);
+    EXPECT_NE(g_gpu.linear_sampler, nullptr);
+    EXPECT_NE(g_gpu.nearest_sampler, nullptr);
+    EXPECT_NE(g_gpu.cpc_texture, nullptr);
+    EXPECT_NE(g_gpu.cpc_upload, nullptr);
+    EXPECT_EQ(g_gpu.cpc_tex_w, 768u);
+    EXPECT_EQ(g_gpu.cpc_tex_h, 540u);
+
+    video_gpu_shutdown();
+
+    EXPECT_FALSE(g_gpu.initialized);
+    EXPECT_EQ(g_gpu.device, nullptr);
+    EXPECT_EQ(g_gpu.linear_sampler, nullptr);
+    EXPECT_EQ(g_gpu.nearest_sampler, nullptr);
+    EXPECT_EQ(g_gpu.cpc_texture, nullptr);
+    EXPECT_EQ(g_gpu.cpc_upload, nullptr);
+
+    SDL_DestroyWindow(w);
+}
+
+TEST_F(VideoGpuTest, SwapchainFormatIsValid) {
+    SDL_Window* w = make_test_window();
+    if (!w) GTEST_SKIP() << "Cannot create window (headless)";
+    TRY_GPU_INIT(w, 768, 540);
+
+    EXPECT_NE(g_gpu.swapchain_fmt, SDL_GPU_TEXTUREFORMAT_INVALID)
+        << "Swapchain format should be a real format after init";
+
+    video_gpu_shutdown();
+    SDL_DestroyWindow(w);
+}
+
+TEST_F(VideoGpuTest, SamplerCreation) {
+    SDL_Window* w = make_test_window();
+    if (!w) GTEST_SKIP() << "Cannot create window (headless)";
+    TRY_GPU_INIT(w, 768, 540);
+
+    EXPECT_NE(g_gpu.linear_sampler, nullptr);
+    EXPECT_NE(g_gpu.nearest_sampler, nullptr);
+
+    // They should be distinct objects.
+    EXPECT_NE(g_gpu.linear_sampler, g_gpu.nearest_sampler);
+
+    video_gpu_shutdown();
+    SDL_DestroyWindow(w);
+}
+
+TEST_F(VideoGpuTest, TransferBufferMapCycle) {
+    SDL_Window* w = make_test_window();
+    if (!w) GTEST_SKIP() << "Cannot create window (headless)";
+    TRY_GPU_INIT(w, 768, 540);
+
+    // Map with cycle=true (the per-frame pattern), write a pattern, unmap.
+    void* ptr = SDL_MapGPUTransferBuffer(g_gpu.device, g_gpu.cpc_upload,
+                                         /*cycle=*/true);
+    ASSERT_NE(ptr, nullptr) << "Map failed: " << SDL_GetError();
+
+    std::memset(ptr, 0xCD, g_gpu.cpc_tex_w * g_gpu.cpc_tex_h * 4);
+    SDL_UnmapGPUTransferBuffer(g_gpu.device, g_gpu.cpc_upload);
+
+    video_gpu_shutdown();
+    SDL_DestroyWindow(w);
+}
+
+TEST_F(VideoGpuTest, DoubleInitIsIdempotent) {
+    SDL_Window* w = make_test_window();
+    if (!w) GTEST_SKIP() << "Cannot create window (headless)";
+    TRY_GPU_INIT(w, 768, 540);
+
+    // Second init with the same window should return true without recreating.
+    SDL_GPUDevice* first_device = g_gpu.device;
+    EXPECT_TRUE(video_gpu_init(w, 768, 540));
+    EXPECT_EQ(g_gpu.device, first_device) << "Double init must not recreate device";
+
+    video_gpu_shutdown();
+    SDL_DestroyWindow(w);
+}
+
+TEST_F(VideoGpuTest, ShutdownWithoutInitIsSafe) {
+    // Must not crash even when nothing was initialized.
+    EXPECT_NO_FATAL_FAILURE(video_gpu_shutdown());
+    EXPECT_FALSE(g_gpu.initialized);
+}
+
+TEST_F(VideoGpuTest, BlitPipelineIsNullUntilPhase3) {
+    SDL_Window* w = make_test_window();
+    if (!w) GTEST_SKIP() << "Cannot create window (headless)";
+    TRY_GPU_INIT(w, 768, 540);
+
+    // Phase 2 creates no pipelines — that's Phase 3's job.
+    EXPECT_EQ(g_gpu.blit_pipeline, nullptr);
+
+    video_gpu_shutdown();
+    SDL_DestroyWindow(w);
+}
+
+}  // namespace


### PR DESCRIPTION
## Summary

- New `src/video_gpu.{h,cpp}` — owns SDL3 GPU device lifecycle: device creation (Metal/Vulkan/D3D12), window claim, swapchain format query, linear + nearest samplers, CPC framebuffer texture (RGBA8 768×540), and 1.6 MB transfer buffer for CPU→GPU staging
- Integrated into `video_init()` / `video_shutdown()` in `kon_cpc_ja.cpp` — coexists alongside GL path, no plugin behaviour changed
- `blit_pipeline` field exists as nullptr — populated in Phase 3 when shader blobs are added
- 7 new tests in `test/video_gpu_test.cpp` — device lifecycle, sampler creation, transfer buffer map/unmap, idempotent init, safe double-shutdown

## Test plan

- [x] `VideoGpuTest.*` — 7 tests pass on M1 Metal (skip gracefully on headless CI)
- [x] Full suite: 1107 pass, 2 skip (pre-existing RAM expansion)
- [ ] CI: all platforms green (macOS Metal, Linux headless skip, MSVC WARP/skip)