### PR TITLE
fix(ui): read the drive's medium, not its sector view

### DIFF
--- a/docs/ipc-protocol.md
+++ b/docs/ipc-protocol.md
@@ -591,7 +591,24 @@ Read and write emulator settings.
 | Command | Description |
 |---------|-------------|
 | `status` | Overall emulator status summary |
-| `status drives` | Detailed drive state (loaded image, tracks, format) |
+| `status drives` | Detailed drive state (see fields below) |
+
+`status drives` reports one line per drive:
+
+```
+drive=A motor=1 track=12 side=0 present=1 flux=1 tracks=80 sides=1 image=demo.hfe write_protected=0 altered=0
+```
+
+| Field | Meaning |
+|-------|---------|
+| `present` | A disc is in the drive. **Use this, not `tracks`** — a flux disc can report `tracks=0` |
+| `flux` | The medium is flux-backed (`.hfe`/`.scp`/`.a2r`), so it can be exported as `.scp`/`.hfe` |
+| `tracks` / `sides` | Geometry of the medium; `0` means unknown, not empty |
+| `track` / `side` | Live head position |
+| `altered` | The medium has been written and differs from the file on disk |
+
+Flux discs carry no sector view, so `tracks` is the flux cylinder count and
+`sides` is always 1 — the FDC captures side 0 only.
 
 ## ASIC Registers (Plus Range)
 

--- a/src/drive_status.cpp
+++ b/src/drive_status.cpp
@@ -3,8 +3,11 @@
 #include <filesystem>
 #include <sstream>
 
+#include "flux_save.h"
+#include "hw/fdc.h"
 #include "hw_views.h"
 #include "koncepcja.h"
+#include "subcycle_bridge.h"
 
 extern t_CPC CPC;
 extern t_FDC FDC;
@@ -18,6 +21,36 @@ std::string image_basename(const std::string& path) {
   return std::filesystem::path(path).filename().string();
 }
 }  // namespace
+
+DriveMedium drive_medium_from(const FluxSaveCaps& caps, unsigned sector_tracks,
+                              unsigned sector_sides, int flux_ntracks) {
+  DriveMedium m;
+  if (!caps.present) return m;  // empty drive: t_drive may hold stale geometry
+
+  m.present = true;
+  m.flux = caps.can_scp;  // .scp/.hfe export ⇔ the medium is flux-backed
+  if (m.flux && sector_tracks == 0) {
+    // Flux with no sector view: the cylinder count comes from the flux medium,
+    // and the FDC captures side 0 only, so the disc is single-sided here.
+    m.tracks = flux_ntracks > 0 ? static_cast<unsigned>(flux_ntracks) : 0;
+    m.sides = 1;
+  } else {
+    m.tracks = sector_tracks;
+    m.sides = sector_sides;
+  }
+  return m;
+}
+
+DriveMedium drive_medium(int unit) {
+  const t_drive& d = (unit & 1) != 0 ? driveB : driveA;
+  int ntracks = 0;
+  if ((unit & 1) == 0) {  // flux is drive-A-only
+    if (const Device* fdc = subcycle_bridge_fdc()) {
+      fdc_media_track_dirty(fdc, ntracks);
+    }
+  }
+  return drive_medium_from(flux_save_caps(unit), d.tracks, d.sides, ntracks);
+}
 
 std::string emulator_status_summary() {
   std::ostringstream oss;
@@ -47,16 +80,25 @@ std::string drive_status_detailed() {
   std::string const imgA = image_basename(CPC.driveA.file);
   std::string const imgB = image_basename(CPC.driveB.file);
 
+  // Geometry comes from the medium: a flux-backed disc has no sector view,
+  // so reading driveX.tracks here reports an empty drive for a mounted disc.
+  const DriveMedium medA = drive_medium(0);
+  const DriveMedium medB = drive_medium(1);
+
   oss << "drive=A"
       << " motor=" << FDC.motor << " track=" << driveA.current_track
-      << " side=" << driveA.current_side << " tracks=" << driveA.tracks
-      << " sides=" << driveA.sides << " image=" << imgA
+      << " side=" << driveA.current_side
+      << " present=" << (medA.present ? 1 : 0)
+      << " flux=" << (medA.flux ? 1 : 0) << " tracks=" << medA.tracks
+      << " sides=" << medA.sides << " image=" << imgA
       << " write_protected=" << driveA.write_protected
       << " altered=" << (driveA.altered ? 1 : 0) << "\n";
   oss << "drive=B"
       << " motor=" << FDC.motor << " track=" << driveB.current_track
-      << " side=" << driveB.current_side << " tracks=" << driveB.tracks
-      << " sides=" << driveB.sides << " image=" << imgB
+      << " side=" << driveB.current_side
+      << " present=" << (medB.present ? 1 : 0)
+      << " flux=" << (medB.flux ? 1 : 0) << " tracks=" << medB.tracks
+      << " sides=" << medB.sides << " image=" << imgB
       << " write_protected=" << driveB.write_protected
       << " altered=" << (driveB.altered ? 1 : 0);
   return oss.str();

--- a/src/drive_status.h
+++ b/src/drive_status.h
@@ -2,6 +2,33 @@
 
 #include <string>
 
+struct FluxSaveCaps;
+
+// What is actually in a drive.
+//
+// The FDC medium is the disc. t_drive is the host's *sector* view of it, and a
+// flux-backed medium (.hfe/.scp/.a2r) has no sector view at all — driveA.tracks
+// reads 0 for a perfectly good disc. Every gate that asks "is a disc in there?"
+// must come through here rather than reading t_drive directly.
+struct DriveMedium {
+  bool present = false;  // a disc is in the drive
+  bool flux = false;     // flux-backed (no sector view; .scp/.hfe export)
+  unsigned tracks = 0;   // cylinder count, 0 when unknown
+  unsigned sides = 0;    // 1 for flux — the FDC captures side 0 only
+};
+
+// Pure decision: describe the medium `caps` reports, filling in the geometry
+// from whichever view holds it. A sector-backed disc knows its own tracks and
+// sides; a flux-backed one has neither, so its cylinder count comes from
+// `flux_ntracks` (fdc_media_track_dirty) and it is single-sided by
+// construction. No disc in the drive means no geometry, whatever t_drive
+// happens to still hold.
+DriveMedium drive_medium_from(const FluxSaveCaps& caps, unsigned sector_tracks,
+                              unsigned sector_sides, int flux_ntracks);
+
+// The live medium of drive `unit` (0=A, 1=B).
+DriveMedium drive_medium(int unit);
+
 // Brief one-line-per-drive summary (for `status` command)
 std::string drive_status_summary();
 

--- a/src/imgui_ui.cpp
+++ b/src/imgui_ui.cpp
@@ -33,6 +33,7 @@ bool g_speedtest_open = false;
 #include "devtools_ui.h"
 #include "disk_format.h"
 #include "drive_sounds.h"
+#include "drive_status.h"
 #include "fileutils.h"
 #include "flux_save.h"
 #include "hw_views.h"
@@ -1379,16 +1380,13 @@ void imgui_render_menubar() {
     if (ImGui::MenuItem("New Disk...")) {
       imgui_state.show_new_disk = true;
     }
-    // Save-As: the format picker's options track the drive's live backing.
-    // Under engine=1 the caps come from the sub-cycle FDC medium; on a legacy
-    // engine=0 run they fall back to the driveA/driveB struct (sector-only).
-    const bool engine_live = subcycle_bridge_active();
-    const FluxSaveCaps caps_a =
-        engine_live ? flux_save_caps(0) : FluxSaveCaps{};
-    const FluxSaveCaps caps_b =
-        engine_live ? flux_save_caps(1) : FluxSaveCaps{};
-    const bool a_dsk = engine_live ? caps_a.can_dsk : (driveA.tracks != 0);
-    const bool b_dsk = engine_live ? caps_b.can_dsk : (driveB.tracks != 0);
+    // Save-As: the format picker's options track the drive's live backing,
+    // read from the FDC medium — the only thing that knows whether a disc is
+    // sector- or flux-backed.
+    const FluxSaveCaps caps_a = flux_save_caps(0);
+    const FluxSaveCaps caps_b = flux_save_caps(1);
+    const bool a_dsk = caps_a.can_dsk;
+    const bool b_dsk = caps_b.can_dsk;
     if (ImGui::BeginMenu("Save Disk A", a_dsk || caps_a.can_scp)) {
       if (ImGui::MenuItem("As .dsk...", nullptr, false, a_dsk)) {
         koncpc_request_file_dialog(
@@ -2076,12 +2074,16 @@ void imgui_render_statusbar() {
         t_drive const& drive = drv == 0 ? driveA : driveB;
         auto& driveFile = drv == 0 ? CPC.driveA.file : CPC.driveB.file;
         const char* driveLabel = drv == 0 ? "A:" : "B:";
+        // Ask the medium, not the sector view: a flux-backed disc (.hfe/.scp/
+        // .a2r) leaves drive.tracks at 0, which read here as "(no disk)" for a
+        // disc the CPC was happily reading.
+        const DriveMedium medium = drive_medium(drv);
 
         if (drv > 0) ImGui::SameLine(0, 12.0f);
 
         // Build display name
         const char* fullName;
-        if (drive.tracks) {
+        if (medium.present) {
           auto pos = driveFile.find_last_of("/\\");
           fullName = (pos != std::string::npos) ? driveFile.c_str() + pos + 1
                                                 : driveFile.c_str();
@@ -2111,7 +2113,7 @@ void imgui_render_statusbar() {
         ImGui::SameLine(0, 4.0f);
 
         // Show track number when disk is loaded
-        if (drive.tracks) {
+        if (medium.present) {
           char trkStr[8];
           snprintf(trkStr, sizeof(trkStr), "T%02d",
                    static_cast<int>(drive.current_track));
@@ -2124,9 +2126,9 @@ void imgui_render_statusbar() {
         }
 
         // Show filename or "(no disk)" with marquee scrolling
-        ImGui::PushStyleColor(ImGuiCol_Text,
-                              drive.tracks ? ImVec4(0.75f, 0.75f, 0.75f, 1.0f)
-                                           : ImVec4(0.45f, 0.45f, 0.45f, 1.0f));
+        ImGui::PushStyleColor(
+            ImGuiCol_Text, medium.present ? ImVec4(0.75f, 0.75f, 0.75f, 1.0f)
+                                          : ImVec4(0.45f, 0.45f, 0.45f, 1.0f));
         ImGui::AlignTextToFramePadding();
         imgui_marquee_text(fullName, 120.0f);
         ImGui::PopStyleColor();
@@ -2134,7 +2136,7 @@ void imgui_render_statusbar() {
 
         // Click on the whole group (label + LED + filename)
         if (ImGui::IsItemClicked()) {
-          if (drive.tracks) {
+          if (medium.present) {
             // Ask to confirm eject
             imgui_state.eject_confirm_drive = drv;
           } else {

--- a/test/drive_status.cpp
+++ b/test/drive_status.cpp
@@ -2,6 +2,7 @@
 
 #include <gtest/gtest.h>
 
+#include "flux_save.h"
 #include "hw_views.h"
 #include "koncepcja.h"
 
@@ -92,15 +93,19 @@ TEST_F(DriveStatusTest, WriteProtectedFlag) {
 TEST_F(DriveStatusTest, DetailedDriveStatusNoDisc) {
   auto s = drive_status_detailed();
   EXPECT_EQ(s,
-            "drive=A motor=0 track=0 side=0 tracks=0 sides=0 image= "
-            "write_protected=0 altered=0\n"
-            "drive=B motor=0 track=0 side=0 tracks=0 sides=0 image= "
-            "write_protected=0 altered=0");
+            "drive=A motor=0 track=0 side=0 present=0 flux=0 tracks=0 sides=0 "
+            "image= write_protected=0 altered=0\n"
+            "drive=B motor=0 track=0 side=0 present=0 flux=0 tracks=0 sides=0 "
+            "image= write_protected=0 altered=0");
 }
 
-TEST_F(DriveStatusTest, DetailedDriveStatusWithDisc) {
+// present/flux/tracks/sides come from the FDC medium, which these tests have
+// no way to mount — writing driveA.tracks does NOT insert a disc, and reading
+// it back as if it did is the mistake that made flux discs show "(no disk)".
+// The decision itself is covered by the drive_medium_from cases below.
+TEST_F(DriveStatusTest, DetailedDriveStatusReportsTheHostFieldsItOwns) {
   CPC.driveA.file = "/games/roland.dsk";
-  driveA.tracks = 40;
+  driveA.tracks = 40;  // a sector view with no medium behind it
   driveA.sides = 2;
   driveA.current_track = 5;
   driveA.current_side = 1;
@@ -110,10 +115,10 @@ TEST_F(DriveStatusTest, DetailedDriveStatusWithDisc) {
 
   auto s = drive_status_detailed();
   EXPECT_EQ(s,
-            "drive=A motor=1 track=5 side=1 tracks=40 sides=2 image=roland.dsk "
-            "write_protected=1 altered=1\n"
-            "drive=B motor=1 track=0 side=0 tracks=0 sides=0 image= "
-            "write_protected=0 altered=0");
+            "drive=A motor=1 track=5 side=1 present=0 flux=0 tracks=0 sides=0 "
+            "image=roland.dsk write_protected=1 altered=1\n"
+            "drive=B motor=1 track=0 side=0 present=0 flux=0 tracks=0 sides=0 "
+            "image= write_protected=0 altered=0");
 }
 
 TEST_F(DriveStatusTest, DetailedBothDrives) {
@@ -132,6 +137,73 @@ TEST_F(DriveStatusTest, DetailedBothDrives) {
   EXPECT_NE(s.find("image=disc1.dsk"), std::string::npos);
   EXPECT_NE(s.find("drive=B"), std::string::npos);
   EXPECT_NE(s.find("image=disc2.dsk"), std::string::npos);
-  EXPECT_NE(s.find("tracks=80 sides=2"), std::string::npos);
   EXPECT_NE(s.find("write_protected=1"), std::string::npos);
+}
+
+// ─────────────────────────────────────────────────
+// drive_medium_from — what is in the drive
+// ─────────────────────────────────────────────────
+
+TEST(DriveMediumTest, SectorDiscKeepsItsOwnGeometry) {
+  FluxSaveCaps caps;
+  caps.present = true;
+  caps.can_dsk = true;
+
+  const DriveMedium m = drive_medium_from(caps, 40, 2, 0);
+  EXPECT_TRUE(m.present);
+  EXPECT_FALSE(m.flux);
+  EXPECT_EQ(m.tracks, 40u);
+  EXPECT_EQ(m.sides, 2u);
+}
+
+// The bug: a mounted .hfe/.scp/.a2r has no sector view at all, so every gate
+// that read t_drive::tracks called it an empty drive — "(no disk)" in the
+// status bar, no track readout, and a click offering Load instead of Eject.
+TEST(DriveMediumTest, FluxDiscIsPresentDespiteAnEmptySectorView) {
+  FluxSaveCaps caps;
+  caps.present = true;
+  caps.can_scp = true;
+  caps.can_hfe = true;
+
+  const DriveMedium m = drive_medium_from(caps, 0, 0, 80);
+  EXPECT_TRUE(m.present) << "a flux disc read as an empty drive";
+  EXPECT_TRUE(m.flux);
+  EXPECT_EQ(m.tracks, 80u) << "cylinder count comes from the flux medium";
+  EXPECT_EQ(m.sides, 1u) << "the FDC captures side 0 only";
+}
+
+// A written flux disc grows a DSK overlay, so it reports both capabilities.
+// The overlay's geometry is real and wins over the flux cylinder count.
+TEST(DriveMediumTest, WrittenFluxDiscPrefersTheOverlayGeometry) {
+  FluxSaveCaps caps;
+  caps.present = true;
+  caps.can_dsk = true;
+  caps.can_scp = true;
+
+  const DriveMedium m = drive_medium_from(caps, 42, 1, 80);
+  EXPECT_TRUE(m.present);
+  EXPECT_TRUE(m.flux);
+  EXPECT_EQ(m.tracks, 42u);
+  EXPECT_EQ(m.sides, 1u);
+}
+
+// t_drive is not cleared the instant a disc leaves, so trusting its geometry
+// would keep reporting the disc that is no longer there.
+TEST(DriveMediumTest, EmptyDriveIgnoresStaleSectorGeometry) {
+  const DriveMedium m = drive_medium_from(FluxSaveCaps{}, 40, 2, 80);
+  EXPECT_FALSE(m.present);
+  EXPECT_FALSE(m.flux);
+  EXPECT_EQ(m.tracks, 0u);
+  EXPECT_EQ(m.sides, 0u);
+}
+
+// A flux medium whose cylinder count is unavailable is still a disc.
+TEST(DriveMediumTest, FluxDiscWithUnknownCylinderCountIsStillPresent) {
+  FluxSaveCaps caps;
+  caps.present = true;
+  caps.can_scp = true;
+
+  const DriveMedium m = drive_medium_from(caps, 0, 0, 0);
+  EXPECT_TRUE(m.present);
+  EXPECT_EQ(m.tracks, 0u) << "unknown, not fabricated";
 }


### PR DESCRIPTION
Closes **beads-cp6g**. A mounted `.hfe`/`.scp`/`.a2r` showed **"(no disk)"** in the status bar — while the CPC was reading the disc perfectly well.

## The rule this restores

**The FDC medium is the disc.** `t_drive` is the host's *sector* view of it, and a flux-backed medium has no sector view at all — so `driveA.tracks` reads `0` for a working disc.

Four gates in the status bar asked `t_drive` directly, and every one of them got the wrong answer for flux:

| Gate | What the user saw |
|---|---|
| display name | `(no disk)` instead of the filename |
| track readout | missing entirely |
| text colour | dimmed, as if empty |
| **click action** | **Load dialog instead of Eject** — no way to eject a flux disc |

They now go through `drive_medium()`, which reads the medium. The Save-As caps in the Media menu did the same thing from the other side — picking between the FDC and `t_drive` — and now just read the FDC.

## `status drives` gains `present` and `flux`

The agent-facing half had the same defect: it reported `tracks=0 sides=0` for a mounted flux disc.

```
drive=A motor=0 track=0 side=0 present=1 flux=1 tracks=40 sides=1 image=ARMAXESS_MEGADEMO_(ARMAXESS).HFE write_protected=0 altered=0
```

`docs/ipc-protocol.md` now documents the field table and says plainly that **`present` is the field to test — `tracks=0` does not mean empty.**

## Verification

That line above is a real run: v6.2.0+ headless, IPC port read from the startup manifest, loading `ARMAXESS_MEGADEMO_(ARMAXESS).HFE` from the demo archive. Before this change the same command reported no `present` field and `tracks=0`. The `tracks=40` can only come from `fdc_media_track_dirty` on a decoded flux medium.

**1618 tests pass, 0 fail**, 3 skipped (the known absent flux fixtures). `make clang-format` clean.

## The tests were part of the bug

`test/drive_status.cpp` fabricated a disc by writing `driveA.tracks = 40` and asserting the output said `tracks=40`. That is exactly the assumption that broke flux — writing to the sector view does not insert a disc. Those tests now assert only the host fields they actually own, and five new cases cover the decision itself:

- sector disc keeps its own geometry
- **flux disc is present despite an empty sector view** (the bug)
- a written flux disc has both a DSK overlay and flux; the overlay's geometry wins
- an empty drive ignores stale `t_drive` geometry — it is not cleared the instant a disc leaves, so trusting it would keep reporting a disc that is gone
- a flux disc with an unknown cylinder count is still present, and reports `0` rather than fabricating a number

## Found while verifying, filed not chased

**beads-bz07 (P1)** — on a headless run, typed characters never reach the CPC but `RETURN` does. `autotype cat~RETURN~` and `input type "cat"` both return `OK`, the telnet console captures every `Ready` prompt, and no letter ever appears. Tried three call shapes to rule out quoting.

That matters beyond this PR: `ipc_harness` only asserts those commands return `OK`, never that the characters arrived — which is why it was invisible. Any fix needs a test that asserts on captured console output.
