### PR TITLE
fix(ci): revive scr_style break-gated autocmd (closes the flake source)

### DIFF
--- a/test/integrated/scr_style/test.sh
+++ b/test/integrated/scr_style/test.sh
@@ -65,7 +65,18 @@ do
     fi
   done
   $SED -i "s/^scr_style=.*$/scr_style=${style}/" koncepcja.cfg || rc=2
-  run_with_timeout 20 $KONCPCDIR/koncepcja -c koncepcja.cfg -a "print #8,\"style=${style}\"" -a KONCPC_EXIT >> "${LOGFILE}" 2>&1
+  # Autocmd sequencing: print first, then `call 0` + KONCPC_WAITBREAK to
+  # synchronize on the resulting PC=0 break before KONCPC_EXIT.  Without
+  # the break gate, KONCPC_EXIT fires the same frame the autocmd queue
+  # finishes typing — BASIC has not yet executed the queued PRINT and
+  # the printer file ends up empty.  This was the recurring macOS CI
+  # flake on PRs #101/103/107/108/109/110.  See dsk/test.sh which uses
+  # the same pattern.
+  run_with_timeout 20 $KONCPCDIR/koncepcja -c koncepcja.cfg \
+      -a "print #8,\"style=${style}\"" \
+      -a "call 0" \
+      -a KONCPC_WAITBREAK \
+      -a KONCPC_EXIT >> "${LOGFILE}" 2>&1
 
   mv ${OUTPUT_DIR}/printer.dat ${OUTPUT_DIR}/printer.dat.${style}
   if ! $DIFF ${OUTPUT_DIR}/printer.dat.${style} model/printer.dat.${style} >> "${LOGFILE}"

--- a/test/integrated/scr_style/test.sh
+++ b/test/integrated/scr_style/test.sh
@@ -72,7 +72,7 @@ do
   # the printer file ends up empty.  This was the recurring macOS CI
   # flake on PRs #101/103/107/108/109/110.  See dsk/test.sh which uses
   # the same pattern.
-  run_with_timeout 20 $KONCPCDIR/koncepcja -c koncepcja.cfg \
+  run_with_timeout 20 "$KONCPCDIR/koncepcja" -c koncepcja.cfg \
       -a "print #8,\"style=${style}\"" \
       -a "call 0" \
       -a KONCPC_WAITBREAK \


### PR DESCRIPTION
## Why

PR #119's macOS CI failed on \`scr_style=2\` with the printer.dat-empty signature. Same fingerprint as the flake on PRs #101/#103/#107/#108/#109/#110 — every one needed 1–3 retriggers.

Investigation found the fix already exists in commit \`88dd745\` on branch \`fix/ci-flake-autocmd-sync\`, originally PR #111. **PR #111 was closed without merging** on 2026-04-26, so the fix never reached master. This PR resurrects just the \`test.sh\` portion (the boot_time bump from #111 was correctly reverted in \`5ad9b3a\` and is excluded here).

## The race

Old autocmd: \`print #8,…\` → \`KONCPC_EXIT\`. Because emulator commands process with no inter-event pause, KONCPC_EXIT could fire on the same frame the trailing newline of the PRINT was typed — BASIC hadn't yet executed the queued PRINT, so printer.dat was empty, diff failed, plugin reported broken.

New autocmd (mirrors dsk pattern): \`print #8,…\` → \`call 0\` → \`KONCPC_WAITBREAK\` → \`KONCPC_EXIT\`. The CALL 0 transitions PC to 0, KONCPC_WAITBREAK gates the queue on that break, and KONCPC_EXIT only fires after BASIC has finished.

## Why this matters now

User flagged that this flake \"could blow up a release artifact build\" — and they're right. Every retriggered run wastes CI minutes and erodes confidence; a release pipeline that doesn't auto-retry would just fail.

## Test plan

- [x] Diff reviewed against \`88dd745\` — minus the rejected boot_time hunk
- [ ] CI passes on the first try (would have failed pre-fix)
- [ ] After merge: confirm subsequent PRs no longer need retriggers