### PR TITLE
chore(release): bump version to v5.8.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.21)
-project(koncepcja VERSION 5.7.0 LANGUAGES C CXX)
+project(koncepcja VERSION 5.8.0 LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/src/koncepcja.h
+++ b/src/koncepcja.h
@@ -48,7 +48,7 @@ class InputMapper;
 //#define DEBUG_TAPE
 //#define DEBUG_Z80
 
-#define VERSION_STRING "v5.7.0"
+#define VERSION_STRING "v5.8.0"
 
 #ifndef _MAX_PATH
  #ifdef _POSIX_PATH_MAX


### PR DESCRIPTION
## Why

The previous version bump in PR #118 set master to **v5.7.0**, but the v5.7.0 release shipped on 2026-04-22 and v5.7.1 on 2026-04-23 — both before the SDL_GPU migration arc landed.

Master now contains material additional to the v5.7.1 release:

- Multi-viewport floating devtools restored on SDL_GPU backend (PR #117)
- macOS keyboard focus restored after native file dialog dismiss (PR #118)
- Per-viewport command buffer architecture in \`imgui_impl_sdlgpu3\`
- SPIRV blob auto-compile CI workflow for Linux Vulkan (PR #116)

A minor bump to **v5.8.0** reflects this scope and avoids version-string collisions with the existing v5.7.0 / v5.7.1 release tags.

## Changes

- \`src/koncepcja.h\`: \`VERSION_STRING\` v5.7.0 → v5.8.0
- \`CMakeLists.txt\`: project version 5.7.0 → 5.8.0

## Test plan

- [x] Both files updated in sync (same value in CMake and the C++ macro)
- [ ] CI builds clean (no other code changes)
- [ ] After merge: tag v5.8.0 and cut a release