### PR TITLE
fix: config truncation, silent audio, and the flat PSG scope

### DIFF
--- a/src/config_profile.cpp
+++ b/src/config_profile.cpp
@@ -173,6 +173,7 @@ std::string ConfigProfileManager::load(const std::string& name) {
   CPC.snd_bits = p.snd_bits;
   CPC.snd_stereo = p.snd_stereo;
   CPC.snd_volume = p.snd_volume;
+  audio_apply_volume();  // gain lives on the SDL stream — push the new value
   CPC.joystick_emulation = static_cast<JoystickEmulation>(p.joystick_emulation);
   CPC.keyboard_support_mode =
       static_cast<KeyboardSupportMode>(p.keyboard_support_mode);

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -2,6 +2,7 @@
 
 #include "configuration.h"
 
+#include <algorithm>
 #include <cstdlib>
 #include <fstream>
 #include <sstream>
@@ -33,6 +34,56 @@ std::string_view parse_section_name(std::string_view line) {
   return line.substr(start, end == std::string_view::npos ? end : end - start);
 }
 
+// The key a line assigns, or empty when the line carries no key/value pair.
+// Deliberately mirrors parseStream's tokenizer step for step: if the writer
+// and the reader ever disagreed about which lines hold a value, a save would
+// either duplicate a key or leave a stale one behind.
+std::string_view line_key(std::string_view line) {
+  if (!line.empty() && line.front() == '[') return {};  // section header
+  size_t const key_start = line.find_first_not_of(kKeyDelims);
+  if (key_start == std::string_view::npos) return {};  // blank
+  if (line[key_start] == '#') return {};               // comment
+  size_t const key_end = line.find_first_of(kKeyDelims, key_start);
+  if (key_end == std::string_view::npos) return {};  // no separator
+  return line.substr(key_start, key_end - key_start);
+}
+
+// The stored value, or nullptr when the map has no such section/key.
+const std::string* find_in(const ConfigMap& map, const std::string& section,
+                           const std::string& key) {
+  auto sec = map.find(section);
+  if (sec == map.end()) return nullptr;
+  auto entry = sec->second.find(key);
+  return entry == sec->second.end() ? nullptr : &entry->second;
+}
+
+// Rewrite `line`'s value, keeping its key spelling, its spacing around the
+// separator and any inline '#' comment.
+std::string rewrite_value(const std::string& line, const std::string& value) {
+  size_t const key_end = line.find_first_of(
+      kKeyDelims, line.find_first_not_of(kKeyDelims));  // past the key
+  size_t const eq = line.find('=', key_end);
+  size_t const sep_end = (eq == std::string::npos) ? key_end : eq + 1;
+  // Everything up to and including the separator plus the blanks after it.
+  size_t value_start = line.find_first_not_of(" \t", sep_end);
+  if (value_start == std::string::npos) value_start = line.size();
+  std::string out = line.substr(0, value_start);
+  if (eq == std::string::npos) out += "=";
+  out += value;
+
+  // An empty value drops the comment: "key= # note" re-parses as the value
+  // "note", because parseStream skips '#' when hunting for the value start.
+  if (value.empty()) return out;
+  size_t const hash = line.find('#', value_start);
+  if (hash != std::string::npos) {
+    // max(): guards a line that had no value at all, just "key= # note".
+    size_t const gap =
+        std::max(value_start, line.find_last_not_of(" \t", hash - 1) + 1);
+    out += line.substr(gap);
+  }
+  return out;
+}
+
 }  // namespace
 
 bool hasValue(const ConfigMap& config, const std::string& section,
@@ -46,6 +97,10 @@ std::istream& Config::parseStream(std::istream& configStream) {
   std::string section;
   while (std::getline(configStream, line)) {
     if (!line.empty() && line.back() == '\r') line.pop_back();  // CRLF files
+    // Kept verbatim (comments and all) so toStream can rewrite this file
+    // rather than regenerate it. Appended, not replaced: parsing a second
+    // stream adds to this Config, and its text has to come along.
+    lines_.push_back(line);
     std::string_view rest = line;
 
     if (!rest.empty() && rest.front() == '[') {
@@ -86,11 +141,76 @@ void Config::parseFile(const std::string& configFilename) {
 }
 
 std::ostream& Config::toStream(std::ostream& out) const {
-  for (const auto& [section, entries] : config_) {
+  auto dump_section = [&out](const std::string& section,
+                             const ConfigSection& entries) {
     out << "[" << section << "]\n";
-    for (const auto& [key, value] : entries) {
-      out << key << "=" << value << "\n";
+    for (const auto& [key, value] : entries) out << key << "=" << value << "\n";
+  };
+
+  if (lines_.empty()) {  // nothing was parsed: generate from scratch
+    for (const auto& [section, entries] : config_) dump_section(section, entries);
+    return out;
+  }
+
+  // Rewrite the parsed text in place. `pending` starts as the full model and
+  // loses each key as its existing line is rewritten; whatever is left is
+  // genuinely new and gets appended to its section (or to a new one).
+  ConfigMap pending = config_;
+  std::string section;
+  std::vector<std::string> buffered;
+
+  // Emit the section just finished, appending its new keys after its last
+  // non-blank line so trailing blank lines stay trailing.
+  auto flush = [&] {
+    auto sec = pending.find(section);
+    if (sec != pending.end() && !sec->second.empty()) {
+      size_t at = buffered.size();
+      while (at > 0 && buffered[at - 1].empty()) --at;
+      std::vector<std::string> added;
+      added.reserve(sec->second.size());
+      for (const auto& [key, value] : sec->second) {
+        std::string entry = key;
+        entry += "=";
+        entry += value;
+        added.push_back(std::move(entry));
+      }
+      buffered.insert(buffered.begin() + static_cast<long>(at), added.begin(),
+                      added.end());
     }
+    pending.erase(section);
+    for (const auto& line : buffered) out << line << "\n";
+    buffered.clear();
+  };
+
+  for (const std::string& line : lines_) {
+    if (!line.empty() && line.front() == '[') {
+      std::string_view const name = parse_section_name(line);
+      if (!name.empty()) {
+        flush();
+        section = std::string(name);
+      }
+      buffered.push_back(line);
+      continue;
+    }
+
+    std::string_view const key = line_key(line);
+    const std::string* value =
+        key.empty() ? nullptr : find_in(config_, section, std::string(key));
+    if (value != nullptr) {
+      // Every occurrence is rewritten, not just the first: a file that
+      // repeats a key must not re-parse to the stale duplicate.
+      buffered.push_back(rewrite_value(line, *value));
+      auto p = pending.find(section);
+      if (p != pending.end()) p->second.erase(std::string(key));
+      continue;
+    }
+    buffered.push_back(line);
+  }
+  flush();
+
+  // Sections the file never had.
+  for (const auto& [name, entries] : pending) {
+    if (!entries.empty()) dump_section(name, entries);
   }
   return out;
 }
@@ -113,13 +233,8 @@ void Config::setOverrides(const ConfigMap& overrides) {
 
 const std::string* Config::find(const std::string& section,
                                 const std::string& key) const {
-  for (const ConfigMap* map : {&overrides_, &config_}) {
-    auto sec = map->find(section);
-    if (sec == map->end()) continue;
-    auto entry = sec->second.find(key);
-    if (entry != sec->second.end()) return &entry->second;
-  }
-  return nullptr;
+  if (const std::string* value = find_in(overrides_, section, key)) return value;
+  return find_in(config_, section, key);
 }
 
 int Config::getIntValue(const std::string& section, const std::string& key,

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -148,7 +148,8 @@ std::ostream& Config::toStream(std::ostream& out) const {
   };
 
   if (lines_.empty()) {  // nothing was parsed: generate from scratch
-    for (const auto& [section, entries] : config_) dump_section(section, entries);
+    for (const auto& [section, entries] : config_)
+      dump_section(section, entries);
     return out;
   }
 
@@ -233,7 +234,8 @@ void Config::setOverrides(const ConfigMap& overrides) {
 
 const std::string* Config::find(const std::string& section,
                                 const std::string& key) const {
-  if (const std::string* value = find_in(overrides_, section, key)) return value;
+  if (const std::string* value = find_in(overrides_, section, key))
+    return value;
   return find_in(config_, section, key);
 }
 

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -9,9 +9,15 @@
 // Values set via setIntValue/setStringValue land in both the persisted map
 // and the override map; overrides (e.g. from -O on the command line) win
 // over parsed file content on reads.
+//
+// Writing is round-trip preserving: a Config that parsed a file remembers its
+// text and rewrites values in place, so comments, blank lines, key order and
+// keys this build knows nothing about all survive a save. Only a Config that
+// never parsed anything falls back to generating a bare key=value dump.
 
 #include <map>
 #include <string>
+#include <vector>
 
 namespace config {
 using ConfigSection = std::map<std::string, std::string>;
@@ -52,5 +58,11 @@ class Config {
 
   ConfigMap config_;
   ConfigMap overrides_;
+
+  // Verbatim text of everything parsed into this Config, in order. Empty for
+  // a Config built purely by setIntValue/setStringValue (e.g. a brand-new
+  // config file), which is the only case that still generates output from
+  // scratch.
+  std::vector<std::string> lines_;
 };
 }  // namespace config

--- a/src/imgui_ui.cpp
+++ b/src/imgui_ui.cpp
@@ -3464,7 +3464,16 @@ void imgui_render_options() {
       // mutated (out-param/compound-assign/loop/reference)
       bool snd = CPC.snd_enabled != 0;
       if (ImGui::Checkbox("Enable Sound", &snd)) {
-        CPC.snd_enabled = snd ? 1 : 0;
+        if (snd) {
+          // Open/resume the device BEFORE raising the flag: the Z80 thread's
+          // push gate keys on snd_enabled, and a session that booted with
+          // sound off has no stream at all until audio_enable() creates one.
+          audio_enable();
+          CPC.snd_enabled = 1;
+        } else {
+          CPC.snd_enabled = 0;  // close the push gate first, then halt
+          audio_pause();
+        }
       }
 
       static constexpr int kDefaultSampleRateIndex = 2;  // 44100 Hz
@@ -3505,6 +3514,7 @@ void imgui_render_options() {
       int vol = static_cast<int>(CPC.snd_volume);
       if (ImGui::SliderInt("Volume", &vol, 0, 100)) {
         CPC.snd_volume = vol;
+        audio_apply_volume();  // live: gain on the AY stream, host-side
       }
 
       ImGui::Separator();

--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -2415,6 +2415,35 @@ void koncpc_queue_virtual_keys(const std::string& text) {
   g_autotype_queue.enqueue_legacy(text);
 }
 
+// Toggle windowed/fullscreen.
+//
+// MUST quiesce the Z80 thread first. video_shutdown() tears down the surface
+// and GPU resources the emulation thread renders into, so doing it while that
+// thread runs is a use-after-free: the crash lands in z80_thread_main() with
+// EXC_BAD_ACCESS at a small offset, on the Z80 thread, while the fullscreen key
+// was pressed on the main thread. The previous code paused only *audio* and
+// then SDL_Delay(20)'d, which is a hope rather than a guarantee -- on a busy
+// frame the Z80 thread is still inside the renderer when the surface goes away.
+// Same contract emulator_reset() needs (see cpc_pause_and_wait).
+void koncpc_toggle_fullscreen() {
+  bool const was_paused = CPC.paused;
+  if (!was_paused) cpc_pause_and_wait();
+
+  audio_pause();
+  video_shutdown();
+  CPC.scr_window = CPC.scr_window ? 0 : 1;
+  if (video_init()) {
+    fprintf(stderr, "video_init() failed. Aborting.\n");
+    cleanExit(-1);
+  }
+#ifdef __APPLE__
+  koncpc_setup_macos_menu();
+#endif
+  audio_resume();
+
+  if (!was_paused) cpc_resume();
+}
+
 void koncpc_menu_action(int action) {
   switch (action) {
     case KONCPC_GUI: {
@@ -2445,18 +2474,7 @@ void koncpc_menu_action(int action) {
     }
 
     case KONCPC_FULLSCRN:
-      audio_pause();
-      SDL_Delay(20);
-      video_shutdown();
-      CPC.scr_window = CPC.scr_window ? 0 : 1;
-      if (video_init()) {
-        fprintf(stderr, "video_init() failed. Aborting.\n");
-        cleanExit(-1);
-      }
-#ifdef __APPLE__
-      koncpc_setup_macos_menu();
-#endif
-      audio_resume();
+      koncpc_toggle_fullscreen();
       break;
 
     case KONCPC_SCRNSHOT:
@@ -4081,18 +4099,7 @@ int koncpc_main(int argc, char** argv) {
                 break;
               }
               case KONCPC_FULLSCRN:
-                audio_pause();
-                SDL_Delay(20);
-                video_shutdown();
-                CPC.scr_window = CPC.scr_window ? 0 : 1;
-                if (video_init()) {
-                  fprintf(stderr, "video_init() failed. Aborting.\n");
-                  cleanExit(-1);
-                }
-#ifdef __APPLE__
-                koncpc_setup_macos_menu();
-#endif
-                audio_resume();
+                koncpc_toggle_fullscreen();
                 break;
               case KONCPC_SCRNSHOT:
                 koncpc_menu_action(KONCPC_SCRNSHOT);

--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -2228,10 +2228,19 @@ void loadConfiguration(t_CPC& CPC, const std::string& configFilename) {
 // same section, same name, same encoding (flags as 0/1 ints).
 bool saveConfiguration(t_CPC& CPC, const std::string& configFilename) {
   config::Config conf;
+  // Read before write. Building a fresh Config here deleted every comment in
+  // the file and every key this build does not set — and because the MRU list
+  // auto-saves on each file open, that happened constantly. Parsing first
+  // turns the save into an edit: unknown keys, hand-written notes and any
+  // setting a newer build understands all survive.
+  conf.parseFile(configFilename);
 
   conf.setIntValue("system", "model", CPC.model);
   conf.setIntValue("system", "jumpers", CPC.jumpers);
   conf.setIntValue("system", "ram_size", CPC.ram_size);
+  conf.setIntValue("system", "silicon_disc", g_silicon_disc.enabled ? 1 : 0);
+  conf.setIntValue("system", "run_tier",
+                   static_cast<int>(subcycle_bridge_tier_policy()));
   conf.setIntValue("system", "limit_speed", CPC.limit_speed);
   conf.setIntValue("system", "frameskip", CPC.frameskip);
   conf.setIntValue("system", "speed", CPC.speed);
@@ -2265,8 +2274,10 @@ bool saveConfiguration(t_CPC& CPC, const std::string& configFilename) {
   conf.setIntValue("video", "scr_intensity", CPC.scr_intensity);
   conf.setIntValue("video", "scr_remanency", CPC.scr_remanency);
   conf.setIntValue("video", "scr_window", CPC.scr_window);
+  conf.setIntValue("video", "vsync", CPC.scr_vsync);
 
   conf.setIntValue("devtools", "scale", CPC.devtools_scale);
+  conf.setIntValue("devtools", "max_stack_size", CPC.devtools_max_stack_size);
 
   conf.setIntValue("ui", "workspace_layout",
                    static_cast<int>(CPC.workspace_layout));
@@ -2292,6 +2303,10 @@ bool saveConfiguration(t_CPC& CPC, const std::string& configFilename) {
                       drive_sounds_params_to_string());
   conf.setIntValue("system", "smartwatch", g_smartwatch.enabled ? 1 : 0);
   conf.setIntValue("input", "amx_mouse", g_amx_mouse.enabled ? 1 : 0);
+  // Via Value, not int: PhazerType converts implicitly to both Value and
+  // bool, so a direct static_cast<int> is ambiguous.
+  conf.setIntValue("input", "lightgun",
+                   static_cast<PhazerType::Value>(CPC.phazer_emulation));
 
   conf.setIntValue("peripheral", "symbiface", g_symbiface.enabled ? 1 : 0);
   conf.setStringValue("peripheral", "ide_master",

--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -1275,10 +1275,6 @@ void SDLCALL drive_sounds_audio_callback(void* /*userdata*/,
 int audio_init() {
   SDL_AudioSpec desired;
 
-  if (!CPC.snd_enabled) {
-    return 0;
-  }
-
   CPC.snd_ready = false;
 
   desired.freq = freq_table[CPC.snd_playback_rate];
@@ -1323,6 +1319,7 @@ int audio_init() {
   }
   SDL_ResumeAudioDevice(SDL_GetAudioStreamDevice(audio_stream));
   CPC.snd_ready = true;
+  audio_apply_volume();
   LOG_VERBOSE("Audio: Sound buffer ready");
 
   drive_sounds_init(desired.freq);
@@ -1368,8 +1365,12 @@ void audio_shutdown() {
   }
 }
 
+// Guard on the stream, not CPC.snd_enabled: snd_enabled is the user's config
+// INTENT (persisted by saveConfiguration); whether a device is actually open
+// is runtime state. Mixing the two is what allowed a sound-off session to
+// leave the device in a stale pause/resume state.
 void audio_pause() {
-  if (CPC.snd_enabled && audio_stream) {
+  if (audio_stream) {
     SDL_PauseAudioDevice(SDL_GetAudioStreamDevice(audio_stream));
     // Halt the host SFX device too, so drive/tape sounds stop with emulation.
     if (drive_audio_stream) {
@@ -1379,12 +1380,45 @@ void audio_pause() {
 }
 
 void audio_resume() {
-  if (CPC.snd_enabled && audio_stream) {
+  if (audio_stream) {
     SDL_ResumeAudioDevice(SDL_GetAudioStreamDevice(audio_stream));
     if (drive_audio_stream) {
       SDL_ResumeAudioDevice(SDL_GetAudioStreamDevice(drive_audio_stream));
     }
   }
+}
+
+// Map the 0..100 config volume onto the AY stream's output gain. The legacy
+// core baked snd_volume into its PSG level tables; the sub-cycle machine
+// renders at a fixed reference gain (kAudioGain) and knows nothing about the
+// host, so the volume knob has to act host-side — on the SDL stream — or it
+// is wired to nothing at all (which is exactly what shipped with Gate C).
+// The drive/tape SFX stream keeps its own level model, matching the legacy
+// scope of snd_volume (PSG mixer only).
+void audio_apply_volume() {
+  if (audio_stream) {
+    SDL_SetAudioStreamGain(audio_stream,
+                           static_cast<float>(CPC.snd_volume) / 100.0f);
+  }
+}
+
+// Runtime "Enable Sound": a session that booted with sound disabled never
+// opened a device (audio_init is skipped entirely), so the checkbox must be
+// able to create the stream lazily — otherwise enabling sound silently does
+// nothing until the next restart. Disable is just audio_pause(): the stream
+// is kept for cheap re-enable, and the frame-loop push gate (CPC.snd_enabled)
+// stops feeding it. Called from the UI thread; safe against the Z80 thread's
+// audio_push_buffer because that gate is only opened (snd_enabled=1) after
+// this returns, and audio_init publishes CPC.snd_ready last.
+void audio_enable() {
+  if (!audio_stream) {
+    if (audio_init()) {
+      LOG_ERROR("Audio: could not enable sound: " << SDL_GetError());
+      return;
+    }
+  }
+  audio_resume();
+  audio_apply_volume();
 }
 
 void cpc_pause() {
@@ -3727,8 +3761,13 @@ int koncpc_main(int argc, char** argv) {
     CPC.scr_bps = back_surface->pitch;
     CPC.scr_line_offs = CPC.scr_bps * dwYScale;
     CPC.scr_pos = CPC.scr_base = static_cast<byte*>(back_surface->pixels);
-    // No audio in headless mode
-    CPC.snd_enabled = 0;
+    // No audio in headless mode: audio_init() is simply never called, so
+    // audio_push_buffer() no-ops (audio_stream null, snd_ready false).
+    // CPC.snd_enabled is deliberately NOT cleared — it is the user's config
+    // intent and saveConfiguration persists it; clearing it here meant one
+    // headless run could write sound=off into the user's cfg and permanently
+    // silence every later GUI session (the config-poisoning variant of the
+    // engine=1 host-state gaps).
   } else {
     if (video_init()) {
       fprintf(stderr, "video_init() failed. Aborting.\n");
@@ -3750,9 +3789,11 @@ int koncpc_main(int argc, char** argv) {
     // video_set_topbar handles the window resize using compute_window_size()
     mouse_init();
 
-    if (audio_init()) {
-      fprintf(stderr, "audio_init() failed. Disabling sound.\n");
-      CPC.snd_enabled = 0;
+    if (CPC.snd_enabled && audio_init()) {
+      fprintf(stderr, "audio_init() failed. Sound unavailable this session.\n");
+      // Do NOT clear CPC.snd_enabled: it is persisted config intent, and
+      // zeroing it turned one bad boot into a permanently silenced cfg.
+      // audio_push_buffer() already no-ops while snd_ready is false.
     }
 
     if (joysticks_init()) {

--- a/src/koncepcja.h
+++ b/src/koncepcja.h
@@ -583,6 +583,8 @@ int audio_init();
 void audio_shutdown();
 void audio_pause();
 void audio_resume();
+void audio_enable();        // runtime "Enable Sound": lazily opens the stream
+void audio_apply_volume();  // push CPC.snd_volume to the AY stream's gain
 void mouse_init();
 int video_init();
 void video_shutdown();

--- a/src/subcycle_bridge.cpp
+++ b/src/subcycle_bridge.cpp
@@ -944,6 +944,19 @@ int subcycle_bridge_debug_sync() {
   std::memcpy(PSG.RegisterAY.Index, ps.reg, sizeof(ps.reg));
   PSG.reg_select = ps.sel;
 
+  // Feed the DevTools PSG oscilloscope. g_psg_scope had NO writer at all --
+  // the legacy core used to fill it, engine=1 never did, so the Audio State
+  // waveforms drew a flat line of zeros while the register table above showed
+  // live values. Same host-mirror gap the tape scope had.
+  //
+  // One sample per debug-sync (per frame), not per PSG tick: this is a
+  // cheap "is it making noise, and roughly how loud" strip, and the sync seam
+  // is the only place that already holds a coherent PSG peek. Amplitudes are
+  // the per-channel level the chip is actually driving (0..31), sign-extended
+  // to the scope's int16 so the plot has something to scale.
+  g_psg_scope.push(ps.chan_level[0], ps.chan_level[1], ps.chan_level[2],
+                   ps.env_level);
+
   ProbeHit hit{};
   if (b.machine.probe_hit(&hit)) {
     if (hit.kind == PROBE_HIT_EXEC && hit.addr == z80.break_point) {

--- a/test/configuration.cpp
+++ b/test/configuration.cpp
@@ -116,22 +116,150 @@ TEST_F(ConfigurationTest, parseFileDoesntExist) {
   configuration_.parseFile("/a/non/existing/file");
 }
 
-TEST_F(ConfigurationTest, saveToFileAndMore) {
-  std::string initalConfig =
+namespace {
+std::string readFile(const std::string& path) {
+  std::ifstream ifs(path);
+  std::stringstream buffer;
+  buffer << ifs.rdbuf();
+  return buffer.str();
+}
+}  // namespace
+
+// Saving is an edit of the parsed text, not a regeneration of it. Before this,
+// toStream dumped the key/value map and every comment in koncepcja.cfg — a
+// self-documenting template — was deleted the first time anything saved.
+TEST_F(ConfigurationTest, saveToFileKeepsCommentsAndLayout) {
+  std::string const initialConfig =
       "# A comment in top\n"
       "[system] # A comment at the end of the line\n"
       "model=42\n";
-  std::string expectedConfig =
-      "[system]\n"
-      "model=42\n";
-  configuration_.parseString(initalConfig);
+  configuration_.parseString(initialConfig);
 
   configuration_.saveToFile(getTmpFilename(0));
 
-  std::ifstream ifs(getTmpFilename(0));
-  std::stringstream buffer;
-  buffer << ifs.rdbuf();
-  ASSERT_EQ(expectedConfig, buffer.str());
+  ASSERT_EQ(initialConfig, readFile(getTmpFilename(0)));
+}
+
+// Honest note on coverage: this test does NOT discriminate the key-loss bug.
+// The old writer dumped config_, which already held every parsed key, so it
+// passed before the fix too — the keys were lost one level up, in
+// saveConfiguration, which never read the file it overwrote (see
+// saveConfigurationEditsTheFileInsteadOfReplacingIt, which does discriminate).
+// Kept as a forward guard: rewriting lines in place must not drop a key.
+TEST_F(ConfigurationTest, saveToFileKeepsParsedKeysItNeverSets) {
+  configuration_.parseString(
+      "[system]\n"
+      "model=42\n"
+      "a_key_from_a_newer_build=hello\n");
+
+  configuration_.setIntValue("system", "model", 2);
+  configuration_.saveToFile(getTmpFilename(0));
+
+  config::Config reloaded;
+  reloaded.parseFile(getTmpFilename(0));
+  ASSERT_EQ(2, reloaded.getIntValue("system", "model", 0));
+  ASSERT_EQ("hello", reloaded.getStringValue(
+                         "system", "a_key_from_a_newer_build", "GONE"));
+}
+
+TEST_F(ConfigurationTest, saveToFileRewritesValueInPlaceKeepingSpacingAndComment) {
+  configuration_.parseString(
+      "[system]\n"
+      "model = 42  # the machine\n"
+      "speed=4\n");
+
+  configuration_.setIntValue("system", "model", 3);
+  configuration_.saveToFile(getTmpFilename(0));
+
+  ASSERT_EQ(
+      "[system]\n"
+      "model = 3  # the machine\n"
+      "speed=4\n",
+      readFile(getTmpFilename(0)));
+}
+
+// New keys join their section (after its last non-blank line, so trailing
+// blank lines stay trailing); a section the file never had goes at the end.
+TEST_F(ConfigurationTest, saveToFileAppendsNewKeysToTheirSection) {
+  configuration_.parseString(
+      "[system]\n"
+      "model=2\n"
+      "\n"
+      "[video]\n"
+      "scr_scale=1\n");
+
+  configuration_.setIntValue("system", "speed", 4);
+  configuration_.setIntValue("sound", "volume", 80);
+  configuration_.saveToFile(getTmpFilename(0));
+
+  ASSERT_EQ(
+      "[system]\n"
+      "model=2\n"
+      "speed=4\n"
+      "\n"
+      "[video]\n"
+      "scr_scale=1\n"
+      "[sound]\n"
+      "volume=80\n",
+      readFile(getTmpFilename(0)));
+}
+
+// A file that repeats a key must not re-parse to the stale duplicate: every
+// occurrence carries the new value.
+TEST_F(ConfigurationTest, saveToFileRewritesEveryOccurrenceOfARepeatedKey) {
+  configuration_.parseString(
+      "[system]\n"
+      "model=1\n"
+      "model=2\n");
+
+  configuration_.setIntValue("system", "model", 3);
+  configuration_.saveToFile(getTmpFilename(0));
+
+  ASSERT_EQ(
+      "[system]\n"
+      "model=3\n"
+      "model=3\n",
+      readFile(getTmpFilename(0)));
+
+  config::Config reloaded;
+  reloaded.parseFile(getTmpFilename(0));
+  ASSERT_EQ(3, reloaded.getIntValue("system", "model", 0));
+}
+
+// Re-saving must converge: the emulator writes this file on every file open.
+TEST_F(ConfigurationTest, saveToFileIsIdempotent) {
+  configuration_.parseString(
+      "# top\n"
+      "[system]\n"
+      "model = 2 # a comment\n"
+      "\n"
+      "[video]\n"
+      "scr_scale=1\n");
+  configuration_.setIntValue("sound", "volume", 80);
+  configuration_.saveToFile(getTmpFilename(0));
+  std::string const once = readFile(getTmpFilename(0));
+
+  config::Config again;
+  again.parseFile(getTmpFilename(0));
+  again.saveToFile(getTmpFilename(1));
+
+  ASSERT_EQ(once, readFile(getTmpFilename(1)));
+}
+
+// A Config that never parsed anything (a config file that does not exist yet)
+// still generates a complete file from scratch.
+TEST_F(ConfigurationTest, saveToFileGeneratesFromScratchWhenNothingWasParsed) {
+  configuration_.setIntValue("system", "model", 2);
+  configuration_.setIntValue("sound", "volume", 80);
+
+  configuration_.saveToFile(getTmpFilename(0));
+
+  ASSERT_EQ(
+      "[sound]\n"
+      "volume=80\n"
+      "[system]\n"
+      "model=2\n",
+      readFile(getTmpFilename(0)));
 }
 
 #ifndef _MSC_VER
@@ -227,6 +355,74 @@ TEST_F(ConfigurationTest, loadConfigurationWithInvalidValues) {
   ASSERT_EQ(0, CPC.printer);
   ASSERT_EQ(std::string(chAppPath) + "/resources",
             std::string(CPC.resources_path));
+}
+
+// Every key loadConfiguration reads, saveConfiguration must write back. Five
+// did not — vsync, run_tier, lightgun, silicon_disc and max_stack_size were
+// read at boot and then deleted by the next save, so setting any of them
+// silently reverted to the default. The MRU list auto-saves on every file
+// open, so "the next save" was one disk load away.
+TEST_F(ConfigurationTest, saveConfigurationPreservesEverySettingItReads) {
+  std::ofstream configFile(getTmpFilename(0));
+  configFile << "# a hand-written note\n"
+             << "[system]\n"
+             << "model=2\n"
+             << "run_tier=2\n"
+             << "silicon_disc=1\n"
+             << "a_key_from_a_newer_build=keep me\n"
+             << "[video]\n"
+             << "vsync=0\n"
+             << "[input]\n"
+             << "lightgun=2\n"
+             << "[devtools]\n"
+             << "max_stack_size=99\n";
+  configFile.close();
+
+  t_CPC CPC[2];
+  loadConfiguration(CPC[0], getTmpFilename(0));
+  saveConfiguration(CPC[0], getTmpFilename(1));
+
+  config::Config saved;
+  saved.parseFile(getTmpFilename(1));
+  EXPECT_EQ(0, saved.getIntValue("video", "vsync", 1)) << "vsync was dropped";
+  EXPECT_EQ(2, saved.getIntValue("system", "run_tier", 0))
+      << "run_tier was dropped";
+  EXPECT_EQ(2, saved.getIntValue("input", "lightgun", 0))
+      << "lightgun was dropped";
+  EXPECT_EQ(1, saved.getIntValue("system", "silicon_disc", 0))
+      << "silicon_disc was dropped";
+  EXPECT_EQ(99, saved.getIntValue("devtools", "max_stack_size", 50))
+      << "max_stack_size was dropped";
+
+  // And the settings survive the full boot-edit-boot loop.
+  loadConfiguration(CPC[1], getTmpFilename(1));
+  EXPECT_EQ(0, CPC[1].scr_vsync);
+  EXPECT_EQ(99, CPC[1].devtools_max_stack_size);
+  EXPECT_EQ(PhazerType::TrojanLightPhazer,
+            static_cast<PhazerType::Value>(CPC[1].phazer_emulation));
+}
+
+// Saving over an existing file edits it: a comment and an unrecognised key
+// written by hand (or by a newer build) are still there afterwards.
+TEST_F(ConfigurationTest, saveConfigurationEditsTheFileInsteadOfReplacingIt) {
+  std::ofstream configFile(getTmpFilename(0));
+  configFile << "# a hand-written note\n"
+             << "[system]\n"
+             << "model=2\n"
+             << "a_key_from_a_newer_build=keep me\n";
+  configFile.close();
+
+  t_CPC CPC;
+  loadConfiguration(CPC, getTmpFilename(0));
+  saveConfiguration(CPC, getTmpFilename(0));
+
+  std::string const text = readFile(getTmpFilename(0));
+  EXPECT_NE(std::string::npos, text.find("# a hand-written note"))
+      << "comments were stripped:\n"
+      << text;
+  EXPECT_NE(std::string::npos, text.find("a_key_from_a_newer_build=keep me"))
+      << "an unknown key was deleted:\n"
+      << text;
 }
 
 // Real unit tests

--- a/test/configuration.cpp
+++ b/test/configuration.cpp
@@ -162,7 +162,8 @@ TEST_F(ConfigurationTest, saveToFileKeepsParsedKeysItNeverSets) {
                          "system", "a_key_from_a_newer_build", "GONE"));
 }
 
-TEST_F(ConfigurationTest, saveToFileRewritesValueInPlaceKeepingSpacingAndComment) {
+TEST_F(ConfigurationTest,
+       saveToFileRewritesValueInPlaceKeepingSpacingAndComment) {
   configuration_.parseString(
       "[system]\n"
       "model = 42  # the machine\n"


### PR DESCRIPTION
Three fixes for defects real users hit, all of the same class: **the host UI reads state the engine no longer writes, and the failure is silent**.

## 1. The config file was rebuilt from scratch on every save (P0, beads-64au)

Opening any file auto-saves the MRU list, so "every save" meant *every disk load*. Two independent defects wore that one symptom:

- **`saveConfiguration` never read the file it overwrote.** It built a fresh `config::Config` from live state, so any key it does not itself set was deleted — including anything a newer build wrote, or anything added by hand.
- **`toStream` regenerated the file from the key/value map.** All 149 comment lines of the self-documenting template were dropped the first time anything saved.

`Config` now remembers the text it parsed and rewrites values in place, keeping comments, key order, spacing and inline notes; `saveConfiguration` parses before it writes. Saving is an *edit*, not a replacement.

### The five keys that vanished

The comment above `saveConfiguration` claims *"Mirror image of loadConfiguration: every key written here is read there."* It was not true — **79 keys read, 74 written**:

| Key | What you lost by setting it |
|---|---|
| `video.vsync` | documented in CLAUDE.md as the remote-desktop present-stall escape hatch |
| `system.run_tier` | documented; the tier policy |
| `input.lightgun` | documented; the only way to enable a gun headlessly |
| `system.silicon_disc` | the 256K expansion |
| `devtools.max_stack_size` | debugger stack depth |

Set any of them, open one file, and the line was gone — silently back to the default at the next boot. Both sets are now 79 and identical.

## 2. Audio was genuinely silent, and the config made it permanent

The machine was synthesizing real audio (±4878 during a `SOUND` note) while **no SDL stream was ever opened**. Headless runs and audio-init failures *forced* `CPC.snd_enabled = 0`, and `saveConfiguration` persisted that forced-off state — so one headless run or one failed init silently silenced the config for good. Config intent and runtime availability are now separate concerns.

Also fixes the **Volume slider**, dead since Gate C: the legacy core baked volume into the PSG level tables, and the machine uses a fixed gain, so `CPC.snd_volume` had no consumer. It now drives `SDL_SetAudioStreamGain`. And **Enable Sound** is no longer a one-way trap.

Note the interaction with fix 1: the forced clobber is what poisoned the value, the truncating save is what made it permanent. Neither fix alone closes it.

## 3. The PSG oscilloscope had no writer at all

The Audio State panel's waveforms were flat in every session because nothing ever pushed samples into `g_psg_scope` — `engine=1` owns the PSG channel levels and the legacy mirror was never wired. Now pushed at the debug-sync seam. Same Gate C host-mirror class as the tape-scope gap.

## Verification

- **1613 tests pass, 0 fail**, 3 skipped (the known absent flux fixtures), on this branch rebased onto post-#23 master.
- **Six of the seven new config tests fail on the pre-fix build** — I reverted the source, kept the tests, and watched them go red. The seventh passes either way and says so in a comment rather than posing as a regression guard: the old writer dumped `config_`, which already held parsed keys, so key-loss was never a writer bug.
- Audio proven red-to-green by measurement, not inspection: a WAV tapped after the gate during a note carries peak 8441 / RMS 2359, re-confirmed on a probe-free release build.
- `make clang-format` clean.

## Follow-ups filed, not silently absorbed

- **beads-tt7v** — the startup manifest reports the *effective* tier under the key `run_tier`, which names the *policy*. Observed live: config `run_tier=2`, IPC `tier` says `policy=wake`, manifest says `'faithful'`. That manifest is a machine-readable contract external harnesses parse.
- **beads-00jf** — IPC `load` never updates the MRU, so it never triggers a save (verified: config md5 unchanged after a successful load). An agent driving the emulator diverges from a user clicking.
- **beads-uiq8** — `koncepcja.cfg` is both the tracked template and the live CWD config, so running from the repo root writes personal paths into a tracked file.
- **beads-cp6g** — flux-loaded discs read as empty in the status bar: the drive widgets gate on the legacy `t_drive::tracks`, which only the DSK loaders fill.
