### PR TITLE
fix(ci): synchronize scr_style autocmd with break gate; bump boot_time

### DIFF
--- a/test/integrated/dsk/koncepcja.cfg
+++ b/test/integrated/dsk/koncepcja.cfg
@@ -54,9 +54,7 @@ resources_path=../../../resources
 # boot_time
 #   Estimated time in *frames* (50 fps) the CPC takes to boot.
 #   The emulator will wait this long before sending a provided autocmd.
-#   100 frames ≈ 2 seconds — empirically chosen to give the CPC enough
-#   headroom to reach BASIC ready on slow CI runners.
-boot_time=100
+boot_time=42
 limit_speed=0
 
 [video]

--- a/test/integrated/dsk/koncepcja.cfg
+++ b/test/integrated/dsk/koncepcja.cfg
@@ -54,7 +54,7 @@ resources_path=../../../resources
 # boot_time
 #   Estimated time in seconds the CPC takes to boot.
 #   Caprice will wait this long before sending a provided autocmd.
-boot_time=42
+boot_time=100
 limit_speed=0
 
 [video]

--- a/test/integrated/dsk/koncepcja.cfg
+++ b/test/integrated/dsk/koncepcja.cfg
@@ -52,8 +52,10 @@ joystick_vkeyboard_button=10
 #   path to resources (menu images...)
 resources_path=../../../resources
 # boot_time
-#   Estimated time in seconds the CPC takes to boot.
-#   Caprice will wait this long before sending a provided autocmd.
+#   Estimated time in *frames* (50 fps) the CPC takes to boot.
+#   The emulator will wait this long before sending a provided autocmd.
+#   100 frames ≈ 2 seconds — empirically chosen to give the CPC enough
+#   headroom to reach BASIC ready on slow CI runners.
 boot_time=100
 limit_speed=0
 

--- a/test/integrated/scr_style/koncepcja.cfg
+++ b/test/integrated/scr_style/koncepcja.cfg
@@ -54,9 +54,7 @@ resources_path=../../../resources
 # boot_time
 #   Estimated time in *frames* (50 fps) the CPC takes to boot.
 #   The emulator will wait this long before sending a provided autocmd.
-#   100 frames ≈ 2 seconds — empirically chosen to give the CPC enough
-#   headroom to reach BASIC ready on slow CI runners.
-boot_time=100
+boot_time=42
 limit_speed=0
 
 [video]

--- a/test/integrated/scr_style/koncepcja.cfg
+++ b/test/integrated/scr_style/koncepcja.cfg
@@ -54,7 +54,7 @@ resources_path=../../../resources
 # boot_time
 #   Estimated time in seconds the CPC takes to boot.
 #   Caprice will wait this long before sending a provided autocmd.
-boot_time=42
+boot_time=100
 limit_speed=0
 
 [video]

--- a/test/integrated/scr_style/koncepcja.cfg
+++ b/test/integrated/scr_style/koncepcja.cfg
@@ -52,8 +52,10 @@ joystick_vkeyboard_button=10
 #   path to resources (menu images...)
 resources_path=../../../resources
 # boot_time
-#   Estimated time in seconds the CPC takes to boot.
-#   Caprice will wait this long before sending a provided autocmd.
+#   Estimated time in *frames* (50 fps) the CPC takes to boot.
+#   The emulator will wait this long before sending a provided autocmd.
+#   100 frames ≈ 2 seconds — empirically chosen to give the CPC enough
+#   headroom to reach BASIC ready on slow CI runners.
 boot_time=100
 limit_speed=0
 

--- a/test/integrated/scr_style/test.sh
+++ b/test/integrated/scr_style/test.sh
@@ -65,7 +65,18 @@ do
     fi
   done
   $SED -i "s/^scr_style=.*$/scr_style=${style}/" koncepcja.cfg || rc=2
-  run_with_timeout 20 $KONCPCDIR/koncepcja -c koncepcja.cfg -a "print #8,\"style=${style}\"" -a KONCPC_EXIT >> "${LOGFILE}" 2>&1
+  # Autocmd sequencing: print first, then `call 0` + KONCPC_WAITBREAK to
+  # synchronize on the resulting PC=0 break before KONCPC_EXIT.  Without
+  # the break gate, KONCPC_EXIT fires the same frame the autocmd queue
+  # finishes typing — BASIC has not yet executed the queued PRINT and
+  # the printer file ends up empty.  This was the recurring macOS CI
+  # flake on PRs #101/103/107/108/109/110.  See dsk/test.sh which uses
+  # the same pattern.
+  run_with_timeout 20 $KONCPCDIR/koncepcja -c koncepcja.cfg \
+      -a "print #8,\"style=${style}\"" \
+      -a "call 0" \
+      -a KONCPC_WAITBREAK \
+      -a KONCPC_EXIT >> "${LOGFILE}" 2>&1
 
   mv ${OUTPUT_DIR}/printer.dat ${OUTPUT_DIR}/printer.dat.${style}
   if ! $DIFF ${OUTPUT_DIR}/printer.dat.${style} model/printer.dat.${style} >> "${LOGFILE}"


### PR DESCRIPTION
## Summary

Targets the recurring macOS CI flake on `scr_style` e2e — refactors the per-iteration autocmd to use the same break-gated pattern as `dsk`.

### `scr_style/test.sh` — break-gated autocmd

Old per-iteration autocmd was just `print #8,…` → `KONCPC_EXIT`. Because emulator commands process with no inter-event pause, `KONCPC_EXIT` could fire on the same frame the trailing `\n` of the PRINT was typed — before BASIC had a chance to actually execute the PRINT. When the timing tipped that way the printer file ended up empty (the historical `0a1 > style=N` diff).

Now mirrors the dsk pattern: `print #8,…` → `call 0` → `KONCPC_WAITBREAK` → `KONCPC_EXIT`. The `CALL 0` jumps PC to 0, `KONCPC_WAITBREAK` gates the autocmd queue on that break, and `KONCPC_EXIT` only fires after BASIC has finished running the PRINT and reset.

### Comment fix in both cfg files

Source-of-truth in `kon_cpc_ja.cpp` uses `boot_time` as a **frame count** (compared to `dwFrameCountOverall`, used as `pause_frames` in the autotype queue). The cfg comment said "seconds" — corrected to "frames (50 fps)".

## What this does NOT fix

- The dsk-test flake is a separate keystroke-loss race (RUN-before-BASIC-ready). Tracked separately.
- A `boot_time` bump experiment (42 → 100) was tested and reverted: the 5× slowdown wasn't justified by the (still flaky) results.

## Test plan

- [x] Local scr_style runs through all 28 plugins; old empty-output failure mode is gone.
- [x] Local dsk e2e passes.
- [ ] CI flake rate observed on next merges.