### PR TITLE
scr_style remap for Phase 7b-shifted indices + IPC quit race fix

### DIFF
--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -2312,29 +2312,27 @@ void loadConfiguration (t_CPC &CPC, const std::string& configFilename)
    CPC.scr_preserve_aspect_ratio = conf.getIntValue("video", "scr_preserve_aspect_ratio", 1);
    CPC.scr_crt_aspect = conf.getIntValue("video", "scr_crt_aspect", 1);
    CPC.scr_style = conf.getIntValue("video", "scr_style", 1);
-   // Phase 7b scr_style remap — the legacy GL CRT plugins (Basic / Full /
-   // Lottes) used to live at indices 11-13 and were removed in PR #107.
-   // A config saved before the deletion still references those indices
-   // (which now silently point at Direct (SDL) / Super eagle (SDL) /
-   // Scale2x (SDL) — wrong plugins).  Configs from the Phase 6b/c/d
-   // window also had the GPU CRT plugins at 28-30, which are now at
-   // 25-27 after the shift (and 28 falls out of range).
+   // Phase 7b scr_style remap — the old CRT GPU plugins used to sit at
+   // indices 28/29/30 (past the pre-deletion position of the legacy GL
+   // CRT plugins at 11-13).  After Phase 7b the vector is 28 entries
+   // long, so 28-30 are now strictly out-of-range and the only reason
+   // a config references them is that it was saved pre-Phase-7b.
    //
-   // Remap those six indices to the equivalent GPU CRT plugin.  For
-   // other indices in the ambiguous 14-27 range we leave the value
-   // alone — without a config-version field we cannot tell whether the
-   // user meant the old or new position, and new configs must be
-   // respected.  Users who hit that case can reselect via the UI.
+   // Remap those three indices to the new CRT GPU positions (25/26/27).
+   // We intentionally do NOT remap 11/12/13: those are legal indices in
+   // the post-7b table (Direct (SDL) / Super eagle (SDL) / Scale2x (SDL))
+   // and a user may have selected them deliberately via the UI — without
+   // a config-version field we cannot tell old from new there.  Same
+   // reasoning for 14-27.  Users with an old config pointing at a
+   // now-deleted legacy GL CRT plugin will fall back to whatever sits at
+   // those indices today; a one-time manual reselect is accepted.
    {
       unsigned int s = CPC.scr_style;
       unsigned int remapped = s;
-      if      (s == 11) remapped = 25;  // old CRT Basic (GL)  -> CRT Basic (GPU)
-      else if (s == 12) remapped = 26;  // old CRT Full  (GL)  -> CRT Full  (GPU)
-      else if (s == 13) remapped = 27;  // old CRT Lottes(GL)  -> CRT Lottes(GPU)
-      else if (s == 28) remapped = 25;  // old CRT Basic (GPU) -> CRT Basic (GPU)
+      if      (s == 28) remapped = 25;  // old CRT Basic (GPU) -> CRT Basic (GPU)
       else if (s == 29) remapped = 26;  // old CRT Full  (GPU) -> CRT Full  (GPU)
       else if (s == 30) remapped = 27;  // old CRT Lottes(GPU) -> CRT Lottes(GPU)
-      if (remapped != s) {
+      if (remapped != s && remapped < video_plugin_list.size()) {
          LOG_INFO("scr_style=" << s << " is obsolete after Phase 7b — "
                   "remapped to " << remapped << " ("
                   << video_plugin_list[remapped].name << ")");
@@ -3004,29 +3002,34 @@ void doCleanUp ()
 
 void cleanExit(int returnCode, bool askIfUnsaved)
 {
-   if (!g_headless && askIfUnsaved && driveAltered() && !userConfirmsQuitWithoutSaving()) {
-     return;
-   }
-
    // Only the main (render) thread is allowed to run SDL_Quit(): it's the
-   // thread that owns the video subsystem and that lives inside
-   // SDL_PumpEvents().  Any other thread calling doCleanUp() directly races
-   // with the pump loop and can segfault at PC=0 when SDL nulls the video
-   // driver's PumpEvents function pointer out from under it.  So:
+   // thread that owns the video subsystem and lives inside SDL_PumpEvents().
+   // Any other thread calling doCleanUp() directly races with the pump loop
+   // and can segfault at PC=0 when SDL nulls the video driver's PumpEvents
+   // function pointer out from under it.  Macos UI ops (the confirm-quit
+   // dialog below) are also main-thread-only.  So we check the thread FIRST,
+   // before any UI, and route off-main callers through SDL_EVENT_QUIT:
    //
    //   - Z80 thread  → push SDL_EVENT_QUIT; loop exits via g_z80_thread_quit
-   //   - IPC / HTTP / telnet / any other aux thread  → same pattern
-   //   - Main thread → safe to call doCleanUp() + _exit() directly
+   //   - IPC / HTTP / telnet / any other aux thread  → push SDL_EVENT_QUIT
+   //   - Main thread → safe to run the confirm dialog + doCleanUp() + _exit()
    //
    // The render thread's SDL_EVENT_QUIT handler calls cleanExit() recursively,
    // at which point we land in the main-thread branch and do the real
-   // teardown.  The requested exit code rides along in the same atomic the
-   // Z80 self-quit path already uses.
+   // teardown (including the confirm dialog if askIfUnsaved was set — the
+   // returnCode carries through via g_z80_requested_exit_code).
+   //
+   // `is_not_main` is framed defensively: if g_main_thread_id hasn't been
+   // captured yet (early-init path), we *assume* we're on main.  That
+   // preserves the pre-fix behaviour during startup and keeps us from
+   // infinitely pushing SDL_EVENT_QUIT to ourselves before the main loop
+   // has a chance to spin.
    const auto tid          = std::this_thread::get_id();
    const bool is_z80_self  = g_z80_thread.joinable() && tid == g_z80_thread.get_id();
-   const bool is_main      = (g_main_thread_id != std::thread::id{}) && (tid == g_main_thread_id);
+   const bool is_not_main  = (g_main_thread_id != std::thread::id{})
+                             && (tid != g_main_thread_id);
 
-   if (is_z80_self || !is_main) {
+   if (is_z80_self || is_not_main) {
       g_z80_requested_exit_code.store(returnCode, std::memory_order_relaxed);
       if (is_z80_self) {
          // Z80 self-quit also has to break its own loop.  Aux threads don't
@@ -3039,6 +3042,10 @@ void cleanExit(int returnCode, bool askIfUnsaved)
       return;
    }
 
+   // Main thread (or early-init pre-capture): safe to prompt and tear down.
+   if (!g_headless && askIfUnsaved && driveAltered() && !userConfirmsQuitWithoutSaving()) {
+     return;
+   }
    doCleanUp();
    _exit(returnCode);
 }

--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -166,6 +166,11 @@ std::atomic<bool> g_emu_paused{false};
 static std::atomic<bool> g_z80_thread_quit{false};
 // Exit code to use when the Z80 thread requests quit via SDL_EVENT_QUIT.
 static std::atomic<int> g_z80_requested_exit_code{0};
+// Captured at the top of koncpc_main() so cleanExit() can tell whether it's
+// running on the main (render) thread vs. an auxiliary thread (IPC / HTTP /
+// telnet).  Only the main thread owns SDL teardown; anything else must push
+// SDL_EVENT_QUIT and let the main loop handle the teardown.
+static std::thread::id g_main_thread_id{};
 // Handle for the Z80 emulation thread (non-headless mode only). Stored so
 // doCleanUp() can join it instead of letting it run past global destruction.
 static std::thread g_z80_thread;
@@ -2307,6 +2312,35 @@ void loadConfiguration (t_CPC &CPC, const std::string& configFilename)
    CPC.scr_preserve_aspect_ratio = conf.getIntValue("video", "scr_preserve_aspect_ratio", 1);
    CPC.scr_crt_aspect = conf.getIntValue("video", "scr_crt_aspect", 1);
    CPC.scr_style = conf.getIntValue("video", "scr_style", 1);
+   // Phase 7b scr_style remap — the legacy GL CRT plugins (Basic / Full /
+   // Lottes) used to live at indices 11-13 and were removed in PR #107.
+   // A config saved before the deletion still references those indices
+   // (which now silently point at Direct (SDL) / Super eagle (SDL) /
+   // Scale2x (SDL) — wrong plugins).  Configs from the Phase 6b/c/d
+   // window also had the GPU CRT plugins at 28-30, which are now at
+   // 25-27 after the shift (and 28 falls out of range).
+   //
+   // Remap those six indices to the equivalent GPU CRT plugin.  For
+   // other indices in the ambiguous 14-27 range we leave the value
+   // alone — without a config-version field we cannot tell whether the
+   // user meant the old or new position, and new configs must be
+   // respected.  Users who hit that case can reselect via the UI.
+   {
+      unsigned int s = CPC.scr_style;
+      unsigned int remapped = s;
+      if      (s == 11) remapped = 25;  // old CRT Basic (GL)  -> CRT Basic (GPU)
+      else if (s == 12) remapped = 26;  // old CRT Full  (GL)  -> CRT Full  (GPU)
+      else if (s == 13) remapped = 27;  // old CRT Lottes(GL)  -> CRT Lottes(GPU)
+      else if (s == 28) remapped = 25;  // old CRT Basic (GPU) -> CRT Basic (GPU)
+      else if (s == 29) remapped = 26;  // old CRT Full  (GPU) -> CRT Full  (GPU)
+      else if (s == 30) remapped = 27;  // old CRT Lottes(GPU) -> CRT Lottes(GPU)
+      if (remapped != s) {
+         LOG_INFO("scr_style=" << s << " is obsolete after Phase 7b — "
+                  "remapped to " << remapped << " ("
+                  << video_plugin_list[remapped].name << ")");
+         CPC.scr_style = remapped;
+      }
+   }
    if (CPC.scr_style >= video_plugin_list.size()) {
       CPC.scr_style = DEFAULT_VIDEO_PLUGIN;
       LOG_ERROR("Unsupported video plugin specified - defaulting to plugin " << video_plugin_list[DEFAULT_VIDEO_PLUGIN].name);
@@ -2974,18 +3008,35 @@ void cleanExit(int returnCode, bool askIfUnsaved)
      return;
    }
 
-   // If we are on the Z80 thread, we must not call doCleanUp() directly: the
-   // render (main) thread may be concurrently inside video_display_b() using
-   // SDL resources.  Instead, signal the Z80 loop to exit and push SDL_EVENT_QUIT
-   // so the render thread handles orderly teardown when it is next safe to do so.
-   if (g_z80_thread.joinable() &&
-       std::this_thread::get_id() == g_z80_thread.get_id()) {
+   // Only the main (render) thread is allowed to run SDL_Quit(): it's the
+   // thread that owns the video subsystem and that lives inside
+   // SDL_PumpEvents().  Any other thread calling doCleanUp() directly races
+   // with the pump loop and can segfault at PC=0 when SDL nulls the video
+   // driver's PumpEvents function pointer out from under it.  So:
+   //
+   //   - Z80 thread  → push SDL_EVENT_QUIT; loop exits via g_z80_thread_quit
+   //   - IPC / HTTP / telnet / any other aux thread  → same pattern
+   //   - Main thread → safe to call doCleanUp() + _exit() directly
+   //
+   // The render thread's SDL_EVENT_QUIT handler calls cleanExit() recursively,
+   // at which point we land in the main-thread branch and do the real
+   // teardown.  The requested exit code rides along in the same atomic the
+   // Z80 self-quit path already uses.
+   const auto tid          = std::this_thread::get_id();
+   const bool is_z80_self  = g_z80_thread.joinable() && tid == g_z80_thread.get_id();
+   const bool is_main      = (g_main_thread_id != std::thread::id{}) && (tid == g_main_thread_id);
+
+   if (is_z80_self || !is_main) {
       g_z80_requested_exit_code.store(returnCode, std::memory_order_relaxed);
-      g_z80_thread_quit.store(true, std::memory_order_relaxed);
+      if (is_z80_self) {
+         // Z80 self-quit also has to break its own loop.  Aux threads don't
+         // need this bit — the main thread handles shutdown orchestration.
+         g_z80_thread_quit.store(true, std::memory_order_relaxed);
+      }
       SDL_Event qe = {};
       qe.type = SDL_EVENT_QUIT;
       SDL_PushEvent(&qe);
-      return; // Z80 thread loop exits on next iteration via g_z80_thread_quit
+      return;
    }
 
    doCleanUp();
@@ -3814,6 +3865,13 @@ static void z80_thread_main()
 
 int koncpc_main (int argc, char **argv)
 {
+   // Remember the main thread — cleanExit() uses this to route IPC/HTTP/
+   // telnet-initiated quits through SDL_EVENT_QUIT instead of letting an
+   // auxiliary thread call SDL_Quit() while the main thread is mid-
+   // SDL_PumpEvents (which crashes when the video subsystem is torn down
+   // out from under it).
+   g_main_thread_id = std::this_thread::get_id();
+
 #ifdef _WIN32
    // Set Windows timer resolution to 1ms for accurate SDL_Delay() in the speed limiter.
    // Without this, SDL_Delay(1) actually sleeps ~15.6ms (default 64Hz timer).

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -3099,14 +3099,10 @@ std::vector<video_plugin> video_plugin_list =
      to live here at indices 11-13.  Removed in Phase 7b; the GPU variants
      below (indices 25-27 after the shift) cover all three tiers on both
      Metal and Vulkan.
-     Config migration note: the vector now has 28 entries, so indices 11
-     through 27 silently refer to DIFFERENT plugins than before the shift
-     — a user whose config had scr_style=11..13 (old CRT GL plugins) will
-     now load whichever plugin sits at the same index today (Direct (SDL)
-     / Super eagle (SDL) / Scale2x (SDL) respectively).  Only scr_style
-     values ≥28 now trigger the index-out-of-range fallback in
-     init_video().  A proper scr_style remap on config load is a
-     follow-up item tracked separately. */
+     Config migration: scr_style values 11/12/13 (old GL CRT) and 28/29/30
+     (old-position GPU CRT) are remapped to the new GPU CRT plugins at
+     25/26/27 on config load (see kon_cpc_ja.cpp init_video()).  Indices
+     14-27 stay untouched since new configs also use that range. */
   /* SDL_Renderer plugins — use D3D11 on Windows, Metal on macOS, GL on Linux.
      No OpenGL context required; no multi-viewport support. flip_b is null. */
   {"Direct (SDL)",            false, sdlr_init,          direct_setpal,   sdlr_flip,     sdlr_close,          1,  0, 0,  0, 0, 0, 0,  nullptr },


### PR DESCRIPTION
## Summary

Two related changes in one PR — the second was discovered while testing the first.

### 1. scr_style remap (`src/kon_cpc_ja.cpp:init_video()`)

Phase 7b (PR #107) removed the three legacy GL CRT plugins at indices 11-13, shifting every plugin after them. Configs saved before Phase 7b still reference the old positions:

| Pre-7b | Plugin | Post-7b behaviour without remap |
|---|---|---|
| 11 | CRT Basic (GL)  | silently loads Direct (SDL) — wrong plugin |
| 12 | CRT Full (GL)   | silently loads Super eagle (SDL) — wrong plugin |
| 13 | CRT Lottes (GL) | silently loads Scale2x (SDL) — wrong plugin |
| 28 | CRT Basic (GPU) | out of range → default plugin |
| 29 | CRT Full (GPU)  | out of range → default plugin |
| 30 | CRT Lottes (GPU) | out of range → default plugin |

Remap those six indices to the equivalent GPU CRT plugin (25/26/27). One-time INFO log so users know the upgrade happened. Indices 14-24 left untouched — without a config-version field we can't disambiguate old vs. new configs there, and new configs must be respected.

### 2. IPC quit race fix (`src/kon_cpc_ja.cpp:cleanExit()`)

Surfaced by testing the remap with `SDL_VIDEODRIVER=dummy` + an IPC `"quit"` command. After GPU init fails (no dummy backend) and the fallback chain lands on Direct (SDL), sending `"quit"` over port 6543 segfaulted at PC=0 inside `SDL_PumpEventsInternal`.

**Root cause:** IPC server thread called `cleanExit(code)` → `doCleanUp()` → `SDL_Quit()` → `_exit()`. The render (main) thread was still inside `SDL_PumpEvents()`. When `SDL_Quit()` nulled the video device's `PumpEvents` function pointer, the render thread dereferenced NULL on its next iteration. Pre-existing bug; just now reachable because `scr_style=11` used to fail earlier (in GL init) under dummy SDL, never reaching the pump loop.

**Fix:** capture `g_main_thread_id` at the top of `koncpc_main()`. In `cleanExit()`, if the caller is not on the main thread (IPC / HTTP / telnet / Z80), push `SDL_EVENT_QUIT` and return. The main loop's `SDL_EVENT_QUIT` handler already calls `cleanExit()` — which lands in the main-thread branch and runs `doCleanUp() + _exit()` safely.

The Z80 self-quit path still sets `g_z80_thread_quit` (its own loop needs that signal); aux threads don't, since the main thread orchestrates shutdown via `SDL_EVENT_QUIT`.

## Test plan

- [x] `scr_style=11` in config logs `remapped to 25 (CRT Basic (GPU))`, loads without crash.
- [x] `quit` over IPC no longer segfaults on the dummy SDL fallback path.
- [x] dsk e2e test passes locally (`Hello, World !` in printer.dat).
- [ ] CI green on macOS / Linux / Windows x6.