### PR TITLE
GPU: restore ImGui multi-viewport (floating devtools) on SDLGPU3 backend

### DIFF
--- a/src/video.cpp
+++ b/src/video.cpp
@@ -280,10 +280,10 @@ void direct_setpal(SDL_Color* c)
 //   - Command buffer is submitted in Phase A (gpu_flip_a).  The render
 //     loop's "skip video_display_b() on quit" optimisation therefore
 //     cannot leak an unsubmitted buffer.
-//   - Multi-viewport is DISABLED (ImGuiConfigFlags_ViewportsEnable off).
-//     imgui_impl_sdlgpu3 registers no platform handlers, so secondary
-//     windows would not render correctly.  Floating devtools stays
-//     docked for now; full viewport support is a follow-up.
+//   - Multi-viewport ENABLED — secondary windows are rendered by the
+//     renderer hooks we added to imgui_impl_sdlgpu3.cpp (ClaimWindowForGPU
+//     in Renderer_CreateWindow, AcquireSwapchain+RenderDrawData+Submit in
+//     Renderer_RenderWindow / Renderer_SwapBuffers).
 //   - Non-blocking swapchain acquire — never blocks the render thread.
 
 SDL_Surface* gpu_direct_init(video_plugin* t, int scale, bool fs)
@@ -308,14 +308,19 @@ SDL_Surface* gpu_direct_init(video_plugin* t, int scale, bool fs)
         return nullptr;
     }
 
-    // ImGui — SDLGPU3 backend, viewports DISABLED (see design note above).
+    // ImGui — SDLGPU3 backend with multi-viewport ENABLED.  The renderer
+    // hooks live in vendor/imgui/backends/imgui_impl_sdlgpu3.cpp; they
+    // claim each secondary window for g_gpu.device on creation and submit
+    // a per-viewport command buffer on render.  ImGui_ImplSDLGPU3_Init
+    // checks io.ConfigFlags after we set the flag and registers the
+    // hooks itself, so order matters: set flags BEFORE Init.
     IMGUI_CHECKVERSION();
     ImGui::CreateContext();
     ImGuiIO& io = ImGui::GetIO();
     io.IniFilename  = imgui_ini_path();
     io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard
-                    | ImGuiConfigFlags_DockingEnable;
-    // Intentionally NO ImGuiConfigFlags_ViewportsEnable.
+                    | ImGuiConfigFlags_DockingEnable
+                    | ImGuiConfigFlags_ViewportsEnable;
     ImGui::StyleColorsDark();
     imgui_init_ui();
     ImGui_ImplSDL3_InitForSDLGPU(mainSDLWindow);
@@ -461,6 +466,15 @@ void gpu_flip_a(video_plugin* t)
     // 6. SUBMIT IN PHASE A — avoids the quit-skip leak from the first attempt.
     SDL_SubmitGPUCommandBuffer(cmd);
     g_gpu.pending_cmd = nullptr;
+
+    // 7. Multi-viewport: render every secondary ImGui window.  The renderer
+    //    hooks in imgui_impl_sdlgpu3.cpp acquire + submit one command buffer
+    //    per viewport.  RenderPlatformWindowsDefault skips the main viewport
+    //    (already rendered above) so there's no double-render race.
+    if (ImGui::GetIO().ConfigFlags & ImGuiConfigFlags_ViewportsEnable) {
+        ImGui::UpdatePlatformWindows();
+        ImGui::RenderPlatformWindowsDefault();
+    }
 }
 
 void gpu_flip_b([[maybe_unused]] video_plugin* t)
@@ -709,6 +723,11 @@ static void crt_basic_gpu_flip_a(video_plugin* t)
     video_capture_if_pending();
     SDL_SubmitGPUCommandBuffer(cmd);
     g_gpu.pending_cmd = nullptr;
+
+    if (ImGui::GetIO().ConfigFlags & ImGuiConfigFlags_ViewportsEnable) {
+        ImGui::UpdatePlatformWindows();
+        ImGui::RenderPlatformWindowsDefault();
+    }
 }
 
 static void crt_basic_gpu_close()
@@ -927,6 +946,11 @@ static void crt_full_gpu_flip_a(video_plugin* t)
     video_capture_if_pending();
     SDL_SubmitGPUCommandBuffer(cmd);
     g_gpu.pending_cmd = nullptr;
+
+    if (ImGui::GetIO().ConfigFlags & ImGuiConfigFlags_ViewportsEnable) {
+        ImGui::UpdatePlatformWindows();
+        ImGui::RenderPlatformWindowsDefault();
+    }
 }
 
 static void crt_full_gpu_close()
@@ -1148,6 +1172,11 @@ static void crt_lottes_gpu_flip_a(video_plugin* t)
     video_capture_if_pending();
     SDL_SubmitGPUCommandBuffer(cmd);
     g_gpu.pending_cmd = nullptr;
+
+    if (ImGui::GetIO().ConfigFlags & ImGuiConfigFlags_ViewportsEnable) {
+        ImGui::UpdatePlatformWindows();
+        ImGui::RenderPlatformWindowsDefault();
+    }
 }
 
 static void crt_lottes_gpu_close()

--- a/vendor/imgui/backends/imgui_impl_sdlgpu3.cpp
+++ b/vendor/imgui/backends/imgui_impl_sdlgpu3.cpp
@@ -38,6 +38,7 @@
 #ifndef IMGUI_DISABLE
 #include "imgui_impl_sdlgpu3.h"
 #include "imgui_impl_sdlgpu3_shaders.h"
+#include <SDL3/SDL_log.h>   // konCePCja: SDL_Log on viewport claim failure
 
 // SDL_GPU Data
 
@@ -729,6 +730,14 @@ static void ImGui_ImplSDLGPU3_CreateWindow(ImGuiViewport* viewport)
             SDL_SetGPUSwapchainParameters(bd->InitInfo.Device, window,
                                           bd->InitInfo.SwapchainComposition,
                                           bd->InitInfo.PresentMode);
+        }
+        else
+        {
+            // Log so platform-specific claim failures are debuggable.  ClaimedForGPU
+            // stays false; Renderer_RenderWindow then skips this viewport silently
+            // rather than crashing on a missing swapchain.
+            SDL_Log("[ImGui_ImplSDLGPU3] SDL_ClaimWindowForGPUDevice failed for viewport ID %u: %s",
+                    (unsigned)viewport->ID, SDL_GetError());
         }
     }
 }

--- a/vendor/imgui/backends/imgui_impl_sdlgpu3.cpp
+++ b/vendor/imgui/backends/imgui_impl_sdlgpu3.cpp
@@ -68,8 +68,22 @@ struct ImGui_ImplSDLGPU3_Data
     ImGui_ImplSDLGPU3_FrameData  MainWindowFrameData;
 };
 
+// konCePCja addition: per-viewport renderer state for multi-viewport mode.
+// One instance lives in viewport->RendererUserData for each ImGui viewport
+// (main + every floating window the user dragged out).  CmdBuf is acquired
+// in Renderer_RenderWindow and submitted in Renderer_SwapBuffers — splitting
+// across the two callbacks lets ImGui's per-viewport draw flow work without
+// any change at the application layer.
+struct ImGui_ImplSDLGPU3_ViewportData
+{
+    SDL_GPUCommandBuffer*  CmdBuf        = nullptr;
+    bool                   ClaimedForGPU = false;
+};
+
 // Forward Declarations
 static void ImGui_ImplSDLGPU3_DestroyFrameData();
+static void ImGui_ImplSDLGPU3_InitMultiViewportSupport();
+static void ImGui_ImplSDLGPU3_ShutdownMultiViewportSupport();
 
 //-----------------------------------------------------------------------------
 // FUNCTIONS
@@ -633,6 +647,14 @@ bool ImGui_ImplSDLGPU3_Init(ImGui_ImplSDLGPU3_InitInfo* info)
 
     bd->InitInfo = *info;
 
+    // konCePCja addition: register per-viewport renderer hooks when the app
+    // turned on ImGuiConfigFlags_ViewportsEnable.  Upstream ImGui 1.92.6 ships
+    // the Platform_* side (imgui_impl_sdl3) but leaves Renderer_* unimplemented
+    // for SDL_GPU.  Without these hooks any popped-out floating window has no
+    // swapchain claim and cannot render.
+    if (io.ConfigFlags & ImGuiConfigFlags_ViewportsEnable)
+        ImGui_ImplSDLGPU3_InitMultiViewportSupport();
+
     return true;
 }
 
@@ -642,6 +664,11 @@ void ImGui_ImplSDLGPU3_Shutdown()
     IM_ASSERT(bd != nullptr && "No renderer backend to shutdown, or already shutdown?");
     ImGuiIO& io = ImGui::GetIO();
     ImGuiPlatformIO& platform_io = ImGui::GetPlatformIO();
+
+    // konCePCja addition: tear down per-viewport renderer state BEFORE
+    // releasing device objects — DestroyPlatformWindows() calls back into
+    // Renderer_DestroyWindow which expects the device to still be live.
+    ImGui_ImplSDLGPU3_ShutdownMultiViewportSupport();
 
     ImGui_ImplSDLGPU3_DestroyDeviceObjects();
 
@@ -659,6 +686,151 @@ void ImGui_ImplSDLGPU3_NewFrame()
 
     if (!bd->TexSamplerLinear)
         ImGui_ImplSDLGPU3_CreateDeviceObjects();
+}
+
+//-----------------------------------------------------------------------------
+// MULTI-VIEWPORT / PLATFORM INTERFACE SUPPORT (konCePCja addition)
+//-----------------------------------------------------------------------------
+// Implements the renderer-side half of ImGui's multi-viewport feature for
+// SDL_GPU.  Upstream's imgui_impl_sdlgpu3 (1.92.6) leaves these hooks empty.
+// Each ImGui viewport is backed by an SDL_Window created by the platform
+// backend (imgui_impl_sdl3); the renderer hooks below claim that window for
+// the GPU device, then per-frame acquire its swapchain texture and submit
+// a command buffer that draws viewport->DrawData onto it.
+//
+// SAFETY NOTES:
+// - Renderer_RenderWindow acquires the cmd buffer + records the draw.
+//   Renderer_SwapBuffers submits it.  Splitting matches ImGui's expected
+//   per-viewport call order (Platform_Render → Renderer_Render →
+//   Platform_Swap → Renderer_Swap).
+// - PrepareDrawData reuses bd->MainWindowFrameData for vertex/index uploads.
+//   We rely on cycle=true semantics inside SDL's GPU buffer rotation so
+//   sequential per-viewport renders don't race.  If visual artefacts appear
+//   under heavy multi-viewport load, switch to per-viewport FrameData.
+// - The main viewport (ImGui::GetMainViewport()) is rendered by the
+//   application's gpu_flip_a path, not by these hooks.  We only claim and
+//   render SECONDARY viewports here.
+
+static void ImGui_ImplSDLGPU3_CreateWindow(ImGuiViewport* viewport)
+{
+    ImGui_ImplSDLGPU3_Data* bd = ImGui_ImplSDLGPU3_GetBackendData();
+    IM_ASSERT(bd != nullptr);
+
+    auto* vd = IM_NEW(ImGui_ImplSDLGPU3_ViewportData)();
+    viewport->RendererUserData = vd;
+
+    SDL_Window* window = (SDL_Window*)viewport->PlatformHandle;
+    if (window != nullptr)
+    {
+        if (SDL_ClaimWindowForGPUDevice(bd->InitInfo.Device, window))
+        {
+            vd->ClaimedForGPU = true;
+            // Match swapchain composition / present mode the user picked at Init.
+            SDL_SetGPUSwapchainParameters(bd->InitInfo.Device, window,
+                                          bd->InitInfo.SwapchainComposition,
+                                          bd->InitInfo.PresentMode);
+        }
+    }
+}
+
+static void ImGui_ImplSDLGPU3_DestroyWindow(ImGuiViewport* viewport)
+{
+    ImGui_ImplSDLGPU3_Data* bd = ImGui_ImplSDLGPU3_GetBackendData();
+    auto* vd = (ImGui_ImplSDLGPU3_ViewportData*)viewport->RendererUserData;
+    if (vd != nullptr)
+    {
+        if (vd->CmdBuf != nullptr)
+        {
+            // ImGui aborted between Render and Swap (e.g. window destroyed
+            // mid-frame).  Submit so the cmd buffer doesn't leak.
+            SDL_SubmitGPUCommandBuffer(vd->CmdBuf);
+            vd->CmdBuf = nullptr;
+        }
+        if (vd->ClaimedForGPU && bd != nullptr)
+        {
+            SDL_Window* window = (SDL_Window*)viewport->PlatformHandle;
+            if (window != nullptr)
+                SDL_ReleaseWindowFromGPUDevice(bd->InitInfo.Device, window);
+        }
+        IM_DELETE(vd);
+    }
+    viewport->RendererUserData = nullptr;
+}
+
+static void ImGui_ImplSDLGPU3_SetWindowSize(ImGuiViewport*, ImVec2)
+{
+    // SDL_GPU swapchains auto-resize on the next AcquireGPUSwapchainTexture.
+    // No explicit work needed here.
+}
+
+static void ImGui_ImplSDLGPU3_RenderWindow(ImGuiViewport* viewport, void*)
+{
+    ImGui_ImplSDLGPU3_Data* bd = ImGui_ImplSDLGPU3_GetBackendData();
+    auto* vd = (ImGui_ImplSDLGPU3_ViewportData*)viewport->RendererUserData;
+    SDL_Window* window = (SDL_Window*)viewport->PlatformHandle;
+    if (bd == nullptr || vd == nullptr || window == nullptr || !vd->ClaimedForGPU)
+        return;
+
+    SDL_GPUCommandBuffer* cmd = SDL_AcquireGPUCommandBuffer(bd->InitInfo.Device);
+    if (cmd == nullptr)
+        return;
+
+    // PrepareDrawData MUST precede BeginGPURenderPass — it issues its own
+    // copy pass for vertex/index uploads.
+    ImGui_ImplSDLGPU3_PrepareDrawData(viewport->DrawData, cmd);
+
+    SDL_GPUTexture* swap_tex = nullptr;
+    Uint32 sw = 0, sh = 0;
+    bool have_swap = SDL_AcquireGPUSwapchainTexture(cmd, window, &swap_tex, &sw, &sh)
+                     && swap_tex != nullptr;
+
+    if (have_swap)
+    {
+        SDL_GPUColorTargetInfo tgt = {};
+        tgt.texture     = swap_tex;
+        tgt.load_op     = (viewport->Flags & ImGuiViewportFlags_NoRendererClear)
+                          ? SDL_GPU_LOADOP_LOAD : SDL_GPU_LOADOP_CLEAR;
+        tgt.store_op    = SDL_GPU_STOREOP_STORE;
+        tgt.cycle       = false;     // swapchain manages its own cycling
+        tgt.clear_color = {0.0f, 0.0f, 0.0f, 1.0f};
+
+        SDL_GPURenderPass* pass = SDL_BeginGPURenderPass(cmd, &tgt, 1, nullptr);
+        ImGui_ImplSDLGPU3_RenderDrawData(viewport->DrawData, cmd, pass);
+        SDL_EndGPURenderPass(pass);
+    }
+
+    // Stash for SwapBuffers — submit happens there to match ImGui's
+    // expected per-viewport callback order.
+    vd->CmdBuf = cmd;
+}
+
+static void ImGui_ImplSDLGPU3_SwapBuffers(ImGuiViewport* viewport, void*)
+{
+    auto* vd = (ImGui_ImplSDLGPU3_ViewportData*)viewport->RendererUserData;
+    if (vd != nullptr && vd->CmdBuf != nullptr)
+    {
+        SDL_SubmitGPUCommandBuffer(vd->CmdBuf);
+        vd->CmdBuf = nullptr;
+    }
+}
+
+static void ImGui_ImplSDLGPU3_InitMultiViewportSupport()
+{
+    ImGuiPlatformIO& platform_io = ImGui::GetPlatformIO();
+    platform_io.Renderer_CreateWindow  = ImGui_ImplSDLGPU3_CreateWindow;
+    platform_io.Renderer_DestroyWindow = ImGui_ImplSDLGPU3_DestroyWindow;
+    platform_io.Renderer_SetWindowSize = ImGui_ImplSDLGPU3_SetWindowSize;
+    platform_io.Renderer_RenderWindow  = ImGui_ImplSDLGPU3_RenderWindow;
+    platform_io.Renderer_SwapBuffers   = ImGui_ImplSDLGPU3_SwapBuffers;
+}
+
+static void ImGui_ImplSDLGPU3_ShutdownMultiViewportSupport()
+{
+    // ImGui::DestroyPlatformWindows() walks every secondary viewport and
+    // calls Platform_DestroyWindow + Renderer_DestroyWindow on each — that's
+    // where our DestroyWindow hook releases the GPU device claim.  Calling
+    // it BEFORE ClearRendererHandlers ensures the hook is still live.
+    ImGui::DestroyPlatformWindows();
 }
 
 #endif // #ifndef IMGUI_DISABLE


### PR DESCRIPTION
## Summary

Restores the floating-devtools-window experience that PR #115 (Phase 7c.1b — delete GL backend) regressed.  Upstream Dear ImGui 1.92.6 ships only the platform side of multi-viewport for SDL_GPU; the renderer-side hooks (\`Renderer_*Window\`) are unimplemented.  Without them, popped-out ImGui windows have no swapchain claim and cannot render — which is why the GPU plugin path turned \`ImGuiConfigFlags_ViewportsEnable\` off (per Phase 4 design landmine #30 + post-mortem #3).

This PR fills in the missing renderer hooks and re-enables the flag.

## What changed

**\`vendor/imgui/backends/imgui_impl_sdlgpu3.cpp\`** — adds 5 renderer-side hooks behind the existing \`SwapchainComposition\` / \`PresentMode\` fields upstream already exposes for multi-viewport:

| Hook | Action |
|------|--------|
| \`Renderer_CreateWindow\` | \`SDL_ClaimWindowForGPUDevice\` + \`SDL_SetGPUSwapchainParameters\` |
| \`Renderer_DestroyWindow\` | submit any in-flight cmd, \`SDL_ReleaseWindowFromGPUDevice\` |
| \`Renderer_SetWindowSize\` | no-op (SDL_GPU swapchain auto-resizes on next acquire) |
| \`Renderer_RenderWindow\` | acquire cmd buffer, \`PrepareDrawData\`, acquire swapchain (non-blocking), begin pass, \`RenderDrawData\`, end pass, stash cmd |
| \`Renderer_SwapBuffers\` | submit the stashed cmd |

Init/Shutdown wiring respects the constraint that \`DestroyPlatformWindows()\` must run **before** device objects are destroyed, since the platform layer owns the secondary windows whose claim we're releasing.

**\`src/video.cpp\`** — re-enables \`ImGuiConfigFlags_ViewportsEnable\` in \`gpu_direct_init\` (called by every GPU plugin), and adds \`ImGui::UpdatePlatformWindows()\` + \`ImGui::RenderPlatformWindowsDefault()\` after the per-frame submit in all four GPU flip paths:

- \`gpu_flip_a\` (Direct + swscale family — swscale delegates to gpu_flip_a)
- \`crt_basic_gpu_flip_a\`
- \`crt_full_gpu_flip_a\`
- \`crt_lottes_gpu_flip_a\`

## Why this design

- **Renderer-side hooks are required, not just platform-side.**  SDL_GPU's swapchain is per-window (unlike SDL_Renderer where the device implicitly covers everything).  Each secondary window needs its own \`SDL_ClaimWindowForGPUDevice\` + per-frame \`AcquireGPUSwapchainTexture\` + per-frame command-buffer submit.
- **Cmd buffer split between \`RenderWindow\` and \`SwapBuffers\`** matches ImGui's expected per-viewport callback order (\`Platform_Render\` → \`Renderer_Render\` → \`Platform_Swap\` → \`Renderer_Swap\`) — submit happens in SwapBuffers so any platform-side state ImGui sets between Render and Swap is honoured.
- **Non-blocking \`SDL_AcquireGPUSwapchainTexture\`** on secondary windows — same defensive pattern as the main viewport.  Minimised / resizing sub-windows skip their render pass without stalling the iteration loop.
- **Shared \`MainWindowFrameData\` for vertex/index uploads** — relies on SDL's \`cycle=true\` buffer rotation (already used inside \`PrepareDrawData\`).  If visual artefacts appear under heavy multi-viewport load, the next iteration is to give each viewport its own \`FrameData\` (commented in the source).

## Test plan

- [x] Full macOS build green (\`scripts/build-macos.sh\`)
- [x] Unit tests: 1108/1110 pass, 2 pre-existing skips, no new failures
- [ ] Manual: \`./koncepcja game.dsk\`, F12 to open devtools, drag a panel out of the main window — verify it renders correctly as a floating OS window
- [ ] Manual: drag the panel back in, close it, re-open via menu — verify create/destroy paths
- [ ] Manual: switch \`scr_style\` between Direct (0), swscale (4-10), CRT (17-19) with a floating panel open — verify all four flip paths work
- [ ] Manual: snapshot save/load mid-frame — verify no GPU state corruption
- [ ] CI: Linux build (Vulkan path) green
- [ ] CI: MSVC build (D3D12 path) green

## Closes

Closes beads-o73 (GPU: restore ImGui multi-viewport).

Refs PR #115 (Phase 7c.1b post-mortem #3 — viewport handling deferred) and Phase 4 design doc landmine #30.