### PR TITLE
feat(gpu): Phase 3 — passthrough blit shader + pipeline on Metal

### DIFF
--- a/scripts/compile_shaders.sh
+++ b/scripts/compile_shaders.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# konCePCja — shader compilation helper (developer tool, not run by CI).
+#
+# Produces backend-specific shader blobs from the sources in src/shaders/
+# and writes them into src/shaders/blit_shaders.h as C++ byte arrays.
+#
+# Required tools (install only the backends you need):
+#   glslangValidator — SPIRV (Vulkan).  `brew install glslang` on macOS.
+#   dxc or fxc       — DXBC (D3D12 on Windows).
+#   xcrun metal      — optional, only if you want to precompile metallib
+#                      instead of shipping MSL source.  `xcodebuild
+#                      -downloadComponent MetalToolchain` on macOS.
+#
+# Metal-only workflow: NOT needed.  We ship MSL source directly in the
+# header and Metal compiles it on the device.
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+SHADERS=src/shaders
+OUT=$SHADERS/blobs
+mkdir -p "$OUT"
+
+echo "==> SPIRV (Vulkan)"
+if command -v glslangValidator >/dev/null; then
+    glslangValidator -V "$SHADERS/blit.vert.glsl" -o "$OUT/blit.vert.spv"
+    glslangValidator -V "$SHADERS/blit.frag.glsl" -o "$OUT/blit.frag.spv"
+    echo "    ok: $OUT/blit.vert.spv, $OUT/blit.frag.spv"
+else
+    echo "    skip: glslangValidator not installed"
+fi
+
+echo "==> DXBC (D3D12)"
+if command -v dxc >/dev/null; then
+    dxc -T vs_5_0 -E main "$SHADERS/blit.vert.hlsl" -Fo "$OUT/blit.vert.dxbc"
+    dxc -T ps_5_0 -E main "$SHADERS/blit.frag.hlsl" -Fo "$OUT/blit.frag.dxbc"
+    echo "    ok: $OUT/blit.vert.dxbc, $OUT/blit.frag.dxbc"
+elif command -v fxc >/dev/null; then
+    fxc /T vs_5_0 /E main "$SHADERS/blit.vert.hlsl" /Fo "$OUT/blit.vert.dxbc"
+    fxc /T ps_5_0 /E main "$SHADERS/blit.frag.hlsl" /Fo "$OUT/blit.frag.dxbc"
+    echo "    ok: $OUT/blit.vert.dxbc, $OUT/blit.frag.dxbc"
+else
+    echo "    skip: neither dxc nor fxc installed"
+fi
+
+# Converting the blob files into the C array literals in blit_shaders.h
+# is a manual step — run xxd or a Python one-liner, then paste into the
+# header:
+#   xxd -i < blit.vert.spv  # produces `0xHH, 0xHH, ...` output
+echo
+echo "==> Next: update src/shaders/blit_shaders.h with the new blob bytes."
+echo "    Suggested: xxd -i < $OUT/blit.vert.spv"

--- a/src/shaders/blit.frag.glsl
+++ b/src/shaders/blit.frag.glsl
@@ -1,0 +1,20 @@
+// konCePCja — passthrough blit fragment shader (GLSL 450 master source)
+//
+// Compiled to SPIRV for the Vulkan backend via:
+//   glslangValidator -V blit.frag.glsl -o blit.frag.spv
+// See scripts/compile_shaders.sh.
+//
+// SDL_GPU binding convention for SPIRV fragment shaders:
+//   set 2 = combined image samplers (texture + sampler pair)
+// We use binding 0 in that set for our single CPC framebuffer texture.
+
+#version 450
+
+layout(location = 0) in vec2 v_uv;
+layout(location = 0) out vec4 out_color;
+
+layout(set = 2, binding = 0) uniform sampler2D u_tex;
+
+void main() {
+    out_color = texture(u_tex, v_uv);
+}

--- a/src/shaders/blit.frag.hlsl
+++ b/src/shaders/blit.frag.hlsl
@@ -1,0 +1,18 @@
+// konCePCja — passthrough blit fragment shader (HLSL 5.0 master source)
+//
+// Compiled to DXBC for the D3D12 backend via:
+//   dxc -T ps_5_0 -E main blit.frag.hlsl -Fo blit.frag.dxbc
+// or
+//   fxc /T ps_5_0 /E main blit.frag.hlsl /Fo blit.frag.dxbc
+// See scripts/compile_shaders.sh.
+//
+// SDL_GPU binding convention for DXBC fragment shaders:
+//   t-register space 2 = textures, s-register space 2 = samplers
+//   (vertex shader would use space 1)
+
+Texture2D    u_tex : register(t0, space2);
+SamplerState u_smp : register(s0, space2);
+
+float4 main(float4 pos : SV_Position, float2 uv : TEXCOORD0) : SV_Target {
+    return u_tex.Sample(u_smp, uv);
+}

--- a/src/shaders/blit.msl
+++ b/src/shaders/blit.msl
@@ -1,0 +1,37 @@
+// konCePCja — passthrough blit shader (Metal Shading Language source)
+//
+// Used by all direct/swscale family plugins in the SDL3 GPU render path.
+// Samples the CPC framebuffer texture and writes it to the swapchain.
+//
+// Fullscreen-triangle trick: the vertex shader generates positions from
+// the vertex ID alone, so no vertex buffer is needed.  The fragment shader
+// samples at the UV passed through from the vertex stage.
+//
+// SDL_GPU consumes this as raw MSL source (SDL_GPU_SHADERFORMAT_MSL) —
+// Metal compiles it on-device at SDL_CreateGPUShader() time.  No offline
+// compilation or metallib generation required.
+
+#include <metal_stdlib>
+using namespace metal;
+
+struct VSOut {
+    float4 position [[position]];
+    float2 uv;
+};
+
+vertex VSOut vert_main(uint vid [[vertex_id]]) {
+    VSOut o;
+    // vid=0 → xy=(0,0) → clip (-1,-1) uv (0,1)
+    // vid=1 → xy=(2,0) → clip ( 3,-1) uv (2,1)
+    // vid=2 → xy=(0,2) → clip (-1, 3) uv (0,-1)
+    float2 xy = float2(float((vid << 1) & 2), float(vid & 2));
+    o.position = float4(xy * 2.0 - 1.0, 0.0, 1.0);
+    o.uv = float2(xy.x, 1.0 - xy.y);  // flip Y: SDL_GPU uses top-left origin
+    return o;
+}
+
+fragment float4 frag_main(VSOut in [[stage_in]],
+                          texture2d<float> tex [[texture(0)]],
+                          sampler smp [[sampler(0)]]) {
+    return tex.sample(smp, in.uv);
+}

--- a/src/shaders/blit.vert.glsl
+++ b/src/shaders/blit.vert.glsl
@@ -1,0 +1,17 @@
+// konCePCja — passthrough blit vertex shader (GLSL 450 master source)
+//
+// Compiled to SPIRV for the Vulkan backend via:
+//   glslangValidator -V blit.vert.glsl -o blit.vert.spv
+// See scripts/compile_shaders.sh.
+
+#version 450
+
+layout(location = 0) out vec2 v_uv;
+
+void main() {
+    // Fullscreen-triangle trick: generate position from gl_VertexIndex.
+    // vid=0 → xy=(0,0); vid=1 → xy=(2,0); vid=2 → xy=(0,2)
+    vec2 xy = vec2(float((gl_VertexIndex << 1) & 2), float(gl_VertexIndex & 2));
+    gl_Position = vec4(xy * 2.0 - 1.0, 0.0, 1.0);
+    v_uv = vec2(xy.x, 1.0 - xy.y);  // flip Y: SDL_GPU uses top-left origin
+}

--- a/src/shaders/blit.vert.hlsl
+++ b/src/shaders/blit.vert.hlsl
@@ -1,0 +1,21 @@
+// konCePCja — passthrough blit vertex shader (HLSL 5.0 master source)
+//
+// Compiled to DXBC for the D3D12 backend via:
+//   dxc -T vs_5_0 -E main blit.vert.hlsl -Fo blit.vert.dxbc
+// or
+//   fxc /T vs_5_0 /E main blit.vert.hlsl /Fo blit.vert.dxbc
+// See scripts/compile_shaders.sh.
+
+struct VSOut {
+    float4 pos : SV_Position;
+    float2 uv  : TEXCOORD0;
+};
+
+VSOut main(uint vid : SV_VertexID) {
+    VSOut o;
+    // Fullscreen-triangle trick — see blit.vert.glsl for derivation
+    float2 xy = float2(float((vid << 1) & 2), float(vid & 2));
+    o.pos = float4(xy * 2.0 - 1.0, 0.0, 1.0);
+    o.uv  = float2(xy.x, 1.0 - xy.y);  // flip Y: SDL_GPU top-left origin
+    return o;
+}

--- a/src/shaders/blit_shaders.h
+++ b/src/shaders/blit_shaders.h
@@ -1,0 +1,55 @@
+// konCePCja — embedded shader blobs for the passthrough blit pipeline.
+//
+// Generated (MSL) by hand from src/shaders/blit.msl and the GLSL/HLSL
+// files checked in alongside.  See scripts/compile_shaders.sh for the
+// SPIRV and DXBC compilation steps — those blobs are currently empty
+// placeholders and will be populated in a follow-up PR.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+// ── Metal (macOS): raw MSL source ─────────────────────────────────────
+// SDL_GPU accepts MSL source text directly (SDL_GPU_SHADERFORMAT_MSL).
+// Metal compiles on-device at SDL_CreateGPUShader() time.
+// Both vert_main and frag_main live in this single source string.
+inline constexpr const char* kBlitMSLSource = R"MSL(
+#include <metal_stdlib>
+using namespace metal;
+
+struct VSOut {
+    float4 position [[position]];
+    float2 uv;
+};
+
+vertex VSOut vert_main(uint vid [[vertex_id]]) {
+    VSOut o;
+    float2 xy = float2(float((vid << 1) & 2), float(vid & 2));
+    o.position = float4(xy * 2.0 - 1.0, 0.0, 1.0);
+    o.uv = float2(xy.x, 1.0 - xy.y);
+    return o;
+}
+
+fragment float4 frag_main(VSOut in [[stage_in]],
+                          texture2d<float> tex [[texture(0)]],
+                          sampler smp [[sampler(0)]]) {
+    return tex.sample(smp, in.uv);
+}
+)MSL";
+
+// ── Vulkan: SPIRV bytecode ────────────────────────────────────────────
+// Populated by a follow-up PR after running scripts/compile_shaders.sh
+// on a machine with glslangValidator (or via a CI job).  Empty for now.
+inline constexpr std::uint8_t kBlitVertexSPIRV[] = {0};
+inline constexpr std::uint8_t kBlitFragmentSPIRV[] = {0};
+inline constexpr std::size_t kBlitVertexSPIRVSize = 0;
+inline constexpr std::size_t kBlitFragmentSPIRVSize = 0;
+
+// ── D3D12: DXBC bytecode ──────────────────────────────────────────────
+// Populated by a follow-up PR after running scripts/compile_shaders.sh
+// on a Windows runner with fxc or dxc.  Empty for now.
+inline constexpr std::uint8_t kBlitVertexDXBC[] = {0};
+inline constexpr std::uint8_t kBlitFragmentDXBC[] = {0};
+inline constexpr std::size_t kBlitVertexDXBCSize = 0;
+inline constexpr std::size_t kBlitFragmentDXBCSize = 0;

--- a/src/video_gpu.cpp
+++ b/src/video_gpu.cpp
@@ -82,6 +82,16 @@ bool create_blit_shaders(const char* driver) {
     g_gpu.blit_fragment_shader = SDL_CreateGPUShader(g_gpu.device, &fsi);
     if (!g_gpu.blit_vertex_shader || !g_gpu.blit_fragment_shader) {
         LOG_ERROR("SDL_CreateGPUShader failed: " << SDL_GetError());
+        // Release whichever shader did succeed so g_gpu stays in a
+        // consistent "no blit shaders" state (both null).
+        if (g_gpu.blit_vertex_shader) {
+            SDL_ReleaseGPUShader(g_gpu.device, g_gpu.blit_vertex_shader);
+            g_gpu.blit_vertex_shader = nullptr;
+        }
+        if (g_gpu.blit_fragment_shader) {
+            SDL_ReleaseGPUShader(g_gpu.device, g_gpu.blit_fragment_shader);
+            g_gpu.blit_fragment_shader = nullptr;
+        }
         return false;
     }
     return true;

--- a/src/video_gpu.cpp
+++ b/src/video_gpu.cpp
@@ -7,11 +7,117 @@
 
 #include "video_gpu.h"
 #include "log.h"
+#include "shaders/blit_shaders.h"
 
 #include <SDL3/SDL.h>
 #include <cstring>
 
 GpuState g_gpu;
+
+namespace {
+
+// Create the blit vertex + fragment shaders for the active backend.
+// On Metal: pass MSL source directly (SDL compiles on device).
+// On Vulkan/D3D12: pass pre-compiled SPIRV/DXBC blobs — but these are
+// currently empty placeholders, so shader creation is skipped and the
+// blit pipeline stays nullptr on those backends.
+// Returns true if both shaders were created; false if the backend has
+// no blob yet (non-fatal — plugins will fall back to the GL path until
+// blobs are populated in a follow-up).
+bool create_blit_shaders(const char* driver) {
+    SDL_GPUShaderCreateInfo vsi{};
+    vsi.stage               = SDL_GPU_SHADERSTAGE_VERTEX;
+    vsi.num_samplers        = 0;
+    vsi.num_uniform_buffers = 0;
+    vsi.num_storage_buffers = 0;
+    vsi.num_storage_textures = 0;
+
+    SDL_GPUShaderCreateInfo fsi{};
+    fsi.stage               = SDL_GPU_SHADERSTAGE_FRAGMENT;
+    fsi.num_samplers        = 1;   // single CPC framebuffer texture
+    fsi.num_uniform_buffers = 0;
+    fsi.num_storage_buffers = 0;
+    fsi.num_storage_textures = 0;
+
+    if (driver && std::strcmp(driver, "metal") == 0) {
+        vsi.format     = SDL_GPU_SHADERFORMAT_MSL;
+        vsi.code       = reinterpret_cast<const Uint8*>(kBlitMSLSource);
+        vsi.code_size  = std::strlen(kBlitMSLSource);
+        vsi.entrypoint = "vert_main";
+
+        fsi.format     = SDL_GPU_SHADERFORMAT_MSL;
+        fsi.code       = reinterpret_cast<const Uint8*>(kBlitMSLSource);
+        fsi.code_size  = std::strlen(kBlitMSLSource);
+        fsi.entrypoint = "frag_main";
+    } else if (driver && std::strcmp(driver, "vulkan") == 0
+               && kBlitVertexSPIRVSize > 0 && kBlitFragmentSPIRVSize > 0) {
+        vsi.format     = SDL_GPU_SHADERFORMAT_SPIRV;
+        vsi.code       = kBlitVertexSPIRV;
+        vsi.code_size  = kBlitVertexSPIRVSize;
+        vsi.entrypoint = "main";
+
+        fsi.format     = SDL_GPU_SHADERFORMAT_SPIRV;
+        fsi.code       = kBlitFragmentSPIRV;
+        fsi.code_size  = kBlitFragmentSPIRVSize;
+        fsi.entrypoint = "main";
+    } else if (driver && std::strcmp(driver, "direct3d12") == 0
+               && kBlitVertexDXBCSize > 0 && kBlitFragmentDXBCSize > 0) {
+        vsi.format     = SDL_GPU_SHADERFORMAT_DXBC;
+        vsi.code       = kBlitVertexDXBC;
+        vsi.code_size  = kBlitVertexDXBCSize;
+        vsi.entrypoint = "main";
+
+        fsi.format     = SDL_GPU_SHADERFORMAT_DXBC;
+        fsi.code       = kBlitFragmentDXBC;
+        fsi.code_size  = kBlitFragmentDXBCSize;
+        fsi.entrypoint = "main";
+    } else {
+        LOG_INFO("No blit shader blob available for driver '"
+                 << (driver ? driver : "(null)")
+                 << "' — blit pipeline will be skipped");
+        return false;
+    }
+
+    g_gpu.blit_vertex_shader   = SDL_CreateGPUShader(g_gpu.device, &vsi);
+    g_gpu.blit_fragment_shader = SDL_CreateGPUShader(g_gpu.device, &fsi);
+    if (!g_gpu.blit_vertex_shader || !g_gpu.blit_fragment_shader) {
+        LOG_ERROR("SDL_CreateGPUShader failed: " << SDL_GetError());
+        return false;
+    }
+    return true;
+}
+
+// Create the passthrough blit graphics pipeline.  Requires shaders to
+// already exist in g_gpu.  Renders a fullscreen triangle with no vertex
+// buffer; one color target matching the swapchain format.
+bool create_blit_pipeline() {
+    if (!g_gpu.blit_vertex_shader || !g_gpu.blit_fragment_shader) return false;
+
+    SDL_GPUColorTargetDescription color_target{};
+    color_target.format = g_gpu.swapchain_fmt;
+    // No blending — passthrough writes the CPC framebuffer's pixels directly.
+
+    SDL_GPUGraphicsPipelineTargetInfo target_info{};
+    target_info.num_color_targets         = 1;
+    target_info.color_target_descriptions = &color_target;
+    target_info.has_depth_stencil_target  = false;
+
+    SDL_GPUGraphicsPipelineCreateInfo info{};
+    info.vertex_shader   = g_gpu.blit_vertex_shader;
+    info.fragment_shader = g_gpu.blit_fragment_shader;
+    info.primitive_type  = SDL_GPU_PRIMITIVETYPE_TRIANGLELIST;
+    info.target_info     = target_info;
+    // vertex_input_state left zero — no VB, fullscreen triangle from vertex ID
+
+    g_gpu.blit_pipeline = SDL_CreateGPUGraphicsPipeline(g_gpu.device, &info);
+    if (!g_gpu.blit_pipeline) {
+        LOG_ERROR("SDL_CreateGPUGraphicsPipeline failed: " << SDL_GetError());
+        return false;
+    }
+    return true;
+}
+
+}  // namespace
 
 bool video_gpu_init(SDL_Window* window, uint32_t fb_w, uint32_t fb_h)
 {
@@ -107,6 +213,16 @@ bool video_gpu_init(SDL_Window* window, uint32_t fb_w, uint32_t fb_h)
         return false;
     }
 
+    // ── 7. Blit shaders + pipeline ────────────────────────────────────
+    // Non-fatal if the backend has no blob yet — plugins will fall back
+    // to the GL path on those platforms.  On Metal (the dev target), a
+    // failure here is a shader source bug and should be treated as one.
+    if (create_blit_shaders(driver)) {
+        if (!create_blit_pipeline()) {
+            LOG_ERROR("Blit pipeline creation failed — continuing without it");
+        }
+    }
+
     g_gpu.initialized = true;
     LOG_INFO("GPU scaffolding initialized ("
              << fb_w << "×" << fb_h << ", "
@@ -127,6 +243,12 @@ void video_gpu_shutdown()
         }
         if (g_gpu.blit_pipeline) {
             SDL_ReleaseGPUGraphicsPipeline(g_gpu.device, g_gpu.blit_pipeline);
+        }
+        if (g_gpu.blit_fragment_shader) {
+            SDL_ReleaseGPUShader(g_gpu.device, g_gpu.blit_fragment_shader);
+        }
+        if (g_gpu.blit_vertex_shader) {
+            SDL_ReleaseGPUShader(g_gpu.device, g_gpu.blit_vertex_shader);
         }
         if (g_gpu.nearest_sampler) {
             SDL_ReleaseGPUSampler(g_gpu.device, g_gpu.nearest_sampler);

--- a/src/video_gpu.h
+++ b/src/video_gpu.h
@@ -28,8 +28,13 @@ struct GpuState {
     uint32_t                 cpc_tex_w       = 0;
     uint32_t                 cpc_tex_h       = 0;
 
-    // Pipelines (nullptr until Phase 3 provides shader blobs)
-    SDL_GPUGraphicsPipeline* blit_pipeline   = nullptr;
+    // Passthrough blit shaders + pipeline.  Created in video_gpu_init()
+    // when the backend has a shader format we ship blobs for (Metal: MSL
+    // source; Vulkan/D3D12: populated in a follow-up after SPIRV/DXBC
+    // blob compilation).  Null on backends without blobs yet.
+    SDL_GPUShader*           blit_vertex_shader   = nullptr;
+    SDL_GPUShader*           blit_fragment_shader = nullptr;
+    SDL_GPUGraphicsPipeline* blit_pipeline        = nullptr;
 
     // Per-frame command buffer (stashed by flip_a, submitted by flip_b).
     // Not used until Phase 4 wires plugins to the GPU path.

--- a/test/video_gpu_test.cpp
+++ b/test/video_gpu_test.cpp
@@ -140,13 +140,39 @@ TEST_F(VideoGpuTest, ShutdownWithoutInitIsSafe) {
     EXPECT_FALSE(g_gpu.initialized);
 }
 
-TEST_F(VideoGpuTest, BlitPipelineIsNullUntilPhase3) {
+// Only Metal currently has a shader blob shipped (MSL source).  Vulkan
+// and D3D12 blob arrays stay empty until a follow-up populates them, so
+// the pipeline is expected to be null on those backends.
+static bool backend_has_blit_blob() {
+    if (!g_gpu.device) return false;
+    const char* drv = SDL_GetGPUDeviceDriver(g_gpu.device);
+    return drv && std::strcmp(drv, "metal") == 0;
+}
+
+TEST_F(VideoGpuTest, BlitShadersCreated) {
     SDL_Window* w = make_test_window();
     if (!w) GTEST_SKIP() << "Cannot create window (headless)";
     TRY_GPU_INIT(w, 768, 540);
 
-    // Phase 2 creates no pipelines — that's Phase 3's job.
-    EXPECT_EQ(g_gpu.blit_pipeline, nullptr);
+    if (!backend_has_blit_blob()) {
+        GTEST_SKIP() << "Backend has no blit shader blob yet";
+    }
+    EXPECT_NE(g_gpu.blit_vertex_shader,   nullptr);
+    EXPECT_NE(g_gpu.blit_fragment_shader, nullptr);
+
+    video_gpu_shutdown();
+    SDL_DestroyWindow(w);
+}
+
+TEST_F(VideoGpuTest, BlitPipelineCreated) {
+    SDL_Window* w = make_test_window();
+    if (!w) GTEST_SKIP() << "Cannot create window (headless)";
+    TRY_GPU_INIT(w, 768, 540);
+
+    if (!backend_has_blit_blob()) {
+        GTEST_SKIP() << "Backend has no blit shader blob yet";
+    }
+    EXPECT_NE(g_gpu.blit_pipeline, nullptr);
 
     video_gpu_shutdown();
     SDL_DestroyWindow(w);


### PR DESCRIPTION
## Summary

Phase 3 of the SDL3 GPU migration (P1.2b). Ships the passthrough blit shader and graphics pipeline, working on Metal today; Vulkan/D3D12 blob arrays stay as empty placeholders until a follow-up populates them.

## What's in

- `src/shaders/blit.msl` — MSL source used at runtime (SDL compiles it on-device, no toolchain required)
- `src/shaders/blit.vert/frag.{glsl,hlsl}` — GLSL 450 and HLSL 5.0 master sources for future SPIRV/DXBC compilation
- `src/shaders/blit_shaders.h` — embedded MSL string + empty SPIRV/DXBC placeholder arrays
- `scripts/compile_shaders.sh` — developer helper documenting the compilation commands
- `video_gpu.cpp`:
  - `create_blit_shaders(driver)` picks format by backend string (`metal`/`vulkan`/`direct3d12`)
  - `create_blit_pipeline()` builds the full SDL_GPU graphics pipeline: fullscreen triangle, no vertex buffer, swapchain format color target
  - Both called from `video_gpu_init()`; shader creation failure is non-fatal (GL path still works)
  - `video_gpu_shutdown()` releases both shader objects
- `GpuState` gains `blit_vertex_shader` and `blit_fragment_shader` fields
- Tests: replaced `BlitPipelineIsNullUntilPhase3` with `BlitShadersCreated` and `BlitPipelineCreated`, both gate on `SDL_GetGPUDeviceDriver() == "metal"` until blobs exist for the other backends

## Fullscreen-triangle trick

Vertex shader generates position + UV from `vertex_id` alone — no vertex buffer, no attributes. Covers the whole screen with a single triangle (better GPU cache coherence than a two-triangle quad). Y-flip is done in the vertex shader's UV output to match SDL_GPU's top-left origin.

## Test plan

- [x] `VideoGpuTest.*` — 8 tests pass on M1 Metal (7 existing + 2 new, 1 removed)
- [x] Full suite: 1108 pass, 2 skip (pre-existing RAM expansion)
- [x] No rendering changes — plugins still use GL path; pipeline sits ready for Phase 4 wiring
- [ ] CI: macOS green (pipeline creates); Linux/MSVC Win32/x64 skip GPU tests (no backend); MSVC ARM64 may skip pipeline test ("no DXBC blob")

## Next

Phase 3b: populate SPIRV + DXBC blob arrays via a one-time compile (needs glslangValidator + dxc/fxc). Then Phase 4 wires the `direct` plugin family through the GPU path.