### PR TITLE
fix(light-gun): tick the gun under Wake + Fast; ci(linux): resolve vendored SDL path

### DIFF
--- a/docs/hardware/light-gun-device.md
+++ b/docs/hardware/light-gun-device.md
@@ -109,9 +109,11 @@ void   light_gun_set_aim(const Device* dev, uint16_t line, uint16_t col);
 void   light_gun_set_trigger(const Device* dev, int pressed);
 ```
 
-`set_type(0)` is the unplug (dormant in `recompose_active`; degrades the
-effective tier to Faithful when plugged — no wake contract, the Symbiface/
-serial precedent, so the strobe path need not thread through `wake_slot`).
+`set_type(0)` is the unplug (dormant in `recompose_active`). Plugged, the gun
+carries a **wake contract** (it ticks with the CRTC) and a **Fast batch
+contract** (char-by-char advance), so it no longer degrades the effective tier
+— Wake stays the default and Fast stays engaged with a gun fitted. See the
+batch-contract section below.
 
 ## 6. Acid tests
 
@@ -126,11 +128,33 @@ serial precedent, so the strobe path need not thread through `wake_slot`).
    their reset value (no legacy increment).
 4. **Unplugged neutral**: `set_type(0)`; the four canonical CKSUMs unchanged
    (strobe never asserts; the CRTC latch never runs).
-5. **Tier**: plugging degrades the effective tier to Faithful (recompose);
-   the latch is identical Faithful vs Soldered.
+5. **Tier oracle**: with the gun plugged and the trigger held, the latched
+   R16/R17 agrees across Soldered, Wake and Fast (`LightGun.
+   TierLatchAgreesSolderedWakeFast`). Unplugged, the four canonical CKSUMs are
+   unchanged (strobe never asserts; the CRTC latch never runs).
 
-## Batch contract (RunTier::Fast)
+## Batch contracts (Wake / Fast)
 
-None needed: an active gun forces Faithful (§5), so the strobe/latch path
-never runs under the wake/fast schedulers. Unplugged, the gun contributes no
-events and `pen.strobe` rests LOW — elision-eligible, byte-exact neutral.
+The gun drives `pen.strobe` only on `clk.crtc` (once per char), so it slots
+into the schedulers as a CRTC-shadowing peripheral. Both batched tiers must
+reproduce the per-cycle timing: the gun reads the committed bus, so it tracks
+the beam **one char behind** the CRTC, and the CRTC latches the char it has
+just advanced to — i.e. the char **after** the one the gun saw.
+
+The per-cycle strobe is a **one-master-cycle pulse per char** (the line rests
+LOW between char ticks), so the CRTC's edge detector re-arms every char and
+latches **every** in-window char, the last winning. The batched latch is
+therefore **level-sensitive** (`crtc_batch_lpen_latch`), NOT edge-triggered —
+feeding a per-char pulse into the edge-triggered `crtc_fast_lpen_strobe`
+latches only the first char of a run (the original Fast bug).
+
+- **Wake** (`wake_slot`): tick the gun on `clk.crtc` with the committed bus;
+  `crtc_tick` advances the char, then `crtc_batch_lpen_latch(gun_strobe)`
+  latches it. `crtc_tick`'s own `pen.strobe` handler stays inert because the
+  committed `pen.strobe` is LOW at a char boundary.
+- **Fast** (`fs_advance_chars`): advance one char at a time, tick the gun with
+  that char's view, defer its decision by one char, and
+  `crtc_batch_lpen_latch` the next char.
+
+Unplugged, the gun contributes no events and `pen.strobe` rests LOW —
+elision-eligible, byte-exact neutral.

--- a/makefile
+++ b/makefile
@@ -83,13 +83,22 @@ endif
 PKG_SDL_CFLAGS=`pkg-config --cflags sdl3`
 PKG_SDL_LIBS=`pkg-config --libs sdl3`
 # SDL_image optional support removed; PNG loads via libpng
-ifeq ($(ARCH),macos)
+# Resolve the vendored SDL via WORKSPACE-RELATIVE paths, not pkg-config.
+# pkg-config reads the install's sdl3.pc, whose baked-in ABSOLUTE prefix breaks
+# whenever the checkout moves: the konCePCja -> koncepcja_v5 repo rename left a
+# stale cached prefix (/home/runner/work/konCePCja/...) that no longer exists on
+# the case-sensitive Linux runner, so pkg-config --cflags sdl3 returned a bogus
+# -I and every SDL3/*.h include failed (the Linux + Coverage CI red). The
+# submodule headers and the built lib are always at these workspace-relative
+# locations, immune to renames. USE_VENDORED_SDL=0 opts back into pkg-config.
 ifeq ($(USE_VENDORED_SDL),1)
 PKG_SDL_CFLAGS=$(SDL_VENDOR_INCLUDE)
 PKG_SDL_LIBS=$(SDL_VENDOR_LIBS)
 ifeq ($(ARCH),macos)
 LDFLAGS += -Wl,-rpath,@executable_path/$(SDL_VENDOR_BUILD)/lib
 endif
+ifeq ($(ARCH),linux)
+LDFLAGS += -Wl,-rpath,'$$ORIGIN/$(SDL_VENDOR_BUILD)/lib'
 endif
 endif
 IPATHS = -Isrc/ -isystem vendor/imgui -isystem vendor/imgui/backends -isystem vendor/msf_gif -isystem vendor/ImGuiColorTextEdit -isystem vendor/portable-file-dialogs `pkg-config --cflags freetype2` $(PKG_SDL_CFLAGS) `pkg-config --cflags libpng` `pkg-config --cflags zlib`

--- a/src/hw/crtc.cpp
+++ b/src/hw/crtc.cpp
@@ -619,4 +619,16 @@ void crtc_fast_lpen_strobe(const Device* dev, bool level) {
   c->lpen_prev = level;
 }
 
+void crtc_batch_lpen_latch(const Device* dev, bool level) {
+  crtc_state* c = static_cast<crtc_state*>(dev->self);
+  // Level-sensitive (see crtc.h): latch ma on every in-window char, not just
+  // the edge. lpen_prev is carried (not used for the decision) so a following
+  // crtc_tick / tier handover inherits a consistent shadow.
+  if (level) {
+    c->reg[16] = static_cast<uint8_t>((c->ma >> 8) & 0x3F);
+    c->reg[17] = static_cast<uint8_t>(c->ma & 0xFF);
+  }
+  c->lpen_prev = level;
+}
+
 }  // extern "C"

--- a/src/hw/crtc.h
+++ b/src/hw/crtc.h
@@ -136,6 +136,18 @@ int crtc_fast_io_read(const Device* dev, uint16_t port, uint8_t* out);
  * is the char's fetch address, matching crtc_tick's post-crtc_char strobe
  * check. */
 void crtc_fast_lpen_strobe(const Device* dev, bool level);
+
+/* Latch ma into R16/R17 whenever `level` is high — LEVEL-sensitive, the batch
+ * twin for a per-char-PULSED LPEN source (the light gun). Distinct from
+ * crtc_fast_lpen_strobe (edge-triggered, for a held LPEN level): in the
+ * per-cycle tiers the gun's strobe is a one-master-cycle pulse per char, so the
+ * CRTC's edge detector re-arms between chars and latches EVERY in-window char,
+ * the last winning. The batched Wake/Fast dispatch ticks the gun once per char
+ * and passes its out->pen.strobe decision; this latches each in-window char the
+ * same way. Call AFTER advancing the CRTC to the latch char so c->ma is that
+ * char's fetch address. The lpen_prev shadow is kept in step so an I/O-wake
+ * crtc_tick or a tier handover sees no spurious edge. */
+void crtc_batch_lpen_latch(const Device* dev, bool level);
 /* Select which 6845 variant is soldered in (0..3, default 0). A hardware strap:
  * persists across reset. Program-visible differences: register readability, the
  * type-1 status register, R3 sync widths, R8 DISPTMG skew (see the spec §5). */

--- a/src/hw/light_gun.cpp
+++ b/src/hw/light_gun.cpp
@@ -30,6 +30,13 @@ void light_gun_tick(void* self, const Bus* __restrict in, Bus* __restrict out) {
   light_gun_state* g = self_of(self);
   if (g->type == 0) return;  // unplugged: never drives the strobe
 
+  // The host feeds aim_col in character columns
+  // (docs/hardware/light-gun-device.md §4), so advance the beam-column tracker
+  // once per CRTC character.  In the per-cycle paths this means gating on
+  // clk.crtc; in the batch Fast path the caller ticks us once per
+  // crtc_advance_view char.
+  if (!in->clk.crtc) return;
+
   const uint16_t line = in->vid.frame_line;
   const bool dispen = in->vid.dispen;
 

--- a/src/subcycle/machine.cpp
+++ b/src/subcycle/machine.cpp
@@ -669,7 +669,31 @@ void Machine::wake_slot(const Bus& cur, Bus& next) {
     if (cur.cpu.irq) next.cpu.irq = true;
     wk_ga_skip_++;
   }
-  if (w_crtc) cdev_.tick(cdev_.self, in, &next);
+  // Light gun: tick on char boundaries (clk.crtc) with the committed bus so it
+  // tracks the beam one char behind the CRTC exactly as in the per-cycle tiers,
+  // then latch the char the CRTC has just advanced to (the per-cycle path
+  // publishes the strobe one master cycle after the gun ticks, and the CRTC
+  // latches that same char — the one after the gun's view).  crtc_tick's own
+  // pen.strobe handler stays inert here: at a char boundary the committed
+  // pen.strobe is LOW (the gun drives it only on clk.crtc and the line rests
+  // between char ticks), so the level-sensitive batch latch owns the decision.
+  // The whole block is skipped on the common unplugged machine, leaving the
+  // plain CRTC tick.
+  if (w_crtc) {
+    if (wk_light_gun_on_) {
+      bool gun_strobe = false;
+      if (cur.clk.crtc) {
+        Bus lg_next = bus_resting();
+        lgdev_.tick(lgdev_.self, in, &lg_next);
+        gun_strobe = lg_next.pen.strobe;
+        next.pen.strobe = gun_strobe;
+      }
+      cdev_.tick(cdev_.self, in, &next);
+      if (cur.clk.crtc) crtc_batch_lpen_latch(&cdev_, gun_strobe);
+    } else {
+      cdev_.tick(cdev_.self, in, &next);
+    }
+  }
   if (w_ppi) pdev_.tick(pdev_.self, in, &next);
   if (w_psg) sdev_.tick(sdev_.self, in, &next);
   if (w_mem) mdev_.tick(mdev_.self, in, &next);
@@ -944,11 +968,11 @@ void Machine::fs_advance_chars(uint64_t target) {
     fs_pend_cap_ = cap;
   }
   CrtcCharView* views = fs_pend_buf_.get() + fs_pend_tail_;
-  crtc_advance_view(&cdev_, n, views);
   uint32_t last_line = 0xFFFFFFFF;  // 16-bit frame_line: the first view always
                                     // relays (asic_batch_frame_line dedupes)
-  for (uint32_t i = 0; i < n; ++i) {
-    CrtcCharView& view = views[i];
+  // Per-view work shared between the bulk (closed-form) and light-gun
+  // (char-by-char) paths.  Kept as a local lambda so both arms stay in sync.
+  auto apply_view = [this, &last_line](CrtcCharView& view) {
     if (view.edges & (1u << CRTC_EDGE_VSYNC_RISE)) {
       ga_batch_vsync_rise(&gdev_);
       if (++fs_frames_seen_ >= fs_target_) fs_cut_ = true;
@@ -966,6 +990,35 @@ void Machine::fs_advance_chars(uint64_t target) {
     view.mode = ga_current_mode(&gdev_);  // the latch as of THIS char —
                                           // stamped in edge order
     fs_vpages_ |= static_cast<uint8_t>(1u << ((view.ma >> 12) & 3));
+  };
+
+  if (fs_lpen_on_) {
+    // Light-gun Fast contract: advance one char at a time so c->ma sits at the
+    // latch char.  The per-cycle tiers publish the gun's strobe one master
+    // cycle after the gun ticks, and the CRTC then latches the char it has just
+    // advanced to — i.e. the char AFTER the one the gun saw.  Mirror that here:
+    // tick the gun with this char's view, defer its decision by one char, and
+    // latch the next char.  The latch is LEVEL-sensitive
+    // (crtc_batch_lpen_latch) because the gun pulses per char, so a held
+    // trigger latches every in-window char, not just the first of a run.
+    for (uint32_t i = 0; i < n; ++i) {
+      CrtcCharView& view = views[i];
+      crtc_advance_view(&cdev_, 1, &view);
+      apply_view(view);
+      crtc_batch_lpen_latch(&cdev_, fs_lpen_pending_);
+      Bus lg_in = bus_resting();
+      lg_in.clk.crtc = true;
+      lg_in.vid.frame_line = view.frame_line;
+      lg_in.vid.dispen = (view.levels & CRTC_LVL_DISPEN) != 0;
+      Bus lg_out = bus_resting();
+      lgdev_.tick(lgdev_.self, &lg_in, &lg_out);
+      fs_lpen_pending_ = lg_out.pen.strobe;
+    }
+  } else {
+    crtc_advance_view(&cdev_, n, views);
+    for (uint32_t i = 0; i < n; ++i) {
+      apply_view(views[i]);
+    }
   }
   fs_pend_tail_ += n;
   fs_chars_ = target;
@@ -1291,6 +1344,13 @@ bool Machine::run_frame_fast(VideoRegs& vr, uint32_t target) {
   fs_cut_ = false;
   fs_bail_ = false;
   fs_asic_on_ = asic_vid_active(&adev_) != 0;
+  {
+    LightGunRegs lg{};
+    light_gun_peek(&lgdev_, &lg);
+    fs_lpen_on_ = lg.plugged != 0;
+  }
+  fs_lpen_pending_ =
+      false;  // no deferred latch carries into this frame's batch
   fs_fdc_hot_ = fdc_quiet(&fdev_) == 0;  // gate said quiet; stay honest
   fs_irq_cache_ = fs_irq() ? 1 : 0;      // the boundary-0 poll (zero chars)
   fs_irq_tmax_ = 0;  // first real boundary computes a horizon
@@ -1492,14 +1552,18 @@ void Machine::recompose_active() {
   // contract in the scheduler — fall back to Faithful.
   wake_valid_ = true;
   wk_serial_on_ = false;
+  wk_light_gun_on_ = false;
   for (int k = 0; k < board_.active_count; ++k) {
     const int idx = board_.tick_order[k];
     const void* dself = board_.dev[idx].self;
-    // The RS232+plotter pair now carries a wake contract (wake_slot dispatches
-    // it on its own quiet/iorq predicate), so it no longer degrades the tier.
+    // The RS232+plotter pair and the light gun now carry wake contracts
+    // (wake_slot dispatches each on its own predicate), so they no longer
+    // degrade the tier.
     const bool serial = dself == rsdev_.self || dself == pldev_.self;
+    const bool light_gun = dself == lgdev_.self;
     if (serial) wk_serial_on_ = true;
-    const bool known = idx <= 10 || dself == adev_.self || serial;
+    if (light_gun) wk_light_gun_on_ = true;
+    const bool known = idx <= 10 || dself == adev_.self || serial || light_gun;
     if (!known) {
       wake_valid_ = false;
       break;
@@ -1589,6 +1653,11 @@ void Machine::run_frame() {
     wk_probe_on_ = probe_active(&prdev_) != 0;
     wk_asic_on_ = asic_vid_active(&adev_) != 0;
     wk_fdc_quiet_ = fdc_quiet(&fdev_) != 0;  // snapshot loads / host pokes
+    {
+      LightGunRegs lg{};
+      light_gun_peek(&lgdev_, &lg);
+      wk_light_gun_on_ = lg.plugged != 0;
+    }
     // Serial pair quiet snapshot: unplugged ⇒ always quiet (never blocks
     // elision); plugged ⇒ the real UART-idle state, so a byte in flight at
     // frame start keeps the pair (and elision) awake from slot 0.

--- a/src/subcycle/machine.h
+++ b/src/subcycle/machine.h
@@ -422,8 +422,9 @@ class Machine {
   // The light gun (Magnum Phaser / Trojan — light-gun-device.md). Its LPEN
   // strobe drives the CRTC light-pen latch; the aim is in CRTC beam space
   // (scanline + active char column), converted from the host mouse by the
-  // bridge. type 0 unplugs it; plugging degrades the effective tier to
-  // Faithful (recompose_active: no wake contract — the serial precedent).
+  // bridge. type 0 unplugs it; plugged, it carries a wake contract (ticks with
+  // the CRTC) and a Fast batch contract (char-by-char advance), so it no longer
+  // degrades the tier.
   const Device* light_gun() const { return &lgdev_; }
   void set_light_gun(int type, uint16_t aim_line, uint16_t aim_col,
                      bool pressed) {
@@ -576,6 +577,7 @@ class Machine {
                                     // so the DART/PIT see the select strobe
                                     // drop and reset their access edge (else
                                     // only the first OUT of a burst registers).
+  bool wk_light_gun_on_ = false;  // light gun plugged this frame (contract on)
 
   // Number of devices the soldered fast path (tick_soldered) calls by name. The
   // fast tier is valid only when the board's device set matches this (see
@@ -608,7 +610,13 @@ class Machine {
   bool fs_asic_on_ = false;   // entry cache: the ASIC is plugged (Plus)
   bool fs_bail_ = false;      // leave the frame to the per-cycle loop (a
                               // mid-frame DMA enable — F7 scope note)
-  uint32_t fs_target_ = 0;    // video frames target this run
+  bool fs_lpen_on_ = false;   // entry cache: light gun plugged (Fast char loop)
+  bool fs_lpen_pending_ = false;  // the deferred LPEN latch (fire at char K →
+                                  // latch char K+1). fs_advance_chars runs in
+                                  // incremental chunks within a frame, so this
+                                  // must persist across calls — a local would
+                                  // drop a fire on a chunk's final char.
+  uint32_t fs_target_ = 0;        // video frames target this run
   uint32_t fast_frames_run_ = 0;  // frames the batch driver completed (an
                                   // engagement signal: tests + the tier UI)
   uint32_t fs_frames_seen_ = 0;   // frames at entry + eager-counted rises

--- a/test/hw/light_gun_test.cpp
+++ b/test/hw/light_gun_test.cpp
@@ -8,10 +8,15 @@
 #include <gtest/gtest.h>
 
 #include <cstdint>
+#include <cstdio>
+#include <fstream>
+#include <iterator>
+#include <string>
 #include <vector>
 
 #include "hw/board.h"
 #include "hw/crtc.h"
+#include "subcycle/machine.h"
 
 namespace {
 
@@ -210,4 +215,83 @@ TEST(LightGun, SnapshotRoundTrip) {
     ASSERT_EQ(ra.reg[16], rb.reg[16]) << "diverged at " << i;
     ASSERT_EQ(ra.reg[17], rb.reg[17]) << "diverged at " << i;
   }
+}
+
+// ---------------------------------------------------------------------------
+// Tier oracle: the light-pen latch must agree across Soldered, Wake and Fast
+// when a gun is plugged and the trigger is held.  This is the integration test
+// that catches the wake_slot / run_frame_fast omission (beads-g4jq).
+// ---------------------------------------------------------------------------
+
+namespace {
+
+std::vector<uint8_t> load_rom_file(const char* path) {
+  std::ifstream file(path, std::ios::binary);
+  return {std::istreambuf_iterator<char>(file),
+          std::istreambuf_iterator<char>()};
+}
+
+std::vector<uint8_t> load_system_rom() {
+  std::vector<uint8_t> rom = load_rom_file("rom/cpc6128.rom");
+  if (rom.size() < 0x8000) rom = load_rom_file("../rom/cpc6128.rom");
+  return rom;
+}
+
+constexpr size_t kFbLen =
+    static_cast<size_t>(subcycle::kFbWidth) * subcycle::kFbHeight * 3;
+
+// Build a 6128, plug the gun, and run enough frames for the beam to sweep the
+// aim point.  Returns the latched light-pen address (R16/R17) and the final
+// framebuffer hash so we can assert observation-identicality across tiers.
+struct LpenResult {
+  uint16_t ma;
+  uint32_t fast_frames;
+};
+
+LpenResult run_with_tier(const std::vector<uint8_t>& rom,
+                         subcycle::Machine::RunTier tier, uint16_t aim_line,
+                         uint16_t aim_col) {
+  subcycle::Machine machine;
+  std::vector<uint8_t> fb(kFbLen, 0);
+  if (!machine.build(rom.data(), rom.size())) return {0, 0};
+  machine.attach_framebuffer(fb.data(), subcycle::kFbWidth,
+                             subcycle::kFbHeight);
+  machine.set_light_gun(1, aim_line, aim_col, true);
+  machine.set_run_tier(tier);
+
+  // Run a handful of frames.  The beam sweeps the whole screen each frame, so
+  // the aim point is guaranteed to be visited.  Fast may need a frame or two to
+  // find a clean batch entry point.
+  for (int frame = 0; frame < 4; ++frame) machine.run_frame();
+
+  CrtcRegs cr{};
+  crtc_peek(machine.crtc(), &cr);
+  const uint16_t ma =
+      static_cast<uint16_t>(((cr.reg[16] & 0x3F) << 8) | cr.reg[17]);
+  return {ma, machine.fast_frames_run()};
+}
+
+}  // namespace
+
+TEST(LightGun, TierLatchAgreesSolderedWakeFast) {
+  std::vector<uint8_t> rom = load_system_rom();
+  if (rom.size() < 0x8000)
+    GTEST_SKIP() << "rom/cpc6128.rom not found (run from project root)";
+
+  // Aim near the middle of the visible window; the ±2 char/line tolerance makes
+  // the exact pixel irrelevant.
+  constexpr uint16_t kAimLine = 120;
+  constexpr uint16_t kAimCol = 18;
+
+  const auto soldered = run_with_tier(rom, subcycle::Machine::RunTier::Soldered,
+                                      kAimLine, kAimCol);
+  const auto wake =
+      run_with_tier(rom, subcycle::Machine::RunTier::Wake, kAimLine, kAimCol);
+  const auto fast =
+      run_with_tier(rom, subcycle::Machine::RunTier::Fast, kAimLine, kAimCol);
+
+  EXPECT_GT(soldered.ma, 0u) << "Soldered tier never latched";
+  EXPECT_EQ(wake.ma, soldered.ma) << "Wake-tier LPEN latch diverged";
+  EXPECT_EQ(fast.ma, soldered.ma) << "Fast-tier LPEN latch diverged";
+  EXPECT_GT(fast.fast_frames, 0u) << "Fast tier never engaged";
 }

--- a/test/hw/tier_peripheral_matrix_test.cpp
+++ b/test/hw/tier_peripheral_matrix_test.cpp
@@ -36,7 +36,7 @@ void boot_fast(subcycle::Machine& m, const std::vector<uint8_t>& rom) {
 
 }  // namespace
 
-TEST(TierPeripheralMatrix, LightGunDegradesFastToFaithful) {
+TEST(TierPeripheralMatrix, LightGunKeepsFastTier) {
   const std::vector<uint8_t> rom = read_rom();
   if (rom.size() < 0x8000) GTEST_SKIP() << "rom/cpc6128.rom not found";
 
@@ -44,9 +44,11 @@ TEST(TierPeripheralMatrix, LightGunDegradesFastToFaithful) {
   boot_fast(m, rom);
   m.set_light_gun(1, 100, 20, false);
   m.run_frame();
-  EXPECT_EQ(m.effective_run_tier(), subcycle::Machine::RunTier::Faithful);
+  // The light gun carries a wake + Fast batch contract (wake_slot /
+  // fs_advance_chars dispatch it), so plugging no longer degrades the tier.
+  EXPECT_EQ(m.effective_run_tier(), subcycle::Machine::RunTier::Fast);
   for (int i = 0; i < 5; ++i) m.run_frame();
-  EXPECT_EQ(m.effective_run_tier(), subcycle::Machine::RunTier::Faithful);
+  EXPECT_EQ(m.effective_run_tier(), subcycle::Machine::RunTier::Fast);
 }
 
 TEST(TierPeripheralMatrix, SymbifaceDegradesFastToFaithful) {


### PR DESCRIPTION
Two related fixes, both landing on top of the sub-cycle engine in `master`.

## 1. Light gun never ticked under Wake / Fast (beads-g4jq)

The light gun Device (`lgdev_`) was only dispatched in `tick_soldered` / `board_tick`. Under the **default Wake tier** and **Fast** it never produced `pen.strobe`, so the CRTC's R16/R17 light-pen latch never updated and light-gun games read stale aim.

**Root causes** (found by a new tier-oracle test):
- **Wake** never latched: the gun's strobe was written into `next.pen.strobe`, but the CRTC sleeps between char ticks and `bus_resting()` cleared the line before the CRTC ever saw it.
- **Fast** latched 3 chars early: it fed the strobe into the **edge-triggered** `crtc_fast_lpen_strobe` (latches only the *first* char of a run, −2) and latched the fire's own char instead of the next (−1).

**Fix.** The per-cycle reference latches **every** in-window char — the gun's `pen.strobe` is a one-master-cycle *pulse* per char (`bus_resting` drops it between char ticks), so the CRTC edge detector re-arms each char and the last latch wins. A per-char pulse is a **level**, not an edge, so the batched latch should not be edge-triggered:
- **`crtc_batch_lpen_latch`** (new, `src/hw/crtc.{h,cpp}`): level-sensitive batch latch. The edge-triggered `crtc_fast_lpen_strobe` (held-level sources) and its contract test are untouched.
- **Wake** (`wake_slot`): tick the gun on `clk.crtc` with the committed bus; `crtc_tick` advances the char, then `crtc_batch_lpen_latch` latches it.
- **Fast** (`fs_advance_chars`): char-by-char advance when plugged (`fs_lpen_on_` cached at entry), tick the gun per char, defer its decision one char, and carry it across incremental chunk calls in `fs_lpen_pending_` (review catch — a local dropped fires at chunk boundaries).
- The gun now carries a wake + Fast batch contract, so it **no longer degrades the tier**.

**Tests:** new oracle `LightGun.TierLatchAgreesSolderedWakeFast` (**Soldered = Wake = Fast = 12908**); renamed `TierPeripheralMatrix.LightGunDegradesFastToFaithful` → `LightGunKeepsFastTier`. Full suite green: **1543 passed, 3 skipped (hw-capture), 0 failed.**

## 2. Linux + Coverage CI red — stale `sdl3.pc` prefix after the repo rename

Both compile with `` `pkg-config --cflags sdl3` ``, which reads the vendored install's `sdl3.pc`. That file's `prefix` is baked in as an **absolute path captured at cache creation**. The repo was renamed `konCePCja` → `koncepcja_v5` after the cache was created, so the cached prefix (`/home/runner/work/konCePCja/...`) no longer exists on the case-sensitive Linux runner — pkg-config returned a bogus `-I` and every `SDL3/*.h` include failed (headers fine, just at the new path). macOS never saw it because it already resolved SDL via `-Ivendor/SDL/include`.

**Fix** (`makefile`): resolve the vendored SDL via **workspace-relative** paths on Linux too — `-Ivendor/SDL/include` + `-Lvendor/SDL/install/lib -lSDL3` + Linux `$ORIGIN` rpath — immune to renames. `USE_VENDORED_SDL=0` opts back into pkg-config.
