### PR TITLE
ci: hand release-please a PAT so releases trigger the binary builds

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,6 +10,15 @@ name: release-please
 # Note: requires "Allow GitHub Actions to create and approve pull requests"
 # (Settings → Actions → General → Workflow permissions) so the default
 # GITHUB_TOKEN can open the release PR.
+#
+# The RELEASE_PLEASE_TOKEN secret (a fine-grained PAT: Contents + Pull
+# requests read/write) is REQUIRED, deliberately with no GITHUB_TOKEN
+# fallback: a release published with the default GITHUB_TOKEN cannot
+# trigger other workflows (GitHub's anti-recursion rule), so the
+# linux/macos/msvc `release: [published]` jobs that attach the platform
+# binaries would never fire. If the PAT expires this job fails loudly on
+# the next master push — that is the intended signal to mint a new one
+# (a silent fallback would ship binary-less releases instead).
 
 on:
   push:
@@ -27,6 +36,6 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -20,7 +20,7 @@ The SPS Decoder Library (capsimg), once vendored under `src/capsimg/` for
 IPF flux decoding, is **gone**: its non-commercial license was incompatible
 with redistribution, so it was replaced by the clean-room decoder in
 `src/ipf_decode.{h,cpp}` (built solely from `docs/hardware/ipf-format.md`)
-and deleted — see the `ipf.cpp/h` row in the replacement ledger and
+and deleted — see the `ipf.{cpp,h}` row in the replacement ledger and
 `NOTICE.md`.
 
 `src/argparse.{cpp,h}` is **not** a third-party library despite the name and

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -13,9 +13,15 @@ intact. They are relocated, not rewritten.
 | msf_gif | `vendor/msf_gif/` | https://github.com/notnullnotvoid/msf_gif | MIT OR Unlicense | Single-header GIF encoder used by the session GIF recorder (`src/gif_recorder.cpp`) |
 | ImGuiColorTextEdit | `vendor/ImGuiColorTextEdit/` | https://github.com/santaclose/ImGuiColorTextEdit (fork of https://github.com/BalazsJako/ImGuiColorTextEdit) | MIT | Colorizing text editor widget backing the DevTools Z80 assembler editor (`src/devtools_ui.cpp`); konCePCja adds a `Z80Assembly()` language definition downstream in `LanguageDefinitions.cpp`, following the file's own pattern |
 | portable-file-dialogs | `vendor/portable-file-dialogs/` | https://github.com/samhocevar/portable-file-dialogs | WTFPL | Native OS file-open/save dialogs used by the DevTools menus (`src/devtools_ui.cpp`, `src/kon_cpc_ja.cpp`) |
-| capsimg | `src/capsimg/` | Applied Engineering / SPS / CAPS project (see `src/capsimg/README.md` and `src/capsimg/LICENCE.txt`) | See upstream LICENCE.txt | IPF/CTRaw flux decoding for the disc flux layer. Intentionally left under `src/` rather than moved here — it already carries its own README/LICENCE and directory structure and was vendored as a self-contained unit before this sweep; replacing its IPF decoder with a clean-room implementation is a separate, later decision (see the replacement ledger) |
 
 ## What does NOT belong here
+
+The SPS Decoder Library (capsimg), once vendored under `src/capsimg/` for
+IPF flux decoding, is **gone**: its non-commercial license was incompatible
+with redistribution, so it was replaced by the clean-room decoder in
+`src/ipf_decode.{h,cpp}` (built solely from `docs/hardware/ipf-format.md`)
+and deleted — see the `ipf.cpp/h` row in the replacement ledger and
+`NOTICE.md`.
 
 `src/argparse.{cpp,h}` is **not** a third-party library despite the name and
 despite being listed as one in an earlier pass of the replacement ledger.


### PR DESCRIPTION
A release published with the workflow's own GITHUB_TOKEN cannot fire other workflows (GitHub anti-recursion), so v6.0.0 initially shipped with no binaries until it was draft-toggled and re-published under a user token. release-please now uses the `RELEASE_PLEASE_TOKEN` fine-grained PAT (Contents + Pull requests, this repo only; already set as a repo secret) — deliberately with **no GITHUB_TOKEN fallback**, so an expired PAT fails loudly on the next master push instead of silently shipping binary-less releases.

Also drops the stale capsimg row from `vendor/README.md`: the SPS Decoder Library was deleted in favour of the clean-room `src/ipf_decode` (see the replacement ledger and NOTICE.md).