### PR TITLE
fix: close the review follow-ups from PR #16

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,8 +24,23 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          submodules: true
+          submodules: false
 
+      # actions/checkout has no retry for submodule fetches, and one PR run does
+      # ~9 of them (6 MSVC configs + linux + macos + coverage). A transient
+      # "Empty reply from server" from the SDL host therefore reddens a run
+      # regularly -- observed on run 30524543939, which passed on re-run with no
+      # code change. Retry the fetch instead of the whole job (beads-rbtp).
+      - name: Fetch submodules (retried)
+        shell: bash
+        run: |
+          for i in 1 2 3; do
+            git submodule update --init --recursive --depth=1 && exit 0
+            echo "submodule fetch attempt $i failed; retrying in 15s" >&2
+            sleep 15
+          done
+          echo "submodule fetch failed after 3 attempts" >&2
+          exit 1
       - name: Install dependencies
         run: |
           sudo apt-get update

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -21,7 +21,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          submodules: true
+          submodules: false
+      # actions/checkout has no retry for submodule fetches, and one PR run does
+      # ~9 of them (6 MSVC configs + linux + macos + coverage). A transient
+      # "Empty reply from server" from the SDL host therefore reddens a run
+      # regularly -- observed on run 30524543939, which passed on re-run with no
+      # code change. Retry the fetch instead of the whole job (beads-rbtp).
+      - name: Fetch submodules (retried)
+        shell: bash
+        run: |
+          for i in 1 2 3; do
+            git submodule update --init --recursive --depth=1 && exit 0
+            echo "submodule fetch attempt $i failed; retrying in 15s" >&2
+            sleep 15
+          done
+          echo "submodule fetch failed after 3 attempts" >&2
+          exit 1
       - run: sudo apt-get update
       - run: >-
           sudo apt-get install pkg-config cmake libfreetype6-dev zlib1g-dev libpng-dev devscripts

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -20,7 +20,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          submodules: true
+          submodules: false
+      # actions/checkout has no retry for submodule fetches, and one PR run does
+      # ~9 of them (6 MSVC configs + linux + macos + coverage). A transient
+      # "Empty reply from server" from the SDL host therefore reddens a run
+      # regularly -- observed on run 30524543939, which passed on re-run with no
+      # code change. Retry the fetch instead of the whole job (beads-rbtp).
+      - name: Fetch submodules (retried)
+        shell: bash
+        run: |
+          for i in 1 2 3; do
+            git submodule update --init --recursive --depth=1 && exit 0
+            echo "submodule fetch attempt $i failed; retrying in 15s" >&2
+            sleep 15
+          done
+          echo "submodule fetch failed after 3 attempts" >&2
+          exit 1
       - uses: actions/setup-node@v4
       - run: brew update
       - run: brew install freetype zlib libpng gnu-sed cmake coreutils

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -31,8 +31,23 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          submodules: true
+          submodules: false
 
+      # actions/checkout has no retry for submodule fetches, and one PR run does
+      # ~9 of them (6 MSVC configs + linux + macos + coverage). A transient
+      # "Empty reply from server" from the SDL host therefore reddens a run
+      # regularly -- observed on run 30524543939, which passed on re-run with no
+      # code change. Retry the fetch instead of the whole job (beads-rbtp).
+      - name: Fetch submodules (retried)
+        shell: bash
+        run: |
+          for i in 1 2 3; do
+            git submodule update --init --recursive --depth=1 && exit 0
+            echo "submodule fetch attempt $i failed; retrying in 15s" >&2
+            sleep 15
+          done
+          echo "submodule fetch failed after 3 attempts" >&2
+          exit 1
       # ── GoogleTest (not a submodule — cloned by Makefile) ──
       - name: Clone GoogleTest
         run: git clone --depth 1 --branch v1.15.2 https://github.com/google/googletest.git

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,7 +130,7 @@ echo "help" | nc localhost 6543
 | `regs` | Dump all registers | `regs` → `OK A=00 F=00 ...` |
 | `reg get <R>` | Get register | `reg get PC` → `OK 1234` |
 | `reg set <R> <V>` | Set register | `reg set PC 0x4000` → `OK` |
-| `mem read <addr> <len> [ascii]` | Read memory | `mem read 0x4000 16 ascii` |
+| `mem read <addr> <len> [--view=read|ram] [--bank=N] [ascii]` | Read memory | `mem read 0x4000 16 ascii` |
 | `mem write <addr> <hex>` | Write memory | `mem write 0x4000 C3004000` |
 | `bp add <addr>` | Add breakpoint | `bp add 0x4000` → `OK` |
 | `bp del <addr>` | Remove breakpoint | `bp del 0x4000` → `OK` |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,12 @@ if(NOT KONCPC_VERSION_MATCH)
           "that file, so the build cannot continue without it.")
 endif()
 set(KONCPC_VERSION "${CMAKE_MATCH_1}")
+
+# A bump to the manifest must re-run configure, or an incremental build keeps the
+# version baked at the last configure.  The makefile has an equivalent stamp;
+# without this line CMake was the half of the fix that silently did nothing.
+set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS
+             "${CMAKE_SOURCE_DIR}/.release-please-manifest.json")
 project(koncepcja VERSION ${KONCPC_VERSION} LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 17)
@@ -164,9 +170,7 @@ endif()
 # makefile uses (see KONCPC_VERSION above).
 target_compile_definitions(koncepcja_lib PUBLIC KONCPC_VERSION_STRING="v${PROJECT_VERSION}")
 
-# Absolute path to the source tree, so tests can find the manifest regardless of
-# the working directory they are launched from (ctest runs from the build dir).
-target_compile_definitions(koncepcja_lib PUBLIC KONCPC_SOURCE_DIR="${CMAKE_SOURCE_DIR}")
+
 
 # Modern-UI guard define (P1.5.1 step 4).  Source files that have
 # optional ImGui paths (currently: macos_menu.mm) check this to skip
@@ -283,6 +287,11 @@ target_link_libraries(test_runner PRIVATE
     gtest
     gmock
 )
+
+# Absolute source-tree path so version_source_test can find the manifest whatever
+# directory ctest launches from.  TEST-ONLY: as a PUBLIC define on koncepcja_lib
+# it baked the build machine's path into every shipped object.
+target_compile_definitions(test_runner PRIVATE KONCPC_SOURCE_DIR="${CMAKE_SOURCE_DIR}")
 
 if(MSVC)
     # Relax warnings for test code

--- a/docs/ipc-protocol.md
+++ b/docs/ipc-protocol.md
@@ -63,7 +63,7 @@ See CLAUDE.md § Telnet Console for architecture details and key mappings.
 
 | Command | Response |
 |---------|----------|
-| `mem read <addr> <len> [--view=read\|write] [--bank=N] [ascii]` | `OK <hex> [\|ascii\|]` — reads through Z80 banking |
+| `mem read <addr> <len> [--view=read\|ram] [--bank=N] [ascii]` | `OK <hex> [\|ascii\|]` — reads through Z80 banking |
 | `mem write <addr> <hex>` | `OK` — writes through Z80 banking |
 | `mem fill <addr> <len> <hex-pattern>` | `OK` — fill memory with repeating hex pattern |
 | `mem compare <addr1> <addr2> <len>` | `OK diffs=N [addr:src:dst ...]` — compare two regions, up to 64 diffs listed |
@@ -73,7 +73,14 @@ Addresses and values accept decimal, `0x` hex, or `0b` binary.
 ### Bank access (mem read)
 
 - Default: reads through `membank_read[]` (standard Z80 view — ROM overlays visible at 0x0000)
-- `--view=write`: reads through `membank_write[]` (underlying RAM at 0x0000-0x3FFF visible)
+- `--view=ram`: the banked RAM byte, ROM overlays ignored. **Use this to poll a
+  game variable.** An address under a paged-in ROM otherwise returns the firmware
+  byte and appears to flicker as the OS banks ROM in and out (e.g. `&1AF1` reads
+  as `&3E` from the 6128 OS ROM). `--view=write` is a deprecated alias.
+- `search hex|text` accepts the same `--view=ram` for the same reason; `search
+  asm` always uses the CPU view, since it disassembles code.
+- An unrecognised `--view=` value is rejected with `ERR 400 bad-view (read|ram)`
+  rather than silently falling back.
 - `--bank=N`: reads raw from physical 16KB bank N (`pbRAM + N*16384`), ignoring current mapping
 
 ## Breakpoints

--- a/makefile
+++ b/makefile
@@ -171,12 +171,19 @@ endif
 # test/version_source_test.cpp fails the build if the compiled-in string and
 # the manifest ever disagree.
 KONCPC_VERSION := $(shell sed -n 's/.*"\."[[:space:]]*:[[:space:]]*"\([0-9][^"]*\)".*/\1/p' .release-please-manifest.json 2>/dev/null | head -1)
-ifneq ($(KONCPC_VERSION),)
-COMMON_CFLAGS += -DKONCPC_VERSION_STRING=\"v$(KONCPC_VERSION)\"
+ifeq ($(KONCPC_VERSION),)
+# Parity with CMakeLists.txt, which FATAL_ERRORs here.  Without this the build
+# silently omitted -DKONCPC_VERSION_STRING and produced a binary that could not
+# report its own version -- the very failure single-sourcing was meant to end.
+# Packaging from a source tarball legitimately has no manifest, so an explicit
+# `make VERSION=x.y.z` still wins (linux.yml does exactly that for distrib).
+ifeq ($(origin VERSION),command line)
+KONCPC_VERSION := $(VERSION)
+else
+$(error Cannot parse the version from .release-please-manifest.json -- it is the single source of truth (see RELEASING.md).  When building from a source tarball pass VERSION=x.y.z explicitly.)
 endif
-# Absolute path to the source tree, so tests can find the manifest regardless of
-# the working directory they are launched from (ctest runs from the build dir).
-COMMON_CFLAGS += -DKONCPC_SOURCE_DIR=\"$(CURDIR)\"
+endif
+COMMON_CFLAGS += -DKONCPC_VERSION_STRING=\"v$(KONCPC_VERSION)\"
 
 ifdef APP_PATH
 COMMON_CFLAGS += -DAPP_PATH=\"$(APP_PATH)\"
@@ -520,6 +527,11 @@ googletest:
 	@[ -d googletest ] || git clone https://github.com/google/googletest.git
 
 TEST_CFLAGS = $(COMMON_CFLAGS) -I$(GTEST_DIR)/include -I$(GTEST_DIR) -I$(GMOCK_DIR)/include -I$(GMOCK_DIR)
+# Absolute source-tree path, so version_source_test can find the manifest no
+# matter what directory the runner is launched from.  TEST-ONLY on purpose: as a
+# COMMON_CFLAGS define it baked the build machine's path into every shipped
+# object.  Single-quoted so a checkout path containing spaces still builds.
+TEST_CFLAGS += '-DKONCPC_SOURCE_DIR="$(CURDIR)"'
 GTEST_DIR = googletest/googletest/
 GMOCK_DIR = googletest/googlemock/
 

--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -3793,6 +3793,7 @@ int koncpc_main(int argc, char** argv) {
     }
     manifest.model = CPC.model;
     manifest.ram_size_kb = CPC.ram_size;
+    manifest.run_tier = subcycle_bridge_effective_tier_name();
     manifest.config_file = config_file;
     startup_manifest_emit(manifest);
   }

--- a/src/koncepcja_ipc_server.cpp
+++ b/src/koncepcja_ipc_server.cpp
@@ -1802,7 +1802,10 @@ std::string handle_command(const std::string& line) {
           // wants this — the default "read" view returns the firmware byte
           // whenever a ROM is paged over the address, so a variable under the
           // lower ROM appears to flicker as the OS banks ROM in and out.
-          if (v == "write" || v == "ram") view_mode = 1;
+          if (v == "write" || v == "ram")
+            view_mode = 1;
+          else if (v != "read")
+            return "ERR 400 bad-view (read|ram)\n";
         } else if (parts[pi].rfind("--bank=", 0) == 0) {
           raw_bank = parse_int(parts[pi].substr(7));
         }
@@ -4377,9 +4380,22 @@ std::string handle_command(const std::string& line) {
     // --- Enhanced search command (with wildcard support) ---
     if (cmd == "search" && parts.size() >= 3) {
       const std::string& submode = parts[1];
-      // Collect pattern from remaining parts
+      // Collect pattern from remaining parts. --view= is a flag, not pattern
+      // text: hex/text search scans DATA, so it needs the same RAM view
+      // `mem read --view=ram` offers. Without it a search for a game variable's
+      // value scans the firmware bytes of any paged-in ROM instead -- the exact
+      // wrong-value class the RAM view exists to fix.
+      bool search_ram_view = false;
       std::string pattern;
       for (size_t pi = 2; pi < parts.size(); pi++) {
+        if (parts[pi].rfind("--view=", 0) == 0) {
+          std::string const v = parts[pi].substr(7);
+          if (v == "ram" || v == "write")
+            search_ram_view = true;
+          else if (v != "read")
+            return "ERR 400 bad-view (read|ram)\n";
+          continue;
+        }
         if (!pattern.empty()) pattern += " ";
         pattern += parts[pi];
       }
@@ -4458,7 +4474,9 @@ std::string handle_command(const std::string& line) {
       // HEX / TEXT mode: read full 64K into buffer
       std::vector<uint8_t> membuf(65536);
       for (size_t i = 0; i < 65536; i++) {
-        membuf[i] = z80_read_mem(static_cast<word>(i));
+        membuf[i] = search_ram_view
+                        ? z80_read_mem_via_write_bank(static_cast<word>(i))
+                        : z80_read_mem(static_cast<word>(i));
       }
       auto results =
           search_memory(membuf.data(), membuf.size(), pattern, mode, 256);

--- a/src/startup_manifest.cpp
+++ b/src/startup_manifest.cpp
@@ -25,6 +25,12 @@ std::string quoted(const std::string& s) {
   return out;
 }
 
+// A string that is absent emits null, not '' -- same reasoning as ports below.
+std::string quoted_or_null(const std::string& s) {
+  if (s.empty()) return "null";
+  return quoted(s);
+}
+
 // Ports are emitted as null rather than 0 when the server is not listening, so
 // a consumer cannot mistake "absent" for "port zero".
 std::string port_or_null(int port) {
@@ -46,10 +52,12 @@ std::string startup_manifest_yaml(const StartupManifest& m) {
   o << "  ipc: " << port_or_null(m.ipc_port) << '\n';
   o << "  telnet: " << port_or_null(m.telnet_port) << '\n';
   o << "  m4_http: " << port_or_null(m.m4_http_port) << '\n';
-  o << "  m4_bind_ip: " << quoted(m.m4_bind_ip) << '\n';
+  // Not nested under ports: a bind address is not a port.
+  o << "m4_bind_ip: " << quoted_or_null(m.m4_bind_ip) << '\n';
   o << "machine:\n";
   o << "  model: " << m.model << '\n';
   o << "  ram_size_kb: " << m.ram_size_kb << '\n';
+  o << "  run_tier: " << quoted_or_null(m.run_tier) << '\n';
   o << "config_file: " << quoted(m.config_file) << '\n';
   o << "...\n";
   return o.str();
@@ -78,10 +86,12 @@ void startup_manifest_emit(const StartupManifest& m) {
   std::string const yaml = startup_manifest_yaml(m);
   // stdio rather than std::cout: the rest of startup logging is a mix of both,
   // and fwrite+fflush guarantees this lands whole and immediately.
+  // Project convention (AGENTS.md): check fwrite/fclose/fflush. Warn on stderr,
+  // because stdout is the stream that just failed.
   if (fwrite(yaml.data(), 1, yaml.size(), stdout) != yaml.size()) {
-    // Nothing useful to do if stdout is broken; a harness will notice the
-    // missing manifest. Explicitly ignored rather than silently unchecked.
+    fprintf(stderr, "WARNING: startup manifest write failed (short write)\n");
     return;
   }
-  fflush(stdout);
+  if (fflush(stdout) != 0)
+    fprintf(stderr, "WARNING: startup manifest flush failed\n");
 }

--- a/src/startup_manifest.h
+++ b/src/startup_manifest.h
@@ -15,7 +15,8 @@
 #include <string>
 
 // A port value of <= 0 means "that server is not running", and is emitted as
-// YAML null.
+// YAML null. An empty m4_bind_ip likewise emits null rather than '' -- a
+// consumer must not have to distinguish "absent" from "the empty string".
 struct StartupManifest {
   std::string version;  // KONCPC_VERSION_STRING
   std::string build;    // short git hash, may be empty
@@ -27,7 +28,12 @@ struct StartupManifest {
   std::string m4_bind_ip;
   unsigned int model = 0;        // 0=464, 1=664, 2=6128, 3=6128+
   unsigned int ram_size_kb = 0;  //
-  std::string config_file;       // may be empty if no config was found
+  // Effective run tier (fast/wake/soldered/faithful). A harness needs it: the
+  // tier decides whether per-cycle observability is on, which changes debugger
+  // semantics. Empty when unknown. (There is deliberately no `engine` field --
+  // the legacy core is gone, so it cannot vary.)
+  std::string run_tier;
+  std::string config_file;  // may be empty if no config was found
 };
 
 // Renders the manifest as one YAML document, framed by a `--- # koncepcja` line

--- a/test/devtools_render_test.cpp
+++ b/test/devtools_render_test.cpp
@@ -57,12 +57,24 @@ class TestRam {
     const byte prog[] = {0x3E, 0x10, 0x3D, 0xC2, 0x05, 0x00, 0xC9};
     std::copy(std::begin(prog), std::end(prog), ram_.begin());
 
+    // Bank 0's READ pointer aims at a separate buffer standing in for the lower
+    // ROM overlay, while its WRITE pointer stays on RAM. That asymmetry is the
+    // whole point: with both pointing at one buffer (as they first did here)
+    // the CPU view and the RAM view are byte-identical, so a memory view that
+    // read through the ROM overlay -- the bug this suite exists to cover --
+    // would pass every assertion. kRomShadowAddr/kRomByte/kRamByte below give
+    // the tests a concrete divergence to assert on.
+    rom_.assign(0x4000, 0);
+    rom_[kRomShadowAddr] = kRomByte;
+    ram_[kRomShadowAddr] = kRamByte;
+
     for (int i = 0; i < 4; i++) {
       saved_read_[i] = membank_read[i];
       saved_write_[i] = membank_write[i];
       membank_read[i] = ram_.data() + (i * 0x4000);
       membank_write[i] = ram_.data() + (i * 0x4000);
     }
+    membank_read[0] = rom_.data();  // lower-ROM overlay over bank 0
     saved_resources_ = CPC.resources_path;
     CPC.resources_path = "resources";
   }
@@ -80,8 +92,17 @@ class TestRam {
     CPC.resources_path = saved_resources_;
   }
 
+ public:
+  // The address the ROM overlay and RAM disagree on, and the two bytes there.
+  // Mirrors the reported case: &1AF1 holds &3E in the 6128 OS ROM while the
+  // game stores its lives counter underneath.
+  static constexpr word kRomShadowAddr = 0x1AF1;
+  static constexpr byte kRomByte = 0x3E;
+  static constexpr byte kRamByte = 0x03;
+
  private:
   std::vector<byte> ram_;
+  std::vector<byte> rom_;
   byte* saved_read_[4] = {};
   byte* saved_write_[4] = {};
   std::string saved_resources_;
@@ -329,4 +350,22 @@ TEST_F(DevToolsRenderTest, ClosedWindowsEmitNoGeometry) {
   int const vtx = gui_.settled_frames([this] { dt_.render(); });
   EXPECT_EQ(vtx, 0) << "DevTools drew " << vtx
                     << " vertices with every window closed.";
+}
+
+// The two memory views must actually disagree where a ROM overlays RAM.
+//
+// This is the assertion that makes the Memory Hex "CPU view" toggle testable at
+// all. Before it, TestRam pointed the read and write banks at one buffer, so
+// both views returned the same byte everywhere and the shipped bug -- a toggle
+// whose branches called the same function -- passed the whole suite.
+TEST_F(DevToolsRenderTest, CpuViewAndRamViewDivergeUnderARomOverlay) {
+  EXPECT_EQ(z80_read_mem(TestRam::kRomShadowAddr), TestRam::kRomByte)
+      << "CPU view must read through the ROM overlay";
+  EXPECT_EQ(z80_read_mem_via_write_bank(TestRam::kRomShadowAddr),
+            TestRam::kRamByte)
+      << "RAM view must ignore the ROM overlay and show the stored byte";
+  EXPECT_NE(z80_read_mem(TestRam::kRomShadowAddr),
+            z80_read_mem_via_write_bank(TestRam::kRomShadowAddr))
+      << "the two views are indistinguishable, so nothing here can cover the "
+         "Memory Hex view toggle";
 }

--- a/test/startup_manifest_test.cpp
+++ b/test/startup_manifest_test.cpp
@@ -122,3 +122,27 @@ TEST(StartupManifestAwaitPort, GivesUpAtTheDeadline) {
   int const port = startup_manifest_await_port([] { return 0; }, 20);
   EXPECT_EQ(port, 0);
 }
+
+// An absent bind address must be null, not '' — a consumer should not have to
+// distinguish "M4 is not running" from "the empty string".
+TEST(StartupManifest, AbsentBindAddressIsNullNotEmptyString) {
+  StartupManifest m = sample();
+  m.m4_http_port = 0;
+  m.m4_bind_ip.clear();
+
+  std::string const y = startup_manifest_yaml(m);
+  EXPECT_TRUE(contains(y, "m4_bind_ip: null"));
+  EXPECT_FALSE(contains(y, "m4_bind_ip: ''"));
+  // A bind address is not a port, so it must not sit inside the ports mapping.
+  EXPECT_TRUE(contains(y, "\nm4_bind_ip:"));
+}
+
+// The run tier changes debugger semantics (per-cycle observability), so a
+// harness needs it alongside the ports.
+TEST(StartupManifest, ReportsRunTier) {
+  StartupManifest m = sample();
+  m.run_tier = "fast";
+  EXPECT_TRUE(contains(startup_manifest_yaml(m), "run_tier: 'fast'"));
+  m.run_tier.clear();
+  EXPECT_TRUE(contains(startup_manifest_yaml(m), "run_tier: null"));
+}


### PR DESCRIPTION
Closes the actionable findings from the multi-agent review of PR #16 — **beads-5a8n**, **beads-wxy6**, **beads-rbtp**.

## The one that mattered: CMake never re-ran configure on a version bump

PR #16 single-sourced the version and gave `make` a stamp so a bump forces a rebuild. `CMakeLists.txt` got nothing — `file(READ)` runs at *configure* time, so an incremental CMake build after a release-please bump kept the **old** version. That reintroduced, on the MSVC/Windows path, precisely the staleness the whole change existed to eliminate. `LESSONS.md` records this drift already costing three re-cut releases once before.

Fixed with `CMAKE_CONFIGURE_DEPENDS` on the manifest.

Two related version-plumbing fixes:
- An unparseable manifest now **fails the make build loudly**, matching CMake's `FATAL_ERROR`, instead of silently emitting a binary that can't report its own version. `make VERSION=x.y.z` still wins — that's what `linux.yml` passes when packaging from a source tarball that ships no manifest.
- `KONCPC_SOURCE_DIR` is now **test-only**. As `COMMON_CFLAGS` + a `PUBLIC` define it baked the build machine's absolute path into every shipped object. It's also single-quoted now, so a checkout path with spaces builds.

## The RAM-view fix stopped short of the agent surface

IPC `search hex|text` read all 64K through the CPU view, so an agent hunting a game variable under a paged-in ROM scanned firmware bytes — the exact wrong-value class the RAM view exists to fix, and the RL harness that motivated it searches over IPC. `search` now takes `--view=ram`; `search asm` deliberately keeps the CPU view since it disassembles code.

Also: an unrecognised `--view=` is now `ERR 400` instead of silently falling back (`--view=write` still works as a deprecated alias), and `docs/ipc-protocol.md` + `AGENTS.md` are updated — both still documented `--view=read|write` with no `ram` and no mention of the manifest.

## Manifest hardening, while `manifest_version: 1` is still unpublished

`m4_bind_ip` emits `null` not `''` when M4 is down and is no longer nested under `ports` (a bind address is not a port); adds `machine.run_tier`, since the tier decides whether per-cycle observability is on and that changes debugger semantics a harness must know. **No `engine` field** — the review asked for one, but the legacy core is gone, so it cannot vary. `fflush`'s return is now checked and a short write warns on stderr (stdout being the stream that just failed).

## The tests couldn't fail for the bug they covered

`TestRam` pointed `membank_read` and `membank_write` at the **same buffer**, so the CPU view and RAM view were byte-identical in every render test — the shipped bug (a toggle whose branches called one function) would have passed the suite unchanged. Bank 0's read pointer now aims at a separate lower-ROM buffer holding `&3E` over RAM's `&03` at `&1AF1`, and a new test asserts the two views genuinely diverge.

## CI: the SDL submodule fetch is a 9x-amplified flake point

Run 30524543939 attempt 1 failed at `actions/checkout` with `Empty reply from server` fetching `vendor/SDL`, then passed on re-run with no code change. One PR run performs ~9 submodule fetches (6 MSVC configs + linux + macos + coverage) and `actions/checkout` has no retry, so a small per-fetch failure rate reddens runs regularly. All four workflows now fetch submodules in a retried step.

## Verification

Live against a running emulator:

| Check | Result |
|---|---|
| Manifest | `version: 'v6.1.1'`, `run_tier: 'faithful'`, `m4_bind_ip` outside `ports` |
| `--view=bogus` | `ERR 400 bad-view (read\|ram)` |
| `--view=write` | still `OK 03` (compat kept) |
| `search hex 03 --view=ram` | finds **1AF1** |
| `search hex 3E` (CPU view) | finds 1AF1 among firmware bytes |
| Missing manifest | build fails with the explanatory error |
| `VERSION=9.9.9` | still overrides |

**1598 tests pass** (`--gtest_shuffle`), `make clang-format` clean. The version chain is now proven through a real release: the manifest reports `v6.1.1` after PR #18 merged, with no manual edit.

## Deferred (still open in beads)

Not in this PR, deliberately: `mem_read_ram` → `mem_read_base_ram` rename and removing the `z80_cpu_read_mem` identity alias (both touch call sites beyond this change's scope); extending the differential-geometry assertion to the other 17 DevTools windows; an `ipc_harness.py` test that parses the manifest from a live process; the off-thread banking read race (pre-existing); and `make distrib` tarballs omitting the manifest.
