### PR TITLE
fix(ci): bundle ROMs, resources and a usable cfg in Windows release zip

### DIFF
--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -99,9 +99,21 @@ jobs:
             Get-ChildItem -Path $vcpkgBin -Filter *.dll | Copy-Item -Destination $stage
           }
 
-          # Include koncepcja.cfg.tmpl as a starter config so users have one
+          # ROM files are required to boot — without them emulator_init() aborts.
+          if (Test-Path rom) {
+            Copy-Item -Recurse rom "$stage/rom"
+          }
+          if (Test-Path resources) {
+            Copy-Item -Recurse resources "$stage/resources"
+          }
+          if (Test-Path licenses) {
+            Copy-Item -Recurse licenses "$stage/licenses"
+          }
+
+          # Strip the __SHARE_PATH__ placeholder so paths resolve relative to the exe.
           if (Test-Path koncepcja.cfg.tmpl) {
-            Copy-Item koncepcja.cfg.tmpl "$stage/koncepcja.cfg"
+            (Get-Content koncepcja.cfg.tmpl) -replace '__SHARE_PATH__/?', '' |
+              Set-Content "$stage/koncepcja.cfg"
           }
 
           $zipPath = "release/$stageName.zip"


### PR DESCRIPTION
## Summary

- The Windows x64 release zip (`koncepcja-windows-x64.zip` from v5.8.0-1) aborted on launch with `Couldn't open ROM file '__SHARE_PATH__/rom/cpc6128.rom'` — `emulator_init() failed. Aborting.`
- Root cause: the MSVC packaging step in `.github/workflows/msvc.yml` shipped only the .exe + vcpkg DLLs + an unsubstituted `koncepcja.cfg.tmpl`. No `rom/`, no `resources/`, no `licenses/`, and the cfg still contained literal `__SHARE_PATH__` tokens.
- Fix: copy `rom/`, `resources/`, `licenses/` into the staging dir and substitute `__SHARE_PATH__/?` → `''` when generating `koncepcja.cfg`, mirroring what `makefile:326,347,361,388,457` already does for the Linux/macOS bundles.

`SDL3.dll` is intentionally absent — `CMakeLists.txt:27-28` sets `SDL_STATIC ON` and the exe links `SDL3::SDL3-static`, so SDL3 is baked into the binary.

## Test plan

- [ ] CI artifact `koncepcja-windows-x64` from this PR contains `rom/`, `resources/`, `licenses/`, and a `koncepcja.cfg` with `rom_path=rom` (no `__SHARE_PATH__`).
- [ ] Download the artifact, extract to a clean dir, run `koncepcja.exe` — emulator boots without the ROM error.
- [ ] After merge + tagged release, confirm the published GitHub Releases zip has the same contents.