### PR TITLE
GPU multi-viewport + macOS keyboard focus fixes (publishable build)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.21)
-project(koncepcja VERSION 5.3.0 LANGUAGES C CXX)
+project(koncepcja VERSION 5.7.0 LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/src/imgui_ui.cpp
+++ b/src/imgui_ui.cpp
@@ -5,6 +5,7 @@
 #include "command_palette.h"
 #include "menu_actions.h"
 #include "workspace_layout.h"
+#include "macos_menu.h"  // koncpc_restore_keyboard_focus
 #include <algorithm>
 #include <cmath>
 #include <cstdio>
@@ -88,6 +89,24 @@ static bool s_bottombar_height_dirty = false; // defer SDL_SetWindowSize to afte
 
 static void SDLCALL file_dialog_callback(void *userdata, const char * const *filelist, int /*filter*/)
 {
+  // After the dialog dismisses (whether the user picked a file or
+  // cancelled), restore keyboard routing to the emulator.
+  //
+  // The hard part is OS-level: on macOS SDL_ShowOpenFileDialog runs as
+  // an NSOpenPanel sheet attached to the parent NSWindow.  When the
+  // sheet dismisses, AppKit doesn't always restore the SDL content view
+  // as the window's firstResponder — keystrokes then route to the
+  // NSApplication menu bar instead of [SDLContentView keyDown:], so
+  // SDL never enqueues a SDL_EVENT_KEY_DOWN.  No ImGui-level gating
+  // matters because the event never arrives.  SDL_RaiseWindow calls
+  // [window makeKeyAndOrderFront:] which forces firstResponder back to
+  // the SDL view.
+  //
+  // Then in Docked mode also tell the workspace renderer to refocus
+  // the CPC Screen panel so cpc_screen_focused becomes true again.
+  koncpc_restore_keyboard_focus();   // macOS: Cocoa makeFirstResponder; no-op elsewhere
+  imgui_state.request_cpc_screen_focus = true;
+
   auto action = static_cast<FileDialogAction>(reinterpret_cast<intptr_t>(userdata));
   if (!filelist || !filelist[0]) return; // cancelled or error
   imgui_state.pending_dialog = action;

--- a/src/koncepcja.h
+++ b/src/koncepcja.h
@@ -48,7 +48,7 @@ class InputMapper;
 //#define DEBUG_TAPE
 //#define DEBUG_Z80
 
-#define VERSION_STRING "v5.6.0"
+#define VERSION_STRING "v5.7.0"
 
 #ifndef _MAX_PATH
  #ifdef _POSIX_PATH_MAX

--- a/src/macos_menu.h
+++ b/src/macos_menu.h
@@ -4,6 +4,11 @@ void koncpc_setup_macos_menu();
 void koncpc_disable_app_nap();
 void koncpc_enable_app_nap();
 void koncpc_activate_app();
+// Restore the SDL view as firstResponder of mainSDLWindow.  Call after
+// dismissing a native sheet/dialog (NSOpenPanel etc.) — AppKit doesn't
+// always reset firstResponder, leaving keystrokes routed to the menu
+// bar instead of [SDLContentView keyDown:].
+void koncpc_restore_keyboard_focus();
 void koncpc_order_viewports_above_main();
 // Dock icon: set the app icon from the bundled PNG, optionally with a live CPC screen inset
 void koncpc_set_dock_icon(const char* png_path);
@@ -14,6 +19,7 @@ void koncpc_update_dock_icon_preview(const void* pixels, int surface_w, int surf
 inline void koncpc_disable_app_nap() {}
 inline void koncpc_enable_app_nap() {}
 inline void koncpc_activate_app() {}
+inline void koncpc_restore_keyboard_focus() {}
 inline void koncpc_order_viewports_above_main() {}
 inline void koncpc_set_dock_icon(const char*) {}
 inline void koncpc_update_dock_icon_preview(const void*, int, int, int, int, int, int, int) {}

--- a/src/macos_menu.mm
+++ b/src/macos_menu.mm
@@ -176,6 +176,30 @@ void koncpc_activate_app() {
   });
 }
 
+// Restore mainSDLWindow's content view as firstResponder so AppKit routes
+// key events to [SDLContentView keyDown:] (and from there into SDL's
+// event queue) instead of the NSApplication menu bar.  Used after native
+// sheet dialogs (NSOpenPanel, NSSavePanel) where the sheet steals
+// firstResponder and AppKit doesn't auto-restore it on dismiss — bug
+// reproduces every time the user goes Menu → Media → Load Disk A.
+extern SDL_Window* mainSDLWindow;
+void koncpc_restore_keyboard_focus() {
+  dispatch_async(dispatch_get_main_queue(), ^{
+    @autoreleasepool {
+      if (!mainSDLWindow) return;
+      NSWindow* nswin = (__bridge NSWindow*)SDL_GetPointerProperty(
+          SDL_GetWindowProperties(mainSDLWindow),
+          SDL_PROP_WINDOW_COCOA_WINDOW_POINTER, NULL);
+      if (!nswin) return;
+      [nswin makeKeyAndOrderFront:nil];
+      NSView* contentView = [nswin contentView];
+      if (contentView) {
+        [nswin makeFirstResponder:contentView];
+      }
+    }
+  });
+}
+
 extern SDL_Window* mainSDLWindow;
 
 static NSWindow* nswindow_from_viewport(ImGuiViewport* vp) {

--- a/vendor/imgui/backends/imgui_impl_sdlgpu3.cpp
+++ b/vendor/imgui/backends/imgui_impl_sdlgpu3.cpp
@@ -75,14 +75,27 @@ struct ImGui_ImplSDLGPU3_Data
 // in Renderer_RenderWindow and submitted in Renderer_SwapBuffers — splitting
 // across the two callbacks lets ImGui's per-viewport draw flow work without
 // any change at the application layer.
+//
+// Each viewport owns its own FrameData (vertex/index/transfer buffers).
+// Sharing a single FrameData across main + sub-viewports caused sub windows
+// to render black: PrepareDrawData uploads with cycle=true so SDL rotates
+// staging buffers, but the device-side SDL_GPUBuffer pointer stored in
+// FrameData::VertexBuffer is shared, and BindGPUVertexBuffer in a later
+// command buffer reads whichever physical storage SDL last bound — racing
+// with main's still-in-flight cmd.  Per-viewport FrameData fully isolates
+// the upload + bind path.
 struct ImGui_ImplSDLGPU3_ViewportData
 {
-    SDL_GPUCommandBuffer*  CmdBuf        = nullptr;
-    bool                   ClaimedForGPU = false;
+    SDL_GPUCommandBuffer*       CmdBuf        = nullptr;
+    bool                        ClaimedForGPU = false;
+    ImGui_ImplSDLGPU3_FrameData FrameData;
 };
 
 // Forward Declarations
 static void ImGui_ImplSDLGPU3_DestroyFrameData();
+static void ImGui_ImplSDLGPU3_ReleaseFrameDataBuffers(SDL_GPUDevice* device, ImGui_ImplSDLGPU3_FrameData* fd);
+static void ImGui_ImplSDLGPU3_PrepareDrawDataImpl(ImDrawData* draw_data, SDL_GPUCommandBuffer* command_buffer, ImGui_ImplSDLGPU3_FrameData* fd);
+static void ImGui_ImplSDLGPU3_RenderDrawDataImpl(ImDrawData* draw_data, SDL_GPUCommandBuffer* command_buffer, SDL_GPURenderPass* render_pass, SDL_GPUGraphicsPipeline* pipeline, ImGui_ImplSDLGPU3_FrameData* fd);
 static void ImGui_ImplSDLGPU3_InitMultiViewportSupport();
 static void ImGui_ImplSDLGPU3_ShutdownMultiViewportSupport();
 
@@ -167,7 +180,9 @@ static void CreateOrResizeBuffers(SDL_GPUBuffer** buffer, SDL_GPUTransferBuffer*
 // SDL_GPU doesn't allow copy passes to occur while a render or compute pass is bound!
 // The only way to allow a user to supply their own RenderPass (to render to a texture instead of the window for example),
 // is to split the upload part of ImGui_ImplSDLGPU3_RenderDrawData() to another function that needs to be called by the user before rendering.
-void ImGui_ImplSDLGPU3_PrepareDrawData(ImDrawData* draw_data, SDL_GPUCommandBuffer* command_buffer)
+// konCePCja: split out the upload body so per-viewport renderer hooks can
+// pass their own FrameData instead of sharing bd->MainWindowFrameData.
+static void ImGui_ImplSDLGPU3_PrepareDrawDataImpl(ImDrawData* draw_data, SDL_GPUCommandBuffer* command_buffer, ImGui_ImplSDLGPU3_FrameData* fd)
 {
     // Avoid rendering when minimized, scale coordinates for retina displays (screen coordinates != framebuffer coordinates)
     int fb_width = (int)(draw_data->DisplaySize.x * draw_data->FramebufferScale.x);
@@ -184,7 +199,6 @@ void ImGui_ImplSDLGPU3_PrepareDrawData(ImDrawData* draw_data, SDL_GPUCommandBuff
 
     ImGui_ImplSDLGPU3_Data* bd = ImGui_ImplSDLGPU3_GetBackendData();
     ImGui_ImplSDLGPU3_InitInfo* v = &bd->InitInfo;
-    ImGui_ImplSDLGPU3_FrameData* fd = &bd->MainWindowFrameData;
 
     uint32_t vertex_size = draw_data->TotalVtxCount * sizeof(ImDrawVert);
     uint32_t index_size  = draw_data->TotalIdxCount * sizeof(ImDrawIdx);
@@ -228,7 +242,16 @@ void ImGui_ImplSDLGPU3_PrepareDrawData(ImDrawData* draw_data, SDL_GPUCommandBuff
     SDL_EndGPUCopyPass(copy_pass);
 }
 
-void ImGui_ImplSDLGPU3_RenderDrawData(ImDrawData* draw_data, SDL_GPUCommandBuffer* command_buffer, SDL_GPURenderPass* render_pass, SDL_GPUGraphicsPipeline* pipeline)
+// Public wrapper — main viewport uses bd->MainWindowFrameData.
+void ImGui_ImplSDLGPU3_PrepareDrawData(ImDrawData* draw_data, SDL_GPUCommandBuffer* command_buffer)
+{
+    ImGui_ImplSDLGPU3_Data* bd = ImGui_ImplSDLGPU3_GetBackendData();
+    ImGui_ImplSDLGPU3_PrepareDrawDataImpl(draw_data, command_buffer, &bd->MainWindowFrameData);
+}
+
+// konCePCja: split out the draw body so per-viewport renderer hooks can
+// pass their own FrameData (matching the per-viewport upload above).
+static void ImGui_ImplSDLGPU3_RenderDrawDataImpl(ImDrawData* draw_data, SDL_GPUCommandBuffer* command_buffer, SDL_GPURenderPass* render_pass, SDL_GPUGraphicsPipeline* pipeline, ImGui_ImplSDLGPU3_FrameData* fd)
 {
     // Avoid rendering when minimized, scale coordinates for retina displays (screen coordinates != framebuffer coordinates)
     int fb_width = (int)(draw_data->DisplaySize.x * draw_data->FramebufferScale.x);
@@ -237,7 +260,6 @@ void ImGui_ImplSDLGPU3_RenderDrawData(ImDrawData* draw_data, SDL_GPUCommandBuffe
         return;
 
     ImGui_ImplSDLGPU3_Data* bd = ImGui_ImplSDLGPU3_GetBackendData();
-    ImGui_ImplSDLGPU3_FrameData* fd = &bd->MainWindowFrameData;
 
     if (pipeline == nullptr)
         pipeline = bd->Pipeline;
@@ -317,6 +339,25 @@ void ImGui_ImplSDLGPU3_RenderDrawData(ImDrawData* draw_data, SDL_GPUCommandBuffe
     // We perform a call to SDL_SetGPUScissor() to set back a full viewport which is likely to fix things for 99% users but technically this is not perfect. (See github #4644)
     SDL_Rect scissor_rect { 0, 0, fb_width, fb_height };
     SDL_SetGPUScissor(render_pass, &scissor_rect);
+}
+
+// Public wrapper — main viewport uses bd->MainWindowFrameData.
+void ImGui_ImplSDLGPU3_RenderDrawData(ImDrawData* draw_data, SDL_GPUCommandBuffer* command_buffer, SDL_GPURenderPass* render_pass, SDL_GPUGraphicsPipeline* pipeline)
+{
+    ImGui_ImplSDLGPU3_Data* bd = ImGui_ImplSDLGPU3_GetBackendData();
+    ImGui_ImplSDLGPU3_RenderDrawDataImpl(draw_data, command_buffer, render_pass, pipeline, &bd->MainWindowFrameData);
+}
+
+// konCePCja: shared helper used by both DestroyFrameData (for the main FrameData)
+// and Renderer_DestroyWindow (for per-viewport FrameData).
+static void ImGui_ImplSDLGPU3_ReleaseFrameDataBuffers(SDL_GPUDevice* device, ImGui_ImplSDLGPU3_FrameData* fd)
+{
+    if (fd->VertexBuffer)         { SDL_ReleaseGPUBuffer(device, fd->VertexBuffer);                 fd->VertexBuffer = nullptr; }
+    if (fd->IndexBuffer)          { SDL_ReleaseGPUBuffer(device, fd->IndexBuffer);                  fd->IndexBuffer = nullptr; }
+    if (fd->VertexTransferBuffer) { SDL_ReleaseGPUTransferBuffer(device, fd->VertexTransferBuffer); fd->VertexTransferBuffer = nullptr; }
+    if (fd->IndexTransferBuffer)  { SDL_ReleaseGPUTransferBuffer(device, fd->IndexTransferBuffer);  fd->IndexTransferBuffer = nullptr; }
+    fd->VertexBufferSize = 0;
+    fd->IndexBufferSize  = 0;
 }
 
 static void ImGui_ImplSDLGPU3_DestroyTexture(ImTextureData* tex)
@@ -713,6 +754,16 @@ void ImGui_ImplSDLGPU3_NewFrame()
 //   application's gpu_flip_a path, not by these hooks.  We only claim and
 //   render SECONDARY viewports here.
 
+// konCePCja: imgui_impl_sdl3 stores SDL_WindowID (an integer) in
+// viewport->PlatformHandle (changed in 2024-08-19), NOT the SDL_Window*.
+// PlatformHandleRaw is the OS native handle (HWND / NSWindow*) — also
+// not what we want.  Look up the SDL_Window* via SDL_GetWindowFromID.
+static SDL_Window* GetViewportSDLWindow(ImGuiViewport* viewport)
+{
+    SDL_WindowID id = (SDL_WindowID)(intptr_t)viewport->PlatformHandle;
+    return id ? SDL_GetWindowFromID(id) : nullptr;
+}
+
 static void ImGui_ImplSDLGPU3_CreateWindow(ImGuiViewport* viewport)
 {
     ImGui_ImplSDLGPU3_Data* bd = ImGui_ImplSDLGPU3_GetBackendData();
@@ -721,7 +772,7 @@ static void ImGui_ImplSDLGPU3_CreateWindow(ImGuiViewport* viewport)
     auto* vd = IM_NEW(ImGui_ImplSDLGPU3_ViewportData)();
     viewport->RendererUserData = vd;
 
-    SDL_Window* window = (SDL_Window*)viewport->PlatformHandle;
+    SDL_Window* window = GetViewportSDLWindow(viewport);
     if (window != nullptr)
     {
         if (SDL_ClaimWindowForGPUDevice(bd->InitInfo.Device, window))
@@ -756,9 +807,15 @@ static void ImGui_ImplSDLGPU3_DestroyWindow(ImGuiViewport* viewport)
             SDL_SubmitGPUCommandBuffer(vd->CmdBuf);
             vd->CmdBuf = nullptr;
         }
+        if (bd != nullptr)
+        {
+            // Release per-viewport vertex/index/transfer buffers before
+            // releasing the window claim — buffers belong to the device.
+            ImGui_ImplSDLGPU3_ReleaseFrameDataBuffers(bd->InitInfo.Device, &vd->FrameData);
+        }
         if (vd->ClaimedForGPU && bd != nullptr)
         {
-            SDL_Window* window = (SDL_Window*)viewport->PlatformHandle;
+            SDL_Window* window = GetViewportSDLWindow(viewport);
             if (window != nullptr)
                 SDL_ReleaseWindowFromGPUDevice(bd->InitInfo.Device, window);
         }
@@ -777,7 +834,7 @@ static void ImGui_ImplSDLGPU3_RenderWindow(ImGuiViewport* viewport, void*)
 {
     ImGui_ImplSDLGPU3_Data* bd = ImGui_ImplSDLGPU3_GetBackendData();
     auto* vd = (ImGui_ImplSDLGPU3_ViewportData*)viewport->RendererUserData;
-    SDL_Window* window = (SDL_Window*)viewport->PlatformHandle;
+    SDL_Window* window = GetViewportSDLWindow(viewport);
     if (bd == nullptr || vd == nullptr || window == nullptr || !vd->ClaimedForGPU)
         return;
 
@@ -786,8 +843,10 @@ static void ImGui_ImplSDLGPU3_RenderWindow(ImGuiViewport* viewport, void*)
         return;
 
     // PrepareDrawData MUST precede BeginGPURenderPass — it issues its own
-    // copy pass for vertex/index uploads.
-    ImGui_ImplSDLGPU3_PrepareDrawData(viewport->DrawData, cmd);
+    // copy pass for vertex/index uploads.  We pass the viewport's OWN
+    // FrameData so this upload doesn't race the main viewport's still-
+    // in-flight cmd buffer (see ViewportData comment for details).
+    ImGui_ImplSDLGPU3_PrepareDrawDataImpl(viewport->DrawData, cmd, &vd->FrameData);
 
     SDL_GPUTexture* swap_tex = nullptr;
     Uint32 sw = 0, sh = 0;
@@ -805,7 +864,7 @@ static void ImGui_ImplSDLGPU3_RenderWindow(ImGuiViewport* viewport, void*)
         tgt.clear_color = {0.0f, 0.0f, 0.0f, 1.0f};
 
         SDL_GPURenderPass* pass = SDL_BeginGPURenderPass(cmd, &tgt, 1, nullptr);
-        ImGui_ImplSDLGPU3_RenderDrawData(viewport->DrawData, cmd, pass);
+        ImGui_ImplSDLGPU3_RenderDrawDataImpl(viewport->DrawData, cmd, pass, /*pipeline=*/nullptr, &vd->FrameData);
         SDL_EndGPURenderPass(pass);
     }
 

--- a/vendor/imgui/backends/imgui_impl_sdlgpu3.cpp
+++ b/vendor/imgui/backends/imgui_impl_sdlgpu3.cpp
@@ -683,7 +683,6 @@ bool ImGui_ImplSDLGPU3_Init(ImGui_ImplSDLGPU3_InitInfo* info)
     io.BackendRendererName = "imgui_impl_sdlgpu3";
     io.BackendFlags |= ImGuiBackendFlags_RendererHasVtxOffset;  // We can honor the ImDrawCmd::VtxOffset field, allowing for large meshes.
     io.BackendFlags |= ImGuiBackendFlags_RendererHasTextures;   // We can honor ImGuiPlatformIO::Textures[] requests during render.
-    io.BackendFlags |= ImGuiBackendFlags_RendererHasViewports;  // konCePCja: per-viewport renderer hooks installed below when ConfigFlags_ViewportsEnable is set.
 
     IM_ASSERT(info->Device != nullptr);
     IM_ASSERT(info->ColorTargetFormat != SDL_GPU_TEXTUREFORMAT_INVALID);
@@ -694,9 +693,15 @@ bool ImGui_ImplSDLGPU3_Init(ImGui_ImplSDLGPU3_InitInfo* info)
     // turned on ImGuiConfigFlags_ViewportsEnable.  Upstream ImGui 1.92.6 ships
     // the Platform_* side (imgui_impl_sdl3) but leaves Renderer_* unimplemented
     // for SDL_GPU.  Without these hooks any popped-out floating window has no
-    // swapchain claim and cannot render.
+    // swapchain claim and cannot render.  Tie the RendererHasViewports flag to
+    // the hook installation so they cannot disagree — if the app toggles
+    // ViewportsEnable on later without re-Init'ing, ImGui core won't see a
+    // capability we haven't actually wired up.
     if (io.ConfigFlags & ImGuiConfigFlags_ViewportsEnable)
+    {
+        io.BackendFlags |= ImGuiBackendFlags_RendererHasViewports;
         ImGui_ImplSDLGPU3_InitMultiViewportSupport();
+    }
 
     return true;
 }

--- a/vendor/imgui/backends/imgui_impl_sdlgpu3.cpp
+++ b/vendor/imgui/backends/imgui_impl_sdlgpu3.cpp
@@ -642,6 +642,7 @@ bool ImGui_ImplSDLGPU3_Init(ImGui_ImplSDLGPU3_InitInfo* info)
     io.BackendRendererName = "imgui_impl_sdlgpu3";
     io.BackendFlags |= ImGuiBackendFlags_RendererHasVtxOffset;  // We can honor the ImDrawCmd::VtxOffset field, allowing for large meshes.
     io.BackendFlags |= ImGuiBackendFlags_RendererHasTextures;   // We can honor ImGuiPlatformIO::Textures[] requests during render.
+    io.BackendFlags |= ImGuiBackendFlags_RendererHasViewports;  // konCePCja: per-viewport renderer hooks installed below when ConfigFlags_ViewportsEnable is set.
 
     IM_ASSERT(info->Device != nullptr);
     IM_ASSERT(info->ColorTargetFormat != SDL_GPU_TEXTUREFORMAT_INVALID);
@@ -675,7 +676,7 @@ void ImGui_ImplSDLGPU3_Shutdown()
 
     io.BackendRendererName = nullptr;
     io.BackendRendererUserData = nullptr;
-    io.BackendFlags &= ~(ImGuiBackendFlags_RendererHasVtxOffset | ImGuiBackendFlags_RendererHasTextures);
+    io.BackendFlags &= ~(ImGuiBackendFlags_RendererHasVtxOffset | ImGuiBackendFlags_RendererHasTextures | ImGuiBackendFlags_RendererHasViewports);
     platform_io.ClearRendererHandlers();
     IM_DELETE(bd);
 }


### PR DESCRIPTION
## Summary

Bundle of three macOS-impacting UX fixes that together make the SDL_GPU build publishable.

### 1. Set `ImGuiBackendFlags_RendererHasViewports`

ImGui only allows panels to extend outside the main window when BOTH `PlatformHasViewports` and `RendererHasViewports` are set.  `imgui_impl_sdl3` sets the platform flag on Init; the renderer flag is the renderer backend's responsibility.  Without it, dragging a panel by its title bar past the window edge silently clamps it inside.

### 2. Fix sub-window rendering black — use `SDL_Window*`, not `SDL_WindowID`

`imgui_impl_sdl3` stores the `SDL_WindowID` (an integer) in `viewport->PlatformHandle`, not the `SDL_Window*` (changed in upstream 2024-08-19, see line 56 changelog of `imgui_impl_sdl3.cpp`).  Our hooks were casting the integer ID directly to `SDL_Window*` and passing garbage to `SDL_AcquireGPUSwapchainTexture` / `SDL_ClaimWindowForGPUDevice` etc.

Diagnostic showed: \`win=0x6\` (a tiny integer where a heap pointer should be), \`have_swap=0\`, \`sub_fmt=0\` (INVALID).  Vtx/idx counts were >0 so ImGui's draw data was correct — only the SDL window pointer was wrong.

Fix: `GetViewportSDLWindow()` helper that calls `SDL_GetWindowFromID` on the `PlatformHandle` integer, used by all three hooks (Create/Destroy/Render).

### 3. Defensive: per-viewport `FrameData`

`PrepareDrawData` previously used `bd->MainWindowFrameData` for vertex/index uploads regardless of which viewport was rendering.  `cycle=true` on `SDL_UploadToGPUBuffer` should have isolated staging, but the device-side `SDL_GPUBuffer` was still shared.  Added a `FrameData` member to `ViewportData` and refactored `PrepareDrawData` / `RenderDrawData` into static `*Impl` helpers that take an explicit `FrameData*`.  Public API unchanged — main viewport keeps using `bd->MainWindowFrameData` via thin wrappers; sub-viewports pass `&vd->FrameData`.

This wasn't the actual bug for the black-render symptom (the WindowID was) but it's correct architecture — multiple viewports rendering in close sequence shouldn't share staging buffers.

### 4. macOS: restore keyboard focus after native file dialog (long-standing bug)

After **Menu → Media → Load Disk A** (or any `SDL_ShowOpenFileDialog`/Save dialog), keystrokes stopped reaching the emulator until the user clicked the SDL window.  Diagnostic logging at the keyboard gate showed ZERO dropped events post-dialog — SDL_PollEvent never saw `SDL_EVENT_KEY_DOWN` at all.  Not an ImGui-state issue — an OS-level firstResponder issue.

Root cause: `SDL_ShowOpenFileDialog` on macOS uses `NSOpenPanel` as a sheet attached to the parent `NSWindow`.  When the sheet dismisses, AppKit doesn't always restore the SDL content view as the window's firstResponder, so `[NSApp sendEvent:]` routes `keyDown:` to the menu bar instead of `[SDLContentView keyDown:]`.  Without the `keyDown:` hitting the SDL view, SDL never enqueues the event.

Neither `SDL_RaiseWindow` nor `[NSApp activateIgnoringOtherApps:]` is sufficient — those only handle window-level focus.  The fix is at the responder-chain level: explicit `[nswindow makeFirstResponder:contentView]`.

Added `koncpc_restore_keyboard_focus()` (Cocoa helper, dispatch to main queue) and called it from `file_dialog_callback` alongside the existing `request_cpc_screen_focus` flag (which handles the Docked-mode ImGui panel focus separately).  Inline no-op stub for non-Apple platforms keeps the call site portable.

## Verification

- ✅ Built locally on macOS Metal (`scripts/build-macos.sh`)
- ✅ Manual: drag-out floating devtools panels render correctly across Direct, swscale, and CRT plugins
- ✅ Manual: Menu → Media → Load Disk A → pick file → keystrokes resume reaching the CPC immediately

## Background

This restores UX features that were either disabled in PR #117 (Phase 7c.1b) or have been broken for as long as the project has used SDL3's native file dialog.  The "floating viewports cause 20fps + black render" problem documented in project memory was a single-thread-GL artifact — eliminated by the P1.2a render-thread split + native SDL_GPU command queue parallelism.

This PR is what makes the SDL_GPU build of konCePCja publishable.

## Closes

beads-o73 (multi-viewport restoration).

Refs PR #115 (Phase 7c.1b), PR #117 (initial multi-viewport hooks).