### PR TITLE
fix(video): quiesce the Z80 thread before tearing down video on fullscreen toggle

### DIFF
--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -2415,6 +2415,35 @@ void koncpc_queue_virtual_keys(const std::string& text) {
   g_autotype_queue.enqueue_legacy(text);
 }
 
+// Toggle windowed/fullscreen.
+//
+// MUST quiesce the Z80 thread first. video_shutdown() tears down the surface
+// and GPU resources the emulation thread renders into, so doing it while that
+// thread runs is a use-after-free: the crash lands in z80_thread_main() with
+// EXC_BAD_ACCESS at a small offset, on the Z80 thread, while the fullscreen key
+// was pressed on the main thread. The previous code paused only *audio* and
+// then SDL_Delay(20)'d, which is a hope rather than a guarantee -- on a busy
+// frame the Z80 thread is still inside the renderer when the surface goes away.
+// Same contract emulator_reset() needs (see cpc_pause_and_wait).
+void koncpc_toggle_fullscreen() {
+  bool const was_paused = CPC.paused;
+  if (!was_paused) cpc_pause_and_wait();
+
+  audio_pause();
+  video_shutdown();
+  CPC.scr_window = CPC.scr_window ? 0 : 1;
+  if (video_init()) {
+    fprintf(stderr, "video_init() failed. Aborting.\n");
+    cleanExit(-1);
+  }
+#ifdef __APPLE__
+  koncpc_setup_macos_menu();
+#endif
+  audio_resume();
+
+  if (!was_paused) cpc_resume();
+}
+
 void koncpc_menu_action(int action) {
   switch (action) {
     case KONCPC_GUI: {
@@ -2445,18 +2474,7 @@ void koncpc_menu_action(int action) {
     }
 
     case KONCPC_FULLSCRN:
-      audio_pause();
-      SDL_Delay(20);
-      video_shutdown();
-      CPC.scr_window = CPC.scr_window ? 0 : 1;
-      if (video_init()) {
-        fprintf(stderr, "video_init() failed. Aborting.\n");
-        cleanExit(-1);
-      }
-#ifdef __APPLE__
-      koncpc_setup_macos_menu();
-#endif
-      audio_resume();
+      koncpc_toggle_fullscreen();
       break;
 
     case KONCPC_SCRNSHOT:
@@ -4076,18 +4094,7 @@ int koncpc_main(int argc, char** argv) {
                 break;
               }
               case KONCPC_FULLSCRN:
-                audio_pause();
-                SDL_Delay(20);
-                video_shutdown();
-                CPC.scr_window = CPC.scr_window ? 0 : 1;
-                if (video_init()) {
-                  fprintf(stderr, "video_init() failed. Aborting.\n");
-                  cleanExit(-1);
-                }
-#ifdef __APPLE__
-                koncpc_setup_macos_menu();
-#endif
-                audio_resume();
+                koncpc_toggle_fullscreen();
                 break;
               case KONCPC_SCRNSHOT:
                 koncpc_menu_action(KONCPC_SCRNSHOT);


### PR DESCRIPTION
Crash on toggling fullscreen, from the report on this machine:

```
EXC_BAD_ACCESS (SIGSEGV), KERN_INVALID_ADDRESS at 0x18
faulting thread 12: (anonymous namespace)::z80_thread_main()
```

The fullscreen key is handled on the **main** thread, but the crash lands on the **Z80 thread** — the signature of a teardown race. The handler was:

```c
audio_pause();
SDL_Delay(20);      // a hope, not a guarantee
video_shutdown();   // frees the surface / GPU resources
video_init();
```

It paused *audio* and slept, but never quiesced the emulation thread, which keeps rendering into the surface `video_shutdown()` just freed. On a busy frame 20 ms isn't enough, and the Z80 thread dereferences freed state — a null plus a small field offset, which is the `0x18`.

Now takes the contract `emulator_reset()` already needs: `cpc_pause_and_wait()` before the teardown, `cpc_resume()` after (only if it wasn't already paused). The `SDL_Delay(20)` race-hope is gone.

**Also de-duplicates.** The handler was copy-pasted at two call sites (`kon_cpc_ja.cpp:2447` and `:4078`), so fixing one would have silently left the other racy. Both now call one helper.

### Honest note on verification

This is **not** verified by reproduction. With the fix, 12 spaced and 25 rapid toggles over IPC survive — but **12 toggles also survived against the unfixed build**, so that stress doesn't open the race window (keys injected via the autotype queue are consumed at a frame boundary where the Z80 thread is already parked). The evidence here is the crash report's faulting thread plus a genuinely unsynchronized teardown in the code, not a red-to-green test.

If you can say whether you hit it via **F2** or the **View ▸ Fullscreen menu item**, and whether it was reliable or occasional, that would narrow it further — the menu path goes through a different dispatch.