### PR TITLE
fix(ci): stop flaky M4 HTTP tests on Windows (ephemeral bind)

### DIFF
--- a/src/m4board_http.cpp
+++ b/src/m4board_http.cpp
@@ -1285,21 +1285,39 @@ void M4HttpServer::run() {
    inet_pton(AF_INET, bind_ip_.c_str(), &addr.sin_addr);
 
    int bound_port = 0;
-   for (int p = configured_port_; p < configured_port_ + 10; p++) {
-      addr.sin_port = htons(static_cast<uint16_t>(p));
+   if (configured_port_ <= 0) {
+      addr.sin_port = 0;
       if (bind(server_fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != SOCKET_ERROR) {
-         bound_port = p;
-         break;
+         sockaddr_in sin{};
+         int sinlen = sizeof(sin);
+         if (getsockname(server_fd, reinterpret_cast<sockaddr*>(&sin), &sinlen) != SOCKET_ERROR)
+            bound_port = static_cast<int>(ntohs(sin.sin_port));
       }
-   }
-   if (bound_port == 0) {
-      LOG_ERROR("M4 HTTP: could not bind to ports " << configured_port_
-                << "-" << (configured_port_ + 9));
-      closesocket(server_fd);
-      WSACleanup();
-      running.store(false);
-      actual_port.store(0);
-      return;
+      if (bound_port == 0) {
+         LOG_ERROR("M4 HTTP: could not bind to an ephemeral port (port<=0)");
+         closesocket(server_fd);
+         WSACleanup();
+         running.store(false);
+         actual_port.store(0);
+         return;
+      }
+   } else {
+      for (int p = configured_port_; p < configured_port_ + 10; p++) {
+         addr.sin_port = htons(static_cast<uint16_t>(p));
+         if (bind(server_fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != SOCKET_ERROR) {
+            bound_port = p;
+            break;
+         }
+      }
+      if (bound_port == 0) {
+         LOG_ERROR("M4 HTTP: could not bind to ports " << configured_port_
+                   << "-" << (configured_port_ + 9));
+         closesocket(server_fd);
+         WSACleanup();
+         running.store(false);
+         actual_port.store(0);
+         return;
+      }
    }
 
    if (listen(server_fd, 4) == SOCKET_ERROR) {
@@ -1476,20 +1494,37 @@ void M4HttpServer::run() {
    inet_pton(AF_INET, bind_ip_.c_str(), &addr.sin_addr);
 
    int bound_port = 0;
-   for (int p = configured_port_; p < configured_port_ + 10; p++) {
-      addr.sin_port = htons(static_cast<uint16_t>(p));
+   if (configured_port_ <= 0) {
+      addr.sin_port = 0;
       if (bind(server_fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) == 0) {
-         bound_port = p;
-         break;
+         sockaddr_in sin{};
+         socklen_t sinlen = sizeof(sin);
+         if (getsockname(server_fd, reinterpret_cast<sockaddr*>(&sin), &sinlen) == 0)
+            bound_port = static_cast<int>(ntohs(sin.sin_port));
       }
-   }
-   if (bound_port == 0) {
-      LOG_ERROR("M4 HTTP: could not bind to ports " << configured_port_
-                << "-" << (configured_port_ + 9));
-      ::close(server_fd);
-      running.store(false);
-      actual_port.store(0);
-      return;
+      if (bound_port == 0) {
+         LOG_ERROR("M4 HTTP: could not bind to an ephemeral port (port<=0)");
+         ::close(server_fd);
+         running.store(false);
+         actual_port.store(0);
+         return;
+      }
+   } else {
+      for (int p = configured_port_; p < configured_port_ + 10; p++) {
+         addr.sin_port = htons(static_cast<uint16_t>(p));
+         if (bind(server_fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) == 0) {
+            bound_port = p;
+            break;
+         }
+      }
+      if (bound_port == 0) {
+         LOG_ERROR("M4 HTTP: could not bind to ports " << configured_port_
+                   << "-" << (configured_port_ + 9));
+         ::close(server_fd);
+         running.store(false);
+         actual_port.store(0);
+         return;
+      }
    }
 
    if (listen(server_fd, 4) < 0) {

--- a/src/m4board_http.h
+++ b/src/m4board_http.h
@@ -32,6 +32,7 @@ class M4HttpServer {
 public:
    ~M4HttpServer();
 
+   // port <= 0: bind an ephemeral TCP port; use port() after the server thread starts.
    void start(int port = 8080, const std::string& bind_ip = "127.0.0.1");
    void stop();
 

--- a/test/m4board_http_test.cpp
+++ b/test/m4board_http_test.cpp
@@ -4,7 +4,7 @@
 #include <cstring>
 #include <thread>
 #include <chrono>
-#include <random>
+#include <stdexcept>
 #include "m4board.h"
 #include "m4board_http.h"
 
@@ -139,6 +139,7 @@ static int extract_status(const std::string& response) {
 // ── Shared server environment ──
 // One server for the entire test suite — avoids 25+ start/stop cycles
 // with TIME_WAIT port exhaustion on slow CI runners (Win32).
+// Port 0 = OS-assigned ephemeral (avoids collisions with parallel jobs on CI).
 
 static std::filesystem::path g_test_sd_dir;
 static int g_test_port = 0;
@@ -160,13 +161,16 @@ public:
       g_m4board.sd_root_path = g_test_sd_dir.string();
       g_m4board.current_dir = "/";
 
-      static std::mt19937 rng(std::random_device{}());
-      int base = 30000 + static_cast<int>(rng() % 20000);
-      g_m4_http.start(base, "127.0.0.1");
-      for (int i = 0; i < 200 && g_m4_http.port() == 0; i++) {
+      g_m4_http.start(0, "127.0.0.1");
+      for (int i = 0; i < 300 && g_m4_http.port() == 0; i++) {
          std::this_thread::sleep_for(std::chrono::milliseconds(20));
       }
       g_test_port = g_m4_http.port();
+      if (g_test_port <= 0) {
+         g_m4_http.stop();
+         throw std::runtime_error(
+            "M4 HTTP test server never published a port (bind/listen failed?)");
+      }
    }
 
    void TearDown() override {
@@ -467,9 +471,7 @@ TEST(M4HttpUrlDecode, BasicDecoding) {
    g_m4board.current_dir = "/";
 
    M4HttpServer server;
-   static std::mt19937 rng(std::random_device{}());
-   int base = 30000 + static_cast<int>(rng() % 20000);
-   server.start(base, "127.0.0.1");
+   server.start(0, "127.0.0.1");
    for (int i = 0; i < 100 && server.port() == 0; i++) {
       std::this_thread::sleep_for(std::chrono::milliseconds(20));
    }
@@ -496,7 +498,7 @@ TEST(M4HttpServerTest, StopWithoutStart) {
 
 TEST(M4HttpServerTest, DoubleStart) {
    M4HttpServer server;
-   server.start(19080);
+   server.start(0);
    for (int i = 0; i < 100 && server.port() == 0; i++) {
       std::this_thread::sleep_for(std::chrono::milliseconds(20));
    }


### PR DESCRIPTION
Windows MSVC jobs were intermittently failing on `m4board_http_test` when the suite picked a random port in 30000–49999 and only probed 10 consecutive ports—busy GitHub runners can leave that entire window busy.

**Changes**
- `M4HttpServer`: `port <= 0` binds with `sin_port = 0` and uses `getsockname()` so the OS assigns a free port (same pattern for Win32 and POSIX).
- Tests call `start(0)` instead of a random base; fail fast with a clear error if the server never publishes a port; slightly longer wait for slow CI.
- `DoubleStart` uses ephemeral bind for the first `start()` instead of a fixed `19080` block.

Also fixes a latent bug where `configured_port_ == 0` could succeed at `bind()` but then be treated as failure because `bound_port` stayed 0.

Made with [Cursor](https://cursor.com)