### PR TITLE
ci(msvc): publish Windows release artifacts on tagged releases

### DIFF
--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -74,12 +74,13 @@ jobs:
           Write-Host "Running: $testRunner"
           & $testRunner --gtest_shuffle
 
-      # ── Package (Release x64 + ARM64 only) ─────────────
-      # Skip Debug (~3x larger, slower, not for end users) and Win32 (32-bit
-      # is legacy; modern Windows is 64-bit).  Bundles koncepcja.exe with
-      # the runtime DLLs from vcpkg so users don't need vcpkg installed.
+      # ── Package (Release builds across all architectures) ─────────────
+      # Skip Debug (~3x larger, slower, not for end users).  Win32 stays
+      # in — this is a retro emulator and our users include people on 32-bit
+      # Windows / older hardware.  Bundles koncepcja.exe with the runtime
+      # DLLs from vcpkg so users don't need vcpkg installed.
       - name: Package Windows release
-        if: matrix.config == 'Release' && matrix.arch != 'Win32'
+        if: matrix.config == 'Release'
         shell: pwsh
         run: |
           $stageName = "koncepcja-windows-${{ matrix.arch }}"
@@ -110,7 +111,7 @@ jobs:
 
       # ── Upload as CI artifact (always, for PR/branch builds) ──
       - name: Upload Windows artifact
-        if: matrix.config == 'Release' && matrix.arch != 'Win32'
+        if: matrix.config == 'Release'
         uses: actions/upload-artifact@v4
         with:
           name: koncepcja-windows-${{ matrix.arch }}
@@ -119,7 +120,7 @@ jobs:
 
       # ── Attach to GitHub Release (only on tagged release events) ──
       - name: Publish release
-        if: github.event_name == 'release' && startsWith(github.event.release.tag_name, 'v') && matrix.config == 'Release' && matrix.arch != 'Win32'
+        if: github.event_name == 'release' && startsWith(github.event.release.tag_name, 'v') && matrix.config == 'Release'
         uses: softprops/action-gh-release@v2
         with:
           files: release/koncepcja-windows-${{ matrix.arch }}.zip

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -73,3 +73,53 @@ jobs:
           }
           Write-Host "Running: $testRunner"
           & $testRunner --gtest_shuffle
+
+      # ── Package (Release x64 + ARM64 only) ─────────────
+      # Skip Debug (~3x larger, slower, not for end users) and Win32 (32-bit
+      # is legacy; modern Windows is 64-bit).  Bundles koncepcja.exe with
+      # the runtime DLLs from vcpkg so users don't need vcpkg installed.
+      - name: Package Windows release
+        if: matrix.config == 'Release' && matrix.arch != 'Win32'
+        shell: pwsh
+        run: |
+          $stageName = "koncepcja-windows-${{ matrix.arch }}"
+          $stage = "release/$stageName"
+          New-Item -ItemType Directory -Force -Path $stage | Out-Null
+
+          $exe = Get-ChildItem -Path build -Recurse -Filter koncepcja.exe -ErrorAction SilentlyContinue | Select-Object -First 1
+          if (-not $exe) {
+            Write-Error "koncepcja.exe not found under build/"
+            exit 1
+          }
+          Copy-Item $exe.FullName $stage
+
+          $vcpkgBin = "build/vcpkg_installed/${{ matrix.triplet }}/bin"
+          if (Test-Path $vcpkgBin) {
+            Get-ChildItem -Path $vcpkgBin -Filter *.dll | Copy-Item -Destination $stage
+          }
+
+          # Include koncepcja.cfg.tmpl as a starter config so users have one
+          if (Test-Path koncepcja.cfg.tmpl) {
+            Copy-Item koncepcja.cfg.tmpl "$stage/koncepcja.cfg"
+          }
+
+          $zipPath = "release/$stageName.zip"
+          Compress-Archive -Path "$stage/*" -DestinationPath $zipPath -Force
+          Write-Host "Packaged $zipPath"
+          Get-Item $zipPath | Select-Object Name, Length
+
+      # ── Upload as CI artifact (always, for PR/branch builds) ──
+      - name: Upload Windows artifact
+        if: matrix.config == 'Release' && matrix.arch != 'Win32'
+        uses: actions/upload-artifact@v4
+        with:
+          name: koncepcja-windows-${{ matrix.arch }}
+          path: release/koncepcja-windows-${{ matrix.arch }}.zip
+          if-no-files-found: error
+
+      # ── Attach to GitHub Release (only on tagged release events) ──
+      - name: Publish release
+        if: github.event_name == 'release' && startsWith(github.event.release.tag_name, 'v') && matrix.config == 'Release' && matrix.arch != 'Win32'
+        uses: softprops/action-gh-release@v2
+        with:
+          files: release/koncepcja-windows-${{ matrix.arch }}.zip


### PR DESCRIPTION
## Why

\`v5.7.1\` and earlier release pages only have macOS DMG + source artifacts — **no Windows binaries**. Looking at \`.github/workflows/msvc.yml\`, the cause is straightforward: the workflow has a \`release\` trigger but never actually publishes anything. It builds + tests across 6 matrix configurations and stops there.

Meanwhile \`.github/workflows/macos.yml\` lines 129–144 has the proper \`softprops/action-gh-release@v2\` upload pattern. This PR ports the same shape to MSVC.

## What ships

Three new steps appended to msvc.yml, gated to **Release × {x64, ARM64}** only:

1. **Package** — bundles \`koncepcja.exe\` + the vcpkg runtime DLLs (freetype, png, zlib, etc.) + a starter \`koncepcja.cfg\` into \`koncepcja-windows-{x64,arm64}.zip\` so end-users don't need vcpkg installed.
2. **Upload CI artifact** — \`actions/upload-artifact@v4\` attaches the zip to every push/PR run (GitHub's default ~90-day lifetime). Contributors can grab a working Windows binary from any green run.
3. **Publish to release** — \`softprops/action-gh-release@v2\` uploads to the GitHub Release on tagged \`v*\` releases.

## Skipped configurations and why

- **Debug builds** — ~3× larger, not for end users
- **Win32 (32-bit)** — modern Windows is 64-bit; the legacy 32-bit niche isn't worth a 50% bigger release page

If users specifically request Win32, easy to add later.

## Test plan

- [ ] CI passes (the test job — pre-existing — still runs as before)
- [ ] After merge: green build on \`master\` produces a downloadable \`koncepcja-windows-x64\` artifact in Actions UI
- [ ] On v5.9.0 release (or whenever you cut next): both \`koncepcja-windows-x64.zip\` and \`koncepcja-windows-arm64.zip\` appear on the Release page alongside the macOS DMG