### PR TITLE
fix(autotype): widen release-to-press gap to fix 'CALL'→'CAL' debounce

### DIFF
--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -4106,8 +4106,16 @@ int koncpc_main (int argc, char **argv)
          CPCScancode scancode = CPC.InputMapper->CPCscancodeFromKeysym(key, mod);
          if (!(scancode & MOD_EMU_KEY)) {
             LOG_DEBUG("The virtual event is a keypress (not a command), so introduce a pause.");
-            nextVirtualEventFrameCount = dwFrameCountOverall
-               + ((evtype == SDL_EVENT_KEY_DOWN || evtype == SDL_EVENT_KEY_UP)?1:0);
+            // After a KEY_UP, wait an extra frame before the next event so the
+            // CPC firmware key-scan sees a clean "released" cycle between the
+            // release and the next press.  Without this, two adjacent identical
+            // characters (e.g. "ll" in "CALL") collapse into a single registered
+            // keypress because both scans land on the "pressed" state.  Mirrors
+            // the inter_char_pause_ logic in AutoTypeQueue::tick().
+            int gap = 0;
+            if (evtype == SDL_EVENT_KEY_DOWN) gap = 1;
+            else if (evtype == SDL_EVENT_KEY_UP) gap = 2;
+            nextVirtualEventFrameCount = dwFrameCountOverall + gap;
          }
 
          // In headless mode, directly process keyboard events


### PR DESCRIPTION
## Summary

The legacy `StringToEvents` autocmd path (used when `-a` argument has no `~` tags) scheduled consecutive virtual `KEY_UP`/`KEY_DOWN` events only 1 frame apart, so the CPC firmware key-scan could land on \"pressed\" for both adjacent presses when typing repeated identical characters. This collapsed `CALL 0` → `CAL 0`, `PRESS` → `PRES`, etc.

## Root cause

`src/kon_cpc_ja.cpp:4109-4111` scheduled the next virtual event at `dwFrameCountOverall + 1` for both `KEY_DOWN` and `KEY_UP`. For \"ll\":

```
frame N+0:  L1 KEY_DOWN  (next at N+1)
frame N+1:  L1 KEY_UP    (next at N+2)
frame N+2:  L2 KEY_DOWN  ← only one frame of \"released\" between adjacent presses
frame N+3:  L2 KEY_UP
```

The CPC firmware key-scan running at ~50 Hz could land in the \"L pressed\" window twice and miss the brief \"released\" window, registering as key repeat instead of two distinct keypresses.

The AutoTypeQueue path (`src/autotype.cpp:122-131`) already handles this correctly via `inter_char_pause_`. This PR mirrors that behavior in the legacy path.

## Fix

After a `KEY_UP`, schedule the next event `+2` frames instead of `+1`. `KEY_DOWN` scheduling unchanged. ~10 lines.

## Likely impact

Suspected cause of intermittent scr_style CI flake where `print #8,\"style=N\"` would occasionally produce truncated printer output. The flake mechanism — keystroke drop on repeated identical chars — is documented in PR #111's close comment.

## Test plan

- [x] Local macOS build clean
- [ ] CI: scr_style on Linux + Windows
- [ ] CI: dsk e2e (uses `-a 'load\"' ENTER...` with no repeated chars but exercises the same path)

## Out of scope

- Stuck-key issue (random character bursts when emulator focus is unexpected) — separate bug, separate PR
- Window-focus-steal during scr_style local runs — testing-only concern