### PR TITLE
feat(ipc): human-readable 'env' (CP/M vs BASIC) hint in the status bracket

### DIFF
--- a/src/koncepcja_ipc_server.cpp
+++ b/src/koncepcja_ipc_server.cpp
@@ -184,12 +184,25 @@ std::string build_debug_context() {
   auto& wps = z80_list_watchpoints_ref();
   auto& ios = z80_list_io_breakpoints_ref();
 
+  // Infer the runtime environment (CP/M vs BASIC) from the screen mode + RAM
+  // bank, so a reader doesn't have to memorize the encoding — during the
+  // plotter e2e a bare 'reg get PC' (which carries no context) was misread as
+  // BASIC while still in CP/M (beads-7hqp). This is a heuristic, not a
+  // guarantee (a BASIC program can MODE 2), so ambiguous combinations
+  // report '?' rather than guess.
+  const char* env = "?";
+  const unsigned ram_bank = GateArray.RAM_config & 7;
+  if (GateArray.scr_mode == 2 && ram_bank == 1)
+    env = "CP/M";
+  else if (GateArray.scr_mode == 1 && ram_bank == 0)
+    env = "BASIC";
+
   int const n = snprintf(
       buf, sizeof(buf),
-      "[PC=%04X SP=%04X|%s|mode=%u|rom:%s|ram:%u/%uK|bp:%zu,wp:%zu,io:%zu",
+      "[PC=%04X SP=%04X|%s|mode=%u|rom:%s|ram:%u/%uK|env:%s|bp:%zu,wp:%zu,io:%zu",
       z80.PC.w.l, z80.SP.w.l, CPC.paused ? "paused" : "running",
       GateArray.scr_mode, rom_str.c_str(), GateArray.RAM_config & 7,
-      CPC.ram_size, bps.size(), wps.size(), ios.size());
+      CPC.ram_size, env, bps.size(), wps.size(), ios.size());
 
   // Clamp to buffer size in case of truncation; n<0 would indicate encoding
   // error

--- a/test/ipc_server.cpp
+++ b/test/ipc_server.cpp
@@ -29,6 +29,7 @@
 
 extern t_z80regs z80;
 extern t_CPC CPC;
+extern t_GateArray GateArray;
 extern SDL_Surface* back_surface;
 extern byte* membank_read[4];
 extern byte* membank_write[4];
@@ -561,6 +562,40 @@ TEST_F(IpcServerTest, GunDrainAppliesAimAndTrigger) {
 
   vid_plugin = saved;
   CPC.phazer_emulation = PhazerType::None;
+}
+
+// ─────────────────────────────────────────────────
+// Status-bracket environment hint (beads-7hqp): the bracket decodes the
+// CP/M-vs-BASIC discriminator (screen mode + RAM bank) into a readable 'env'
+// field, so a reader doesn't have to remember the encoding (a bare 'reg get
+// PC' carries no such context). Heuristic only — ambiguous combinations must
+// report '?', not a guess.
+// ─────────────────────────────────────────────────
+
+TEST_F(IpcServerTest, StatusBracketInfersEnvironment) {
+  const unsigned int saved_mode = GateArray.scr_mode;
+  const unsigned char saved_ram = GateArray.RAM_config;
+
+  // CP/M Plus boots 80-col (mode 2) on RAM bank 1.
+  GateArray.scr_mode = 2;
+  GateArray.RAM_config = 1;
+  auto resp = send_command("pause");
+  EXPECT_NE(resp.find("env:CP/M"), std::string::npos) << resp;
+
+  // BASIC/AMSDOS sits in mode 1 on bank 0.
+  GateArray.scr_mode = 1;
+  GateArray.RAM_config = 0;
+  resp = send_command("pause");
+  EXPECT_NE(resp.find("env:BASIC"), std::string::npos) << resp;
+
+  // A mixed state (mode 2 but bank 0) is unknown — reported, not guessed.
+  GateArray.scr_mode = 2;
+  GateArray.RAM_config = 0;
+  resp = send_command("pause");
+  EXPECT_NE(resp.find("env:?"), std::string::npos) << resp;
+
+  GateArray.scr_mode = saved_mode;
+  GateArray.RAM_config = saved_ram;
 }
 
 }  // namespace


### PR DESCRIPTION
## Problem (beads-7hqp)

The IPC status bracket encodes machine state as `mode=2 | ram:1/128K`. That IS the reliable CP/M-vs-BASIC discriminator (mode 2 80-col + RAM bank 1 = CP/M Plus; mode 1 + bank 0 = BASIC/AMSDOS) — but only if you remember the encoding. During the plotter e2e a bare `reg get PC` (which carries no mode/ram context) was misread as BASIC while still in CP/M, nearly resetting a live session.

## Fix

`build_debug_context()` now appends an `env:` field decoding mode+bank into a readable label: **CP/M**, **BASIC**, or **?** when the combination is ambiguous. It's a heuristic, not a guarantee (a BASIC program can `MODE 2`), so it never guesses. `reg get` stays single-value by design; the bracket is the place that always carries the context.

## Test

New `IpcServerTest.StatusBracketInfersEnvironment` covers CP/M, BASIC, and the ambiguous `?` case.

## Verified

`IpcServerTest` 32/32; full suite 1547 passed / 3 skipped.