### PR TITLE
feat: route flux disk images (.hfe/.scp/.a2r) through every front door

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,8 @@ Options:
   -V/--version             Show version
   -v/--verbose             Verbose logging
 
-Slot files: .dsk (disk), .cdt/.voc (tape), .cpr (cartridge), .sna (snapshot)
+Slot files: .dsk/.ipf/.raw (disk), .scp/.hfe/.a2r (flux disk, drive A only),
+.cdt/.voc (tape), .cpr (cartridge), .sna (snapshot)
 ```
 
 ### Examples

--- a/doc/man6/koncepcja.6
+++ b/doc/man6/koncepcja.6
@@ -13,10 +13,10 @@ koncepcja - konCePCja Amstrad CPC emulator
 \fBMedia loading\fR
 .RS
 Upon invocation, the FILEs specified as arguments will be used to populate the various available CPC machine slots. The type of slot is determined by the file format, detected by its extension. konCePCja supports the following file formats:
-\fB.dsk\fR (disk image), \fB.ipf\fR (Interchangeable Preservation Format disk image), \fB.raw\fR (CT-RAW format), \fB.voc\fR or \fB.cdt\fR (tape image), \fB.cpr\fR (cartridge image), \fB.sna\fR (snapshot image), \fB.zip\fR (zip of any previously described file).
+\fB.dsk\fR (disk image), \fB.ipf\fR (Interchangeable Preservation Format disk image), \fB.raw\fR (CT-RAW format), \fB.scp\fR (SuperCard Pro flux image), \fB.hfe\fR (HxC/Gotek flux image), \fB.a2r\fR (Applesauce flux image), \fB.voc\fR or \fB.cdt\fR (tape image), \fB.cpr\fR (cartridge image), \fB.sna\fR (snapshot image), \fB.zip\fR (zip of any previously described file).
 Specifying slot content on the command line is optional.
 .PP
-konCePCja supports two disk drives: drive A and drive B. If two disk image files (.dsk or .ipf) are provided, the first one will be loaded in drive A and the second one in drive B.
+konCePCja supports two disk drives: drive A and drive B. If two disk image files (.dsk or .ipf) are provided, the first one will be loaded in drive A and the second one in drive B. Flux images (.scp, .hfe, .a2r) load into drive A only \(em the FDC\(aqs flux capture is side-0/drive-A.
 .PP
 The \fBcart_path\fR, \fBsnap_path\fR, \fBdsk_path\fR and \fBtape_path\fR entries in the configuration file are \fIonly\fR used to specify the directory to open when loading/saving files in the GUI. The full path to the various slot contents must be provided on the command line.
 .PP

--- a/docs/ipc-protocol.md
+++ b/docs/ipc-protocol.md
@@ -39,7 +39,7 @@ See CLAUDE.md § Telnet Console for architecture details and key mappings.
 
 | Command | Description |
 |---------|-------------|
-| `load <path>` | Load file by extension: `.dsk` (drive A), `.sna` (snapshot), `.cpr` (cartridge), `.bin` (binary at 0x6000) |
+| `load <path>` | Load file by extension: `.dsk`/`.ipf`/`.raw` and the flux images `.scp`/`.hfe`/`.a2r` (all drive A — flux is drive-A only), `.cdt`/`.voc` (tape), `.sna` (snapshot), `.cpr` (cartridge), `.bin` (binary at 0x6000). An unrecognised extension returns `ERR 415 unsupported` |
 
 ## Registers
 

--- a/src/argparse.cpp
+++ b/src/argparse.cpp
@@ -26,19 +26,19 @@
 namespace {
 
 struct OptionSpec {
-  char short_name;        // unique key, also the short flag
+  char short_name;  // unique key, also the short flag
   std::string_view long_name;
   bool takes_value;
 };
 
 constexpr OptionSpec kOptions[] = {
-    {'a', "autocmd", true},      {'B', "exit-on-break", false},
-    {'c', "cfg_file", true},     {'D', "debug", false},
-    {'E', "exit-after", true},   {'F', "fps", false},
-    {'H', "headless", false},    {'h', "help", false},
-    {'i', "inject", true},       {'L', "list-plugins", false},
-    {'o', "offset", true},       {'O', "override", true},
-    {'s', "sym_file", true},     {'V', "version", false},
+    {'a', "autocmd", true},    {'B', "exit-on-break", false},
+    {'c', "cfg_file", true},   {'D', "debug", false},
+    {'E', "exit-after", true}, {'F', "fps", false},
+    {'H', "headless", false},  {'h', "help", false},
+    {'i', "inject", true},     {'L', "list-plugins", false},
+    {'o', "offset", true},     {'O', "override", true},
+    {'s', "sym_file", true},   {'V', "version", false},
     {'v', "verbose", false},
 };
 
@@ -106,7 +106,8 @@ void usage(std::ostream& os, const char* progPath, int errcode) {
   os << "\nslotfiles is an optional list of files giving the content of the "
         "various CPC ports.\n";
   os << "Ports files are identified by their extension. Supported formats are "
-        ".dsk (disk), .cdt or .voc (tape), .cpr (cartridge), .sna (snapshot), "
+        ".dsk, .ipf or .raw (disk), .scp, .hfe or .a2r (flux disk, drive A "
+        "only), .cdt or .voc (tape), .cpr (cartridge), .sna (snapshot), "
         "or .zip (archive containing one or more of the supported ports "
         "files).\n";
   os << "\nExample: " << progname << " sorcery.dsk\n";
@@ -153,8 +154,8 @@ void printVersion() {
 #endif
             << "\n";
 
-  std::cout << "Number of video plugins available: "
-            << video_plugin_list.size() << std::endl;
+  std::cout << "Number of video plugins available: " << video_plugin_list.size()
+            << std::endl;
   exit(0);
 }
 

--- a/src/imgui_ui.cpp
+++ b/src/imgui_ui.cpp
@@ -1105,12 +1105,15 @@ extern "C" void koncpc_request_file_dialog(int action) {
   switch (fda) {
     case FileDialogAction::LoadDiskA: {
       static const SDL_DialogFileFilter f[] = {
-          {"Disk Images", "dsk;ipf;raw;zip"}};
+          {"Disk Images", "dsk;ipf;raw;scp;hfe;a2r;zip"}};
       SDL_ShowOpenFileDialog(file_dialog_callback, ud, mainSDLWindow, f, 1,
                              CPC.current_dsk_path.c_str(), false);
       break;
     }
     case FileDialogAction::LoadDiskB: {
+      // No flux formats (scp/hfe/a2r) here on purpose: flux capture is
+      // drive-A-only (side-0/drive-A FDC seam) — see drive_extensions() in
+      // slotshandler.cpp, which the loader enforces.
       static const SDL_DialogFileFilter f[] = {
           {"Disk Images", "dsk;ipf;raw;zip"}};
       SDL_ShowOpenFileDialog(file_dialog_callback, ud, mainSDLWindow, f, 1,
@@ -2135,9 +2138,15 @@ void imgui_render_statusbar() {
             // Ask to confirm eject
             imgui_state.eject_confirm_drive = drv;
           } else {
-            // Load disk
-            static const SDL_DialogFileFilter disk_filters[] = {
+            // Load disk. Per-drive filters: drive A takes the flux
+            // containers, drive B must not (flux is drive-A-only — see
+            // drive_extensions() in slotshandler.cpp).
+            static const SDL_DialogFileFilter drive_a_filters[] = {
+                {"Disk Images", "dsk;ipf;raw;scp;hfe;a2r;zip"}};
+            static const SDL_DialogFileFilter drive_b_filters[] = {
                 {"Disk Images", "dsk;ipf;raw;zip"}};
+            const SDL_DialogFileFilter* disk_filters =
+                drv == 0 ? drive_a_filters : drive_b_filters;
             auto act = drv == 0 ? FileDialogAction::LoadDiskA_LED
                                 : FileDialogAction::LoadDiskB_LED;
             SDL_ShowOpenFileDialog(

--- a/src/imgui_ui_testable.h
+++ b/src/imgui_ui_testable.h
@@ -58,6 +58,23 @@ constexpr unsigned int SAMPLE_RATES[] = {11025, 22050, 44100, 48000, 96000};
 constexpr int SAMPLE_RATE_COUNT =
     sizeof(SAMPLE_RATES) / sizeof(SAMPLE_RATES[0]);
 
+// Exact-token membership in a dotted extension list (".dsk.ipf.raw"): true
+// iff `ext` (".dsk", lowercase, leading dot) appears as a WHOLE token — i.e.
+// followed by another '.' or the end of the list. Plain substring find() is
+// wrong here: ".hf" would match inside ".hfe". Pure so the drag-&-drop
+// routing can be unit-tested against the list slotshandler exports.
+inline bool extension_in_dotted_list(const std::string& list,
+                                     const std::string& ext) {
+  if (ext.size() < 2 || ext[0] != '.') return false;
+  size_t pos = 0;
+  while ((pos = list.find(ext, pos)) != std::string::npos) {
+    size_t const end = pos + ext.size();
+    if (end == list.size() || list[end] == '.') return true;
+    pos += 1;
+  }
+  return false;
+}
+
 // Check if a RAM size is in the allowed set
 inline bool is_valid_ram_size(unsigned int ram) {
   for (unsigned int const i : RAM_SIZES) {

--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -3930,7 +3930,11 @@ int koncpc_main(int argc, char** argv) {
                        std::filesystem::path(drop_path).filename();
           };
 
-          if (ext == ".dsk" || ext == ".ipf" || ext == ".raw") {
+          // Route by the list slotshandler actually accepts for drive A
+          // (.dsk/.ipf/.raw + the flux containers .scp/.hfe/.a2r) instead of
+          // a hand-kept copy — a dropped .hfe used to hit the unknown-file
+          // toast because this list had drifted from the loaders.
+          if (extension_in_dotted_list(drive_extensions(DRIVE::DSK_A), ext)) {
             if (already_mounted(CPC.driveA.file) ||
                 already_mounted(CPC.driveB.file)) {
               LOG_INFO("Ignoring drop of already-mounted disk: " << drop_fname);

--- a/src/koncepcja_ipc_server.cpp
+++ b/src/koncepcja_ipc_server.cpp
@@ -584,12 +584,16 @@ void init_command_registry() {
       "path — both observation-identical. Fast auto-degrades to faithful when "
       "the board is not the canonical device composition. 'get' reports the "
       "requested and effective tier and whether fast is available.");
-  register_command("load", "CORE", "load <file>",
-                   "Load a .DSK, .SNA, or .CPR file",
-                   "Loads a media or state file. Supports Disk Images (.DSK), "
-                   "Snapshots (.SNA), and Cartridges (.CPR). "
-                   "The file type is determined by the extension. For disks, "
-                   "it loads into Drive A.");
+  register_command(
+      "load", "CORE", "load <file>", "Load a disk, tape, snapshot or cartridge",
+      "Loads a media or state file; the type is determined by the "
+      "extension.\n"
+      "  Disks   (.dsk .ipf .raw) and flux images (.scp .hfe .a2r) load into "
+      "Drive A.\n"
+      "          Flux formats are Drive A only — the FDC's flux capture is "
+      "side-0/drive-A.\n"
+      "  Tapes   (.cdt .voc), snapshots (.sna), cartridges (.cpr), raw "
+      "binaries (.bin at 0x6000).");
 
   register_command("tier", "SYSTEM", "tier | tier set <policy>",
                    "Get or set the sub-cycle engine's run-tier policy",
@@ -1275,11 +1279,16 @@ std::string handle_command(const std::string& line) {
       auto dot = lower.find_last_of('.');
       if (dot == std::string::npos) return "ERR 415 unsupported\n";
       std::string const ext = lower.substr(dot);
-      if (ext == ".dsk") {
+      // Every drive-A disk format, from the one list slotshandler exports:
+      // .dsk/.ipf/.raw plus the flux containers .scp/.hfe/.a2r. This arm used
+      // to hard-code ".dsk" alone, so `load game.hfe` returned ERR 415 even
+      // though the loader handles it — the same front-door drift the drop
+      // handler had.
+      if (extension_in_dotted_list(drive_extensions(DRIVE::DSK_A), ext)) {
         CPC.driveA.file = path;
         CPC.driveA.zip_index = 0;
         return file_load(CPC.driveA) == 0 ? ok_with_context()
-                                          : "ERR 500 load-dsk\n";
+                                          : "ERR 500 load-disk\n";
       }
       if (ext == ".sna") {
         bool const was_paused = CPC.paused;

--- a/src/slotshandler.cpp
+++ b/src/slotshandler.cpp
@@ -945,7 +945,6 @@ int cartridge_load(FILE* file) {
   return ERR_FILE_UNSUPPORTED;
 }
 
-namespace {
 std::string drive_extensions(const DRIVE drive) {
   switch (drive) {
     case DRIVE::DSK_A:
@@ -963,7 +962,6 @@ std::string drive_extensions(const DRIVE drive) {
   LOG_ERROR("Unsupported drive type: " << static_cast<int>(drive))
   return "";
 }
-}  // namespace
 
 // Read a whole file into memory — for mirroring media into the sub-cycle
 // engine, which wants the raw image bytes rather than parsed track structures.

--- a/src/slotshandler.h
+++ b/src/slotshandler.h
@@ -15,6 +15,13 @@
 FILE* extractFile(const std::string& zipfile, const std::string& filename,
                   const std::string& ext);
 
+// The dotted extension list a slot accepts (e.g. ".dsk.ipf.raw.scp.hfe.a2r"
+// for drive A — flux containers are drive-A-only, side-0/drive-A flux
+// capture). THE single source of truth for what each slot loads: the loader
+// dispatch, the zip prefilter, the drag-&-drop routing and its drift-guard
+// test all consume this. Add a format here, not at the call sites.
+std::string drive_extensions(DRIVE drive);
+
 int snapshot_load(FILE* pfile);
 int snapshot_load(const std::string& filename);
 int snapshot_save(const std::string& filename);

--- a/test/drop_routing_test.cpp
+++ b/test/drop_routing_test.cpp
@@ -1,0 +1,61 @@
+// konCePCja — drag-&-drop extension routing.
+//
+// The drop handler used to compare against a hand-kept extension list that
+// drifted from what slotshandler's loaders actually accept: flux containers
+// (.hfe/.scp/.a2r) loaded fine from the CLI and File menu but a *drop* hit
+// the unknown-file toast. The fix routes drops through the one exported list
+// (drive_extensions) via an exact-token matcher; these tests pin both halves.
+
+#include <gtest/gtest.h>
+
+#include "imgui_ui_testable.h"
+#include "slotshandler.h"
+
+// ── The exact-token matcher ──────────────────────────────────────────
+
+TEST(ExtensionInDottedList, MatchesWholeTokensOnly) {
+  const std::string list = ".dsk.ipf.raw.scp.hfe.a2r";
+  EXPECT_TRUE(extension_in_dotted_list(list, ".dsk"));
+  EXPECT_TRUE(extension_in_dotted_list(list, ".a2r"));  // end of list
+  EXPECT_TRUE(extension_in_dotted_list(list, ".hfe"));
+  // Substring-but-not-a-token must NOT match — the trap plain find() has.
+  EXPECT_FALSE(extension_in_dotted_list(list, ".hf"));
+  EXPECT_FALSE(extension_in_dotted_list(list, ".a"));
+  EXPECT_FALSE(extension_in_dotted_list(list, ".ra"));
+}
+
+TEST(ExtensionInDottedList, RejectsDegenerateInput) {
+  EXPECT_FALSE(extension_in_dotted_list(".dsk", ""));
+  EXPECT_FALSE(extension_in_dotted_list(".dsk", "."));
+  EXPECT_FALSE(extension_in_dotted_list(".dsk", "dsk"));  // no leading dot
+  EXPECT_FALSE(extension_in_dotted_list("", ".dsk"));
+}
+
+// ── Drift guard: the routing consumes the REAL slot lists ────────────
+//
+// The drop handler calls extension_in_dotted_list(drive_extensions(DSK_A), e),
+// so these tests pin the actual exported list — not a copy. If a format is
+// added to (or removed from) slotshandler's drive-A set, this fails until the
+// expectations here are updated deliberately.
+
+TEST(DropRouting, DriveAAcceptsEveryDiskAndFluxFormat) {
+  const std::string a = drive_extensions(DRIVE::DSK_A);
+  for (const char* e : {".dsk", ".ipf", ".raw", ".scp", ".hfe", ".a2r"})
+    EXPECT_TRUE(extension_in_dotted_list(a, e)) << e;
+}
+
+TEST(DropRouting, DriveARejectsNonDiskMedia) {
+  const std::string a = drive_extensions(DRIVE::DSK_A);
+  for (const char* e : {".cdt", ".voc", ".sna", ".cpr", ".zip", ".bin", ".hf"})
+    EXPECT_FALSE(extension_in_dotted_list(a, e)) << e;
+}
+
+// Flux stays drive-A-only by FDC design (side-0/drive-A flux capture). The
+// drive-B dialogs and docs rely on this holding.
+TEST(DropRouting, DriveBExcludesFluxByDesign) {
+  const std::string b = drive_extensions(DRIVE::DSK_B);
+  for (const char* e : {".dsk", ".ipf", ".raw"})
+    EXPECT_TRUE(extension_in_dotted_list(b, e)) << e;
+  for (const char* e : {".scp", ".hfe", ".a2r"})
+    EXPECT_FALSE(extension_in_dotted_list(b, e)) << e;
+}

--- a/test/integrated/ipc_harness.py
+++ b/test/integrated/ipc_harness.py
@@ -985,6 +985,61 @@ def test_joystick_input():
         return True
 
 
+def test_load_accepts_flux_disk_formats():
+    """IPC `load` routes flux disk images to drive A (beads-wxy6).
+
+    The dispatcher hard-coded ".dsk", so `load game.hfe` returned
+    ERR 415 unsupported even though the loader handles HFE — a front door
+    that had drifted from what slotshandler actually accepts.
+
+    Discriminates at the DOOR, not the loader: a deliberately-invalid file
+    with an accepted extension must get past extension dispatch and fail in
+    the loader (ERR 500), while an unknown extension is still rejected up
+    front (ERR 415). That distinction is exactly what this fix changed, and
+    it needs no real disk fixture — the repo has no flux images checked in.
+    """
+    print("Running IPC flux-format load routing test...")
+
+    import tempfile
+
+    with EmulatorRunner() as emu:
+        if not emu.start():
+            print("FAIL: Could not start emulator")
+            return False
+
+        with tempfile.TemporaryDirectory() as td:
+            # Accepted extensions: past the door, rejected by the loader.
+            for ext in ('.hfe', '.scp', '.a2r', '.ipf', '.raw', '.dsk'):
+                path = os.path.join(td, 'probe' + ext)
+                with open(path, 'wb') as f:
+                    f.write(b'not a real disk image')
+                ok, resp = emu.ipc.send_command('load ' + path)
+                if '415' in resp:
+                    print(f"FAIL: {ext} rejected at the door: {resp.strip()!r}")
+                    return False
+                print(f"  {ext}: accepted by dispatch -> {resp.strip()}")
+
+            # Unknown extension must still be refused up front.
+            path = os.path.join(td, 'probe.xyz')
+            with open(path, 'wb') as f:
+                f.write(b'nope')
+            ok, resp = emu.ipc.send_command('load ' + path)
+            if '415' not in resp:
+                print(f"FAIL: unknown ext should be ERR 415, got {resp.strip()!r}")
+                return False
+            print(f"  .xyz: correctly refused -> {resp.strip()}")
+
+        # The help text must advertise what the dispatcher accepts.
+        ok, resp = emu.ipc.send_command('help load')
+        if '.hfe' not in resp:
+            print(f"FAIL: 'help load' does not mention flux formats: {resp!r}")
+            return False
+        print("  help load advertises the flux formats")
+
+    print("PASS: IPC load accepts flux disk formats")
+    return True
+
+
 def main():
     """Run all IPC tests."""
     print("=" * 50)
@@ -1008,6 +1063,7 @@ def main():
         test_type_input,
         test_input_state,
         test_joystick_input,
+        test_load_accepts_flux_disk_formats,
     ]
 
     passed = 0


### PR DESCRIPTION
Implements `docs/plans/2026-07-30-001-feat-flux-drag-drop-dialog-plan.md`.

HFE/SCP/A2R loading has worked since the flux work landed — the pipeline reads them, `slotshandler` accepts them for drive A. What didn't work was **getting a file in**: three separate front doors each kept their own hand-written extension list, and all three had drifted from what the loaders actually accept.

| Front door | Before | After |
|---|---|---|
| Drag & drop | `.hfe` → "Unknown file type" toast | mounts drive A (toast + MRU) |
| File ▸ Load Disk A / drive-LED dialog | flux greyed out | selectable |
| IPC `load` | `ERR 415 unsupported` | loads — **and `.ipf`/`.raw`, also missing** |

## The actual fix: one exported list, not four copies

`drive_extensions()` was internal-linkage in `slotshandler.cpp`, so every caller kept a copy and the copies drifted. It's now exported from `slotshandler.h` as the single source of truth, and all three front doors consume it.

Matching is an **exact-token** test, not `find()` — a plain substring search would let `.hf` match inside `.hfe`. That's pinned by a test.

## Scope note: `.ipf`/`.raw` over IPC

Not in the plan. Routing the IPC dispatcher through the shared list picked them up for free — they were missing for the same reason. Excluding them would have meant writing *more* code to preserve a bug.

## Drive B still excludes flux, deliberately

Flux capture is side-0/drive-A only (FDC seam). Drive B's dialog filter is unchanged and now carries a comment saying why; a test pins the asymmetry so it reads as intent rather than oversight. The drive-LED dialog previously shared one filter array across both drives, so drive A couldn't gain flux without drive B gaining it too — split per drive.

## Verification

- **1605 unit tests** green (`--gtest_shuffle`), **16/16 IPC harness** green, `make clang-format` clean.
- **IPC verified live** against a running emulator — the discrimination is at the door: an accepted extension with garbage content returns `ERR 500 load-disk` (past dispatch, loader rejected it), an unknown extension still returns `ERR 415 unsupported`. Before, `.hfe` returned 415. That's the exact behaviour change, and it needs no flux fixture — the repo has none checked in.
- `./koncepcja --help` and `man` render the new format lists correctly.
- **Drag & drop is covered by unit tests and code review, not an actual drag** — I can't synthesise a real `SDL_EVENT_DROP_FILE` from here. The routing predicate is directly tested; the branch it now enters is the unchanged `.dsk` branch.

## One thing left undone

`doc/man.html` is **generated** from `doc/man6/koncepcja.6` (`make doc`, via groff). The `.6` source is updated and `man(1)` renders it cleanly, but groff isn't available in this environment and no CI job rebuilds the HTML — so the derived file is now one revision stale. I did not hand-edit it: editing a generated artifact is exactly the drift this PR removes. It needs `make doc` on a machine with groff.
