### PR TITLE
fix(ipc): guard key/joy injection against null CPC.InputMapper

### DIFF
--- a/src/koncepcja_ipc_server.cpp
+++ b/src/koncepcja_ipc_server.cpp
@@ -2573,6 +2573,18 @@ std::string handle_command(const std::string& line) {
 
     // Input replay commands
     if (cmd == "input" && parts.size() >= 2) {
+      // Key/joystick injection resolves key names through CPC.InputMapper,
+      // which koncpc_main constructs AFTER the IPC server starts accepting
+      // (g_ipc->start() at kon_cpc_ja.cpp:3664 < CPC.InputMapper at :3752). A
+      // key/joy command arriving in that window would dereference a null
+      // InputMapper (SIGSEGV at 0x48), so reject it as not-ready instead.
+      // 'state' and the mouse/gun device paths have their own guards; 'type'
+      // only queues text and needs none.
+      if ((parts[1] == "keydown" || parts[1] == "keyup" || parts[1] == "key" ||
+           parts[1] == "chord" || parts[1] == "joy") &&
+          !CPC.InputMapper) {
+        return "ERR 503 emulator-not-ready\n";
+      }
       // Helper: resolve a key name to CPC scancode
       auto resolve_key =
           [](const std::string& name) -> std::pair<bool, CPCScancode> {

--- a/test/ipc_server.cpp
+++ b/test/ipc_server.cpp
@@ -563,4 +563,33 @@ TEST_F(IpcServerTest, GunDrainAppliesAimAndTrigger) {
   CPC.phazer_emulation = PhazerType::None;
 }
 
+// ─────────────────────────────────────────────────
+// Null-InputMapper guard (beads-p95s): the IPC server accepts connections
+// before koncpc_main constructs CPC.InputMapper, so key/joy injection arriving
+// in that window must return 503 — not dereference a null InputMapper (the
+// SIGSEGV-at-0x48 this guard prevents). IpcServerTest runs with no InputMapper,
+// which is exactly that window.
+// ─────────────────────────────────────────────────
+
+TEST_F(IpcServerTest, KeyJoyInjectionRequiresInputMapper) {
+  InputMapper* const saved = CPC.InputMapper;
+  CPC.InputMapper = nullptr;  // the early-boot window
+
+  // Every key/joy sub-command resolves names through CPC.InputMapper; with it
+  // null they must be rejected, not crash.
+  for (const char* cmd :
+       {"input key RETURN", "input keydown A", "input keyup A",
+        "input chord SHIFT+A", "input joy 0 U", "input joy 1 F1"}) {
+    EXPECT_EQ(send_command(cmd), "ERR 503 emulator-not-ready\n") << cmd;
+  }
+
+  // The guard is scoped to key/joy injection: 'type' only queues text (OK)
+  // and 'state' has its own InputMapper guard (503) — neither over-blocked.
+  EXPECT_OK(send_command("input type \"hi\""));
+  g_autotype_queue.clear();
+  EXPECT_EQ(send_command("input state"), "ERR 503 emulator-not-ready\n");
+
+  CPC.InputMapper = saved;
+}
+
 }  // namespace


### PR DESCRIPTION
## Problem (beads-p95s)

The IPC server starts accepting connections (`g_ipc->start()`, `kon_cpc_ja.cpp:3664`) **before** `koncpc_main` constructs `CPC.InputMapper` (`kon_cpc_ja.cpp:3752`). Key/joystick injection resolves key names through `CPC.InputMapper->CPCscancodeFromCPCkey`, so `input key/keydown/keyup/chord/joy` sent in that window **dereferenced a null pointer and segfaulted the emulator** (fault at `0x48` = null + member offset).

Repro (headless): start the emulator, send `input key RETURN` immediately after the `IPC: listening` line → `Segmentation fault: 11`.

## Fix

Return `ERR 503 emulator-not-ready` for the key/joy sub-commands when `InputMapper` is null — the same contract `input state` already uses. `input mouse/gun` are untouched (they gate on `device_active`, no InputMapper deref) and `input type` only queues text.

## Test

New `IpcServerTest.KeyJoyInjectionRequiresInputMapper`: the fixture runs with `CPC.InputMapper == nullptr` (exactly the early-boot window) and asserts every key/joy sub-command returns 503 while `type`/`state` keep their own behaviour.

## Verified

- Early `input key RETURN` → `ERR 503` (was SIGSEGV); emulator stays alive.
- `IpcServerTest` 32/32; full suite 1547 passed / 3 skipped.

Surfaced by the p6im harness work (#13), which now connects earlier and exposed the window.