### PR TITLE
feat(ipc): add 'plugins' command — list available video plugins

### DIFF
--- a/src/koncepcja_ipc_server.cpp
+++ b/src/koncepcja_ipc_server.cpp
@@ -4,6 +4,7 @@
 #include "gfx_finder.h"
 #include "search_engine.h"
 #include "imgui_ui.h"
+#include "video.h"   // video_plugin_list (for the "plugins" IPC command)
 
 #include <cstring>
 #include <string>
@@ -292,6 +293,24 @@ void init_command_registry() {
           f_avg, d_avg, z_avg, s_avg, aq_avg, aq_min,
           underruns, near_underruns);
       return std::string(buf);
+    });
+
+  register_command("plugins", "CORE", "plugins",
+    "List available video plugins (one per line: index name)",
+    "Returns the current video-plugin table — the same data the CLI -L flag\n"
+    "prints — over IPC for tools and scripts that need it programmatically.\n"
+    "Each line is `<index> <name>'; useful when an automation needs to map\n"
+    "a config's scr_style value to a human-readable plugin name, e.g. after\n"
+    "a Phase-7-style index shift.\n"
+    "Format: 'OK count=N' on the first line, then one 'idx=I name=...' line\n"
+    "per plugin.",
+    [](const auto&, const auto&) {
+      std::string out = "OK count=" + std::to_string(video_plugin_list.size()) + "\n";
+      for (size_t i = 0; i < video_plugin_list.size(); ++i) {
+        out += "idx=" + std::to_string(i)
+             + " name=" + video_plugin_list[i].name + "\n";
+      }
+      return out;
     });
 
   register_command("quit", "CORE", "quit [code]", "Exit the emulator with optional exit code",

--- a/src/koncepcja_ipc_server.cpp
+++ b/src/koncepcja_ipc_server.cpp
@@ -308,23 +308,21 @@ void init_command_registry() {
     [](const auto&, const auto&) {
       // Stack buffer keyed off plugin-list size: 28 plugins × ~64 bytes per
       // line is ~1.8 KiB, so 4 KiB has ample headroom for any realistic
-      // plugin-table growth.  snprintf truncation is safe — len_remaining
-      // bounds every write.
+      // plugin-table growth.  snprintf return-value handling treats any
+      // negative or truncating result as "stop appending" so the buffer
+      // stays nul-terminated.
       char buf[4096];
-      char* p   = buf;
-      size_t r  = sizeof(buf);
-      auto append = [&](const char* fmt, auto... args) {
-        int n = std::snprintf(p, r, fmt, args...);
-        if (n < 0) return;
-        size_t w = (static_cast<size_t>(n) >= r) ? (r - 1) : static_cast<size_t>(n);
-        p += w;
-        r -= w;
-      };
-      append("OK count=%zu\n", video_plugin_list.size());
-      for (size_t i = 0; i < video_plugin_list.size(); ++i) {
-        append("idx=%zu name=%s\n", i, video_plugin_list[i].name);
+      size_t pos = 0;
+      const size_t cap = sizeof(buf);
+      int n = std::snprintf(buf, cap, "OK count=%zu\n", video_plugin_list.size());
+      if (n > 0 && static_cast<size_t>(n) < cap) pos = static_cast<size_t>(n);
+      for (size_t i = 0; i < video_plugin_list.size() && pos + 1 < cap; ++i) {
+        n = std::snprintf(buf + pos, cap - pos,
+                          "idx=%zu name=%s\n", i, video_plugin_list[i].name);
+        if (n <= 0 || static_cast<size_t>(n) >= cap - pos) break;
+        pos += static_cast<size_t>(n);
       }
-      return std::string(buf);
+      return std::string(buf, pos);
     });
 
   register_command("quit", "CORE", "quit [code]", "Exit the emulator with optional exit code",

--- a/src/koncepcja_ipc_server.cpp
+++ b/src/koncepcja_ipc_server.cpp
@@ -4,7 +4,8 @@
 #include "gfx_finder.h"
 #include "search_engine.h"
 #include "imgui_ui.h"
-#include "video.h"   // video_plugin_list (for the "plugins" IPC command)
+// `video.h` (defining video_plugin_list) is already included via the
+// project-internal include block below.
 
 #include <cstring>
 #include <string>
@@ -296,21 +297,34 @@ void init_command_registry() {
     });
 
   register_command("plugins", "CORE", "plugins",
-    "List available video plugins (one per line: index name)",
+    "List available video plugins (one per line: idx=I name=...)",
     "Returns the current video-plugin table — the same data the CLI -L flag\n"
     "prints — over IPC for tools and scripts that need it programmatically.\n"
-    "Each line is `<index> <name>'; useful when an automation needs to map\n"
-    "a config's scr_style value to a human-readable plugin name, e.g. after\n"
-    "a Phase-7-style index shift.\n"
-    "Format: 'OK count=N' on the first line, then one 'idx=I name=...' line\n"
-    "per plugin.",
+    "Useful when an automation needs to map a config's scr_style value to\n"
+    "a human-readable plugin name, e.g. after a Phase-7-style index shift.\n"
+    "Format:\n"
+    "    OK count=N\n"
+    "    idx=I name=...    (× N)",
     [](const auto&, const auto&) {
-      std::string out = "OK count=" + std::to_string(video_plugin_list.size()) + "\n";
+      // Stack buffer keyed off plugin-list size: 28 plugins × ~64 bytes per
+      // line is ~1.8 KiB, so 4 KiB has ample headroom for any realistic
+      // plugin-table growth.  snprintf truncation is safe — len_remaining
+      // bounds every write.
+      char buf[4096];
+      char* p   = buf;
+      size_t r  = sizeof(buf);
+      auto append = [&](const char* fmt, auto... args) {
+        int n = std::snprintf(p, r, fmt, args...);
+        if (n < 0) return;
+        size_t w = (static_cast<size_t>(n) >= r) ? (r - 1) : static_cast<size_t>(n);
+        p += w;
+        r -= w;
+      };
+      append("OK count=%zu\n", video_plugin_list.size());
       for (size_t i = 0; i < video_plugin_list.size(); ++i) {
-        out += "idx=" + std::to_string(i)
-             + " name=" + video_plugin_list[i].name + "\n";
+        append("idx=%zu name=%s\n", i, video_plugin_list[i].name);
       }
-      return out;
+      return std::string(buf);
     });
 
   register_command("quit", "CORE", "quit [code]", "Exit the emulator with optional exit code",


### PR DESCRIPTION
## Summary

IPC sibling of the CLI `-L/--list-plugins` flag (PR #109). Same data, same source of truth (`video_plugin_list`), but accessible over the TCP IPC protocol on port 6543 — useful for tools and scripts that already have a long-lived IPC connection and don't want to spawn a separate process.

## Format

\`\`\`
OK count=N
idx=I name=...     (× N)
\`\`\`

## Example

\`\`\`
\$ echo "plugins" | nc localhost 6543
OK count=28
idx=0 name=Direct
idx=1 name=Direct double
idx=2 name=Half size
...
idx=27 name=CRT Lottes (GPU)
\`\`\`

## Why

When an automation script reads a user's config and sees `scr_style=N`, it needs to map `N` to a plugin name to make sensible decisions (e.g. "are we on a GPU plugin or fallback path?"). Until now the only way to get this list at runtime was to spawn `koncepcja -L`, which is wasteful when the IPC connection is already open. This is also the natural data source for any future tooling that wants to render plugin lists in a GUI.

## Test plan

- [x] `echo plugins | nc localhost 6543` returns `OK count=28` followed by 28 `idx=… name=…` lines.
- [x] Total response = 29 lines as expected.
- [x] Clean shutdown via `quit` IPC command (no regression to the cleanExit fix from PR #108).
- [ ] CI green on macOS / Linux / Windows.