### PR TITLE
fix: expansion ROMs, the configured RAM size, and an honest build hash

### DIFF
--- a/makefile
+++ b/makefile
@@ -279,22 +279,34 @@ TEST_OBJECTS:=$(TEST_DEPENDS:.d=.o)
 # builds stay incremental.
 VERSION_STAMP := $(OBJDIR)/.version-stamp
 
-# The stamp rule below is the first *real* rule in this file, and make takes its
-# first real rule as the default goal — so without this line a bare `make` would
-# build only the stamp and stop, silently doing nothing else.  `all` is defined
-# further down (conditionally on DEBUG); naming it here is enough.
+# The build hash has the same problem and is worse: nothing about a commit
+# touches a source file, so `koncepcja --version` and the startup manifest kept
+# reporting the *previous* commit until something else happened to rebuild.
+# Only argparse.cpp and kon_cpc_ja.cpp embed it, so scope the rebuild to those.
+HASH_STAMP := $(OBJDIR)/.hash-stamp
+
+# Refresh both stamps while the makefile is read, rewriting one only when its
+# value actually changed. Doing it here rather than in a rule with a phony
+# prerequisite keeps them ordinary files with honest timestamps, so
+# `make -q koncepcja` truthfully answers "is the binary current?". (Bare
+# `make -q` always reports out of date, stamps or not: the default goal `all`
+# depends on the phony check_deps. Ask about the target you care about.)
+$(shell mkdir -p $(OBJDIR))
+$(shell printf '%s' '$(KONCPC_VERSION)' | cmp -s - $(VERSION_STAMP) 2>/dev/null \
+          || printf '%s' '$(KONCPC_VERSION)' > $(VERSION_STAMP))
+$(shell printf '%s' '$(GIT_HASH)' | cmp -s - $(HASH_STAMP) 2>/dev/null \
+          || printf '%s' '$(GIT_HASH)' > $(HASH_STAMP))
+
+# The dependency lines below are the first *real* rules in this file, and make
+# takes its first real rule as the default goal — without this line a bare
+# `make` would build one object and stop. `all` is defined further down
+# (conditionally on DEBUG); naming it here is enough.
 .DEFAULT_GOAL := all
 
-$(VERSION_STAMP): FORCE
-	@mkdir -p $(dir $@)
-	@printf '%s' '$(KONCPC_VERSION)' | cmp -s - $@ 2>/dev/null \
-	  || printf '%s' '$(KONCPC_VERSION)' > $@
-
 $(OBJECTS) $(TEST_OBJECTS): $(VERSION_STAMP)
+$(OBJDIR)/src/argparse.o $(OBJDIR)/src/kon_cpc_ja.o: $(HASH_STAMP)
 
-FORCE:
-
-.PHONY: all check_deps clean deb_pkg debug debug_flag distrib doc tags unit_test install doxygen coverage coverage-report coverage-clean sim sim_headless bench pgo FORCE
+.PHONY: all check_deps clean deb_pkg debug debug_flag distrib doc tags unit_test install doxygen coverage coverage-report coverage-clean sim sim_headless bench pgo
 
 WARNINGS = -Wall -Wextra -Wzero-as-null-pointer-constant -Wformat=2 -Wold-style-cast -Wmissing-include-dirs -Woverloaded-virtual -Wpointer-arith -Wredundant-decls -Wimplicit-fallthrough
 # Tier 1: always-errors even in release (undefined behavior / security critical)

--- a/src/imgui_ui.cpp
+++ b/src/imgui_ui.cpp
@@ -356,8 +356,20 @@ void process_pending_dialog() {
       emulator_reset();
       break;
     case FileDialogAction::LoadROM:
-      if (rom_slot >= 0 && rom_slot < MAX_ROM_SLOTS)
+      // Record it AND fit it: setting rom_file alone only took effect at the
+      // next full init, so picking a ROM here appeared to do nothing.
+      if (rom_slot >= 0 && rom_slot < MAX_ROM_SLOTS) {
         CPC.rom_file[rom_slot] = path;
+        if (load_expansion_rom_slot(rom_slot, path) != 0) {
+          imgui_toast_error("Not a valid 16K CPC ROM: " + fname);
+          CPC.rom_file[rom_slot] = "";
+        } else if (memmap_ROM[rom_slot] == nullptr) {
+          imgui_toast_error("Could not load ROM: " + fname);
+        } else {
+          imgui_toast_success("ROM fitted in slot " + std::to_string(rom_slot) +
+                              ": " + fname);
+        }
+      }
       break;
     case FileDialogAction::SelectM4SDFolder:
       g_m4board.sd_root_path = path;
@@ -3293,6 +3305,9 @@ void imgui_render_options() {
             ImGui::TextDisabled("system");
           } else if (loaded) {
             if (ImGui::SmallButton("X")) {
+              // Unfit it in the CPC before freeing: the board holds this
+              // pointer until told otherwise.
+              subcycle_bridge_attach_rom_slot(i, nullptr);
               delete[] memmap_ROM[i];
               memmap_ROM[i] = nullptr;
               CPC.rom_file[i] = "";

--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -872,10 +872,8 @@ int input_init() {
 }
 }  // namespace
 
-namespace {
-
 // Read one expansion-ROM image (a 16K CPC ROM, optionally prefixed by a
-// 128-byte AMSDOS header) into memmap_ROM[slot].
+// 128-byte AMSDOS header) into memmap_ROM[slot] and fit it in the CPC.
 //
 // Mirrors the classic slot semantics: a missing file or a non-CPC image is a
 // SOFT failure — the slot is cleared with a message and boot continues; a
@@ -883,7 +881,11 @@ namespace {
 // oversized, I/O error) is a HARD failure that aborts emulator_init.
 // Returns 0 on success or soft failure, an ERR_* code on hard failure.
 int load_expansion_rom_slot(int slot, const std::string& rom_file) {
-  const std::string path = CPC.rom_path + "/" + rom_file;
+  // `rom_file` is a bare name in CPC.rom_path (the [rom] slotNN config form)
+  // or a full path, which is what the ROMs dialog and IPC `rom load` hand in.
+  const std::string path = std::filesystem::path(rom_file).is_absolute()
+                               ? rom_file
+                               : CPC.rom_path + "/" + rom_file;
   FilePtr const f = open_file(path, "rb");
   if (!f) {
     fprintf(stderr, "ERROR: The %s file is missing - clearing ROM slot %d.\n",
@@ -948,9 +950,18 @@ int load_expansion_rom_slot(int slot, const std::string& rom_file) {
               << path);
     return ERR_NOT_A_CPC_ROM;
   }
+  // Replace whatever was fitted: unfit it in the CPC before the image it is
+  // still pointing at goes away.
+  subcycle_bridge_attach_rom_slot(slot, nullptr);
+  delete[] memmap_ROM[slot];
   memmap_ROM[slot] = rom.release();
+  // Fit it. At boot the board is not up yet and this is a no-op —
+  // subcycle_bridge_start() attaches every populated slot on the way up.
+  subcycle_bridge_attach_rom_slot(slot, memmap_ROM[slot]);
   return 0;
 }
+
+namespace {
 
 // Load the Multiface II ROM: 8K firmware image kept twice — a pristine
 // backup (pbMF2ROMbackup, restored on every reset) and the live 8K ROM + 8K

--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -950,14 +950,29 @@ int load_expansion_rom_slot(int slot, const std::string& rom_file) {
               << path);
     return ERR_NOT_A_CPC_ROM;
   }
-  // Replace whatever was fitted: unfit it in the CPC before the image it is
-  // still pointing at goes away.
-  subcycle_bridge_attach_rom_slot(slot, nullptr);
-  delete[] memmap_ROM[slot];
+  // Swap the new image in, repoint everything that was reading the old one,
+  // and only then free it. Freeing first would leave a window — however
+  // short — in which the board and the host's paging both point at released
+  // memory, and this runs while the machine is live: the ROMs dialog fits a
+  // ROM without a reset.
+  byte* const previous = memmap_ROM[slot];
   memmap_ROM[slot] = rom.release();
-  // Fit it. At boot the board is not up yet and this is a no-op —
-  // subcycle_bridge_start() attaches every populated slot on the way up.
+
+  // At boot the board is not up yet and this is a no-op —
+  // subcycle_bridge_start() fits every configured slot on the way up.
   subcycle_bridge_attach_rom_slot(slot, memmap_ROM[slot]);
+
+  // The host's own paging caches the selected upper ROM, so replacing the ROM
+  // that is currently selected has to move that pointer too. `rom load` and
+  // both unload paths already do this; doing it here covers every caller.
+  if (GateArray.upper_ROM == static_cast<unsigned char>(slot)) {
+    pbExpansionROM = memmap_ROM[slot];
+    if (!(GateArray.ROM_config & 0x08)) {
+      memory_set_read_bank(3, pbExpansionROM);
+    }
+  }
+
+  delete[] previous;
   return 0;
 }
 

--- a/src/koncepcja.h
+++ b/src/koncepcja.h
@@ -610,6 +610,12 @@ bool autotype_waitbreak_in_flight();
 //  - $HOME/.koncepcja.cfg
 //  - /etc/koncepcja.cfg
 std::string getConfigurationFilename(bool forWrite = false);
+// Load a 16K expansion ROM into `slot` and fit it in the CPC. `rom_file` is a
+// bare name resolved against CPC.rom_path, or a full path. Replaces whatever
+// occupied the slot. Returns 0 on success, an ERR_* code on a bad image; a
+// missing file or a non-CPC ROM clears the slot and still returns 0.
+int load_expansion_rom_slot(int slot, const std::string& rom_file);
+
 void loadConfiguration(t_CPC& CPC, const std::string& configFilename);
 bool saveConfiguration(t_CPC& CPC, const std::string& configFilename);
 

--- a/src/koncepcja_ipc_server.cpp
+++ b/src/koncepcja_ipc_server.cpp
@@ -4583,6 +4583,7 @@ std::string handle_command(const std::string& line) {
         }
         memmap_ROM[slot] = rom_data;
         CPC.rom_file[slot] = path;
+        subcycle_bridge_attach_rom_slot(slot, rom_data);  // fit it in the CPC
         // If the currently selected upper ROM is this slot, update pointer
         if (GateArray.upper_ROM == static_cast<unsigned char>(slot)) {
           pbExpansionROM = memmap_ROM[slot];
@@ -4601,6 +4602,8 @@ std::string handle_command(const std::string& line) {
         if (slot < 0 || slot >= MAX_ROM_SLOTS)
           return "ERR 400 slot must be 0-31\n";
         if (slot < 2) return "ERR 400 cannot-unload-system-rom\n";
+        subcycle_bridge_attach_rom_slot(slot, nullptr);  // unfit it first:
+        // the board must stop reading the image before it is freed.
         if (memmap_ROM[slot] != nullptr) {
           delete[] memmap_ROM[slot];
           memmap_ROM[slot] = nullptr;

--- a/src/subcycle/machine.cpp
+++ b/src/subcycle/machine.cpp
@@ -100,7 +100,9 @@ bool Machine::build(const uint8_t* rom, size_t rom_len) {
 
   mem_load_lower_rom(&mdev_, rom, 0x4000);           // OS at 0x0000
   mem_load_upper_rom(&mdev_, rom + 0x4000, 0x4000);  // BASIC at 0xC000
-  xmem_.assign(0x10000, 0);  // 64K expansion: the machine is a real 128K 6128
+  // Expansion above the base 64K. set_ram_size() may already have chosen a
+  // size; the default is the 64K that makes a 6128.
+  xmem_.assign(want_expansion_, 0);
   mem_attach_expansion(&mdev_, xmem_.data(), xmem_.size());
   built_ = true;
   recompose_active();  // establish dormancy + wake-tier validity at
@@ -1816,10 +1818,27 @@ size_t Machine::ram_size() const { return 0x10000 + xmem_.size(); }
 // memory Device already banks. Grow the expansion to 512K so banks 4-7 exist;
 // re-attach (resize may reallocate). Existing contents are preserved.
 void Machine::enable_silicon_disc(bool on) {
-  const size_t want = on ? kSiliconEnd : 0x10000;
+  silicon_ = on;
+  resize_expansion();
+}
+
+void Machine::set_ram_size(size_t total_bytes) {
+  want_expansion_ = total_bytes > 0x10000 ? total_bytes - 0x10000 : 0;
+  want_expansion_ -= want_expansion_ % 0x10000;  // whole 64K banks only
+  resize_expansion();
+}
+
+// The expansion is whichever is larger: what the machine was asked for, and
+// what the Silicon Disc needs to have banks 4-7 to live in. resize() keeps
+// existing contents; re-attach because it may have reallocated.
+void Machine::resize_expansion() {
+  const size_t want =
+      silicon_ && want_expansion_ < kSiliconEnd ? kSiliconEnd : want_expansion_;
   if (xmem_.size() == want) return;
   xmem_.resize(want, 0);
-  mem_attach_expansion(&mdev_, xmem_.data(), xmem_.size());
+  // Before build() there is no memory Device to attach to yet — it picks the
+  // size up itself. Attaching here would dereference an unbuilt Device.
+  if (built_) mem_attach_expansion(&mdev_, xmem_.data(), xmem_.size());
 }
 
 void Machine::silicon_disc_load(const uint8_t* src, size_t len) {

--- a/src/subcycle/machine.cpp
+++ b/src/subcycle/machine.cpp
@@ -124,8 +124,10 @@ void Machine::attach_amsdos(const uint8_t* rom16k, size_t len) {
 }
 
 void Machine::attach_rom(int slot, const uint8_t* rom16k) {
-  if (rom16k != nullptr && slot >= 0 && slot < 256)
-    mem_attach_rom(&mdev_, slot, rom16k);
+  // nullptr empties the slot — an empty slot reads as BASIC, exactly like no
+  // board fitted. Removal has to be possible: the caller owns the image and
+  // frees it, and the memory device would otherwise keep reading it.
+  if (slot >= 0 && slot < 256) mem_attach_rom(&mdev_, slot, rom16k);
 }
 
 void Machine::attach_cartridge(const uint8_t* image, size_t bytes) {

--- a/src/subcycle/machine.h
+++ b/src/subcycle/machine.h
@@ -79,7 +79,9 @@ class Machine {
 
   // AMSDOS (or any 16K ROM) into upper-ROM slot 7. Caller-owned.
   void attach_amsdos(const uint8_t* rom16k, size_t len);
-  // Any caller-owned 16K ROM into an arbitrary upper-ROM slot (e.g. the M4).
+  // Any caller-owned 16K ROM into an arbitrary upper-ROM slot (e.g. the M4,
+  // or an expansion board the user fitted). nullptr empties the slot, which
+  // then reads as BASIC — call that before freeing the image.
   void attach_rom(int slot, const uint8_t* rom16k);
 
   // Plus (6128+) cartridge: the parsed CPR image (caller-owned, 16K banks)

--- a/src/subcycle/machine.h
+++ b/src/subcycle/machine.h
@@ -310,6 +310,13 @@ class Machine {
   // PHYSICAL RAM (base 64K then expansion), independent of banking — the
   // memory layout snapshots dump and restore.
   size_t ram_size() const;
+
+  // Fit `total_bytes` of physical RAM: the base 64K plus whatever expansion
+  // is left over, rounded down to whole 64K banks. Call before boot — this
+  // reallocates, so anything already in expansion RAM is lost. The Silicon
+  // Disc occupies banks 4-7 and raises the floor to 512K of expansion while
+  // it is enabled, whatever is asked for here.
+  void set_ram_size(size_t total_bytes);
   uint8_t ram_read(size_t addr) const;
   void ram_write(size_t addr, uint8_t val);
 
@@ -483,7 +490,11 @@ class Machine {
   std::vector<uint8_t> gmem_, cmem_, pmem_, smem_, mmem_, vmem_, zmem_, fmem_,
       prmem_, prtmem_, admem_, mfmem_, axmem_, swmem_, sfmem_, m4mem_, asmem_,
       tmem_, rsmem_, plmem_, lgmem_;
-  std::vector<uint8_t> xmem_;  // 64K expansion RAM: a true 128K 6128
+  void resize_expansion();
+
+  std::vector<uint8_t> xmem_;        // expansion RAM above the base 64K
+  size_t want_expansion_ = 0x10000;  // requested expansion (default: 128K CPC)
+  bool silicon_ = false;             // Silicon Disc fitted (needs banks 4-7)
   // Writable-flux DSK overlay (Stage 2): synthesized from the SCP at insert and
   // owned here, it is the FDC's mutable `image`; the caller's SCP stays the
   // pristine source. Empty when drive A holds a DSK or a read-only flux dump.

--- a/src/subcycle_bridge.cpp
+++ b/src/subcycle_bridge.cpp
@@ -254,6 +254,10 @@ bool subcycle_bridge_start() {
   } else {
     b.rom = read_file(rom_file);  // models 0-2: a plain 32K OS+BASIC ROM
   }
+  // Physical RAM the user asked for. Without this the board is always a 128K
+  // 6128: a stock 64K 464 and a 576K Yarek config both booted with 128K while
+  // the status bar and `config get ram_size` reported the requested figure.
+  b.machine.set_ram_size(static_cast<size_t>(CPC.ram_size) * 1024);
   if (!b.machine.build(b.rom.data(), b.rom.size())) {
     LOG_ERROR("subcycle engine: cannot load system ROM "
               << rom_file << " (" << b.rom.size() << " bytes)");

--- a/src/subcycle_bridge.cpp
+++ b/src/subcycle_bridge.cpp
@@ -273,14 +273,19 @@ bool subcycle_bridge_start() {
   }
   b.amsdos = read_file(CPC.rom_path + "/amsdos.rom");
   b.machine.attach_amsdos(b.amsdos.data(), b.amsdos.size());
-  // Expansion ROM slots the host has loaded ([rom] slotNN, the ROMs dialog,
+  // Expansion ROM slots the USER asked for ([rom] slotNN, the ROMs dialog,
   // IPC `rom load`). Without this the board's roms[] stays empty and every
   // fitted board — ParaDOS, Utopia, Maxam — falls back to BASIC, so |HELP
-  // never lists it and the ROM looks like it was never fitted. The M4 and
-  // serial-card attaches below deliberately run after, and win, for their
-  // own slots.
+  // never lists it and the ROM looks like it was never fitted.
+  //
+  // CPC.rom_file is what makes a slot the user's: the peripheral managers
+  // (M4, serial card) put their own images straight into memmap_ROM and never
+  // claim a rom_file entry. Fitting those here would be wrong twice over —
+  // their ROM only works when their Device is also wired up, which is decided
+  // below and can legitimately not happen, and they free their image on their
+  // own schedule, which would leave the board reading freed memory.
   for (int slot = 0; slot < MAX_ROM_SLOTS; slot++) {
-    if (memmap_ROM[slot] != nullptr)
+    if (!CPC.rom_file[slot].empty() && memmap_ROM[slot] != nullptr)
       b.machine.attach_rom(slot, memmap_ROM[slot]);
   }
   if (!CPC.rom_mf2.empty()) {  // Multiface II (multiface-device.md §6)

--- a/src/subcycle_bridge.cpp
+++ b/src/subcycle_bridge.cpp
@@ -41,9 +41,10 @@
 #include "trace.h"  // g_trace: per-instruction debug recorder (engine=1 seam)
 #include "zip_archive.h"  // read_media_file: first media entry of a .zip slot
 
-extern t_drive driveA;  // legacy drive struct: UI reads its altered flag
-extern t_drive driveB;  // ...and both drives' mechanics (drive_status)
-extern t_FDC FDC;       // motor latch for the status surfaces
+extern t_drive driveA;         // host sector view: UI reads its altered flag
+extern t_drive driveB;         // ...and both drives' mechanics (drive_status)
+extern t_FDC FDC;              // motor latch for the status surfaces
+extern byte* memmap_ROM[256];  // host-loaded 16K expansion ROM images
 #include "subcycle/machine.h"
 #include "z80_view.h"  // legacy: the Wave-1 view struct + bench lists (transitional)
 
@@ -51,8 +52,8 @@ extern t_CPC CPC;
 extern std::string chROMFile[4];  // per-model system ROM names (kon_cpc_ja.cpp)
 extern std::unique_ptr<byte[]>
     pbCartridgeImage;  // parsed CPR banks (cartridge.cpp)
-extern t_z80regs z80;  // legacy structs: Wave-1 view buffers
-extern t_CRTC CRTC;    // (all die with the legacy files)
+extern t_z80regs z80;  // host view buffers, filled by debug_sync
+extern t_CRTC CRTC;
 extern t_GateArray GateArray;
 extern t_PSG PSG;
 // legacy tape scope level (tape.cpp); engine=1 mirrors it
@@ -255,8 +256,7 @@ bool subcycle_bridge_start() {
   }
   if (!b.machine.build(b.rom.data(), b.rom.size())) {
     LOG_ERROR("subcycle engine: cannot load system ROM "
-              << rom_file << " (" << b.rom.size()
-              << " bytes) — staying on legacy core");
+              << rom_file << " (" << b.rom.size() << " bytes)");
     return false;
   }
   b.machine.set_overlay(&g_drive_overlay);  // drive sounds (self-gated on cfg)
@@ -269,6 +269,16 @@ bool subcycle_bridge_start() {
   }
   b.amsdos = read_file(CPC.rom_path + "/amsdos.rom");
   b.machine.attach_amsdos(b.amsdos.data(), b.amsdos.size());
+  // Expansion ROM slots the host has loaded ([rom] slotNN, the ROMs dialog,
+  // IPC `rom load`). Without this the board's roms[] stays empty and every
+  // fitted board — ParaDOS, Utopia, Maxam — falls back to BASIC, so |HELP
+  // never lists it and the ROM looks like it was never fitted. The M4 and
+  // serial-card attaches below deliberately run after, and win, for their
+  // own slots.
+  for (int slot = 0; slot < MAX_ROM_SLOTS; slot++) {
+    if (memmap_ROM[slot] != nullptr)
+      b.machine.attach_rom(slot, memmap_ROM[slot]);
+  }
   if (!CPC.rom_mf2.empty()) {  // Multiface II (multiface-device.md §6)
     b.mf2rom = read_file(CPC.rom_path + "/" + CPC.rom_mf2);
     if (b.mf2rom.size() >= 0x2000)
@@ -1144,6 +1154,12 @@ void subcycle_bridge_eject_tape() {
 
 void subcycle_bridge_mf2_stop() {
   g_bridge.mf2_stop.store(true, std::memory_order_release);
+}
+
+void subcycle_bridge_attach_rom_slot(int slot, const uint8_t* rom16k) {
+  if (!g_bridge.active) return;  // start() attaches every slot on the way up
+  if (slot < 0 || slot >= MAX_ROM_SLOTS) return;
+  g_bridge.machine.attach_rom(slot, rom16k);
 }
 
 void subcycle_bridge_eject_media(uint8_t unit) {

--- a/src/subcycle_bridge.h
+++ b/src/subcycle_bridge.h
@@ -60,6 +60,13 @@ void subcycle_bridge_insert_media(std::vector<uint8_t> bytes, bool flux,
                                   uint8_t unit = 0);
 void subcycle_bridge_eject_media(uint8_t unit = 0);
 
+/* Fit or remove an expansion ROM in `slot` (0-31). `rom16k` is a caller-owned
+ * 16K image, or nullptr to empty the slot — an empty slot reads as BASIC, the
+ * same as no board fitted. Call this whenever the host's memmap_ROM changes
+ * (the ROMs dialog, IPC `rom load`/`rom unload`); writing memmap_ROM alone
+ * leaves the CPC unable to see the ROM. */
+void subcycle_bridge_attach_rom_slot(int slot, const uint8_t* rom16k);
+
 /* The Multiface II STOP button (deferred to the frame boundary). */
 void subcycle_bridge_mf2_stop();
 

--- a/test/hw/machine_test.cpp
+++ b/test/hw/machine_test.cpp
@@ -13,6 +13,7 @@
 
 #include "hw/fdc.h"
 #include "hw/gate_array.h"
+#include "hw/memory.h"
 #include "hw/probe.h"
 
 namespace {
@@ -244,4 +245,43 @@ TEST(SubcycleMachine, DormantPeripheralsLeaveTheTickList) {
   m.run_frame();
   EXPECT_EQ(m.active_tick_count(), stock + 1)
       << "an armed execution breakpoint rejoins the probe to the tick list";
+}
+
+// An expansion ROM the user fits must be readable by the CPC, and removable
+// again. attach_rom used to ignore a nullptr, so a slot could be filled but
+// never emptied: `rom unload` freed the image while the memory device was
+// still pointing at it, and the CPC read freed memory.
+TEST(SubcycleMachine, ExpansionRomSlotCanBeFittedAndEmptied) {
+  std::vector<uint8_t> rom = read_file("rom/cpc6128.rom");
+  if (rom.size() < 0x8000) rom = read_file("../rom/cpc6128.rom");
+  if (rom.size() < 0x8000) GTEST_SKIP() << "rom/cpc6128.rom not found";
+
+  subcycle::Machine m;
+  ASSERT_TRUE(m.build(rom.data(), rom.size()));
+
+  // Select upper-ROM slot 4 the way the CPC does: RMR (&7Fxx) enables both
+  // ROMs, the &DFxx latch picks the slot.
+  constexpr int kSlot = 4;
+  mem_fast_io_write(m.mem(), 0x7F00, 0x81);
+  mem_fast_io_write(m.mem(), 0xDF00, kSlot);
+
+  // An empty slot reads as BASIC — indistinguishable from no board fitted.
+  const uint8_t basic0 = mem_peek_cpu(m.mem(), 0xC000);
+  const uint8_t basic1 = mem_peek_cpu(m.mem(), 0xC001);
+
+  // A recognisable 16K image; the caller owns it, as the API requires.
+  std::vector<uint8_t> fitted(0x4000, 0x00);
+  fitted[0] = 0xA5;
+  fitted[1] = 0x5A;
+  ASSERT_NE(basic0, 0xA5) << "the marker must not collide with BASIC";
+
+  m.attach_rom(kSlot, fitted.data());
+  EXPECT_EQ(mem_peek_cpu(m.mem(), 0xC000), 0xA5)
+      << "a fitted ROM is not visible to the CPC";
+  EXPECT_EQ(mem_peek_cpu(m.mem(), 0xC001), 0x5A);
+
+  m.attach_rom(kSlot, nullptr);
+  EXPECT_EQ(mem_peek_cpu(m.mem(), 0xC000), basic0)
+      << "an emptied slot must read as BASIC again, not as the freed image";
+  EXPECT_EQ(mem_peek_cpu(m.mem(), 0xC001), basic1);
 }

--- a/test/hw/machine_test.cpp
+++ b/test/hw/machine_test.cpp
@@ -285,3 +285,51 @@ TEST(SubcycleMachine, ExpansionRomSlotCanBeFittedAndEmptied) {
       << "an emptied slot must read as BASIC again, not as the freed image";
   EXPECT_EQ(mem_peek_cpu(m.mem(), 0xC001), basic1);
 }
+
+// The machine used to allocate a fixed 64K of expansion whatever was asked
+// for, so a stock 64K 464 and a 576K Yarek config both booted as a 128K 6128.
+TEST(SubcycleMachine, RamSizeFitsTheRequestedExpansion) {
+  std::vector<uint8_t> rom = read_file("rom/cpc6128.rom");
+  if (rom.size() < 0x8000) rom = read_file("../rom/cpc6128.rom");
+  if (rom.size() < 0x8000) GTEST_SKIP() << "rom/cpc6128.rom not found";
+
+  struct Case {
+    size_t requested_kb;
+    size_t expect_total;
+  };
+  // 64K has no expansion at all; the rest keep whole 64K banks.
+  const Case kCases[] = {{64, 0x10000},
+                         {128, 0x20000},
+                         {256, 0x40000},
+                         {576, 0x90000},
+                         {4160, 0x410000}};
+
+  for (const auto& c : kCases) {
+    subcycle::Machine m;
+    m.set_ram_size(c.requested_kb * 1024);
+    ASSERT_TRUE(m.build(rom.data(), rom.size()));
+    EXPECT_EQ(m.ram_size(), c.expect_total)
+        << c.requested_kb << "K was not fitted";
+  }
+}
+
+// The Silicon Disc lives in expansion banks 4-7, so it raises the floor —
+// but it must not shrink a machine that was asked for more.
+TEST(SubcycleMachine, SiliconDiscRaisesTheRamFloorWithoutShrinkingIt) {
+  std::vector<uint8_t> rom = read_file("rom/cpc6128.rom");
+  if (rom.size() < 0x8000) rom = read_file("../rom/cpc6128.rom");
+  if (rom.size() < 0x8000) GTEST_SKIP() << "rom/cpc6128.rom not found";
+
+  subcycle::Machine small;
+  small.set_ram_size(128 * 1024);
+  ASSERT_TRUE(small.build(rom.data(), rom.size()));
+  small.enable_silicon_disc(true);
+  EXPECT_GE(small.ram_size(), 0x90000u) << "no room for banks 4-7";
+
+  subcycle::Machine big;
+  big.set_ram_size(4160 * 1024);
+  ASSERT_TRUE(big.build(rom.data(), rom.size()));
+  const size_t before = big.ram_size();
+  big.enable_silicon_disc(true);
+  EXPECT_EQ(big.ram_size(), before) << "the Silicon Disc shrank the machine";
+}

--- a/test/integrated/ipc_harness.py
+++ b/test/integrated/ipc_harness.py
@@ -14,7 +14,7 @@ import time
 import sys
 import os
 from pathlib import Path
-from typing import Optional, Tuple
+from typing import List, Optional, Tuple
 
 class KoncepcjaIPC:
     """Client for konCePCja IPC protocol."""
@@ -192,6 +192,9 @@ class EmulatorRunner:
         self.process: Optional[subprocess.Popen] = None
         self.ipc = KoncepcjaIPC()
         self._stderr_q: "queue.Queue[Optional[str]]" = queue.Queue()
+        # Every stderr line, kept because _await_ipc_port consumes the queue:
+        # a later probe (the telnet port) would otherwise find its line gone.
+        self._stderr_lines: List[str] = []
 
     def _pump_stderr(self) -> None:
         """Drain child stderr into _stderr_q for the process's whole life.
@@ -202,6 +205,7 @@ class EmulatorRunner:
         """
         assert self.process is not None and self.process.stderr is not None
         for line in self.process.stderr:
+            self._stderr_lines.append(line)
             self._stderr_q.put(line)
         self._stderr_q.put(None)
 
@@ -229,6 +233,23 @@ class EmulatorRunner:
             m = re.search(r'\bIPC: listening on port (\d+)', line)
             if m:
                 return int(m.group(1))
+
+    def await_logged_port(self, needle: str, timeout: float = 20.0) -> Optional[int]:
+        """Return a port this instance logged, e.g. 'Telnet console'.
+
+        Ports must always come from the process's own output: the servers
+        probe forward past busy ports, so a hardcoded or derived number can
+        silently address a different, already-running emulator.
+        """
+        pattern = re.compile(re.escape(needle) + r': listening on port (\d+)')
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            for line in list(self._stderr_lines):
+                m = pattern.search(line)
+                if m:
+                    return int(m.group(1))
+            time.sleep(0.1)
+        return None
 
     def _drain_stderr_tail(self, max_lines: int = 20) -> str:
         """Non-blocking grab of buffered stderr lines, for error messages."""
@@ -1040,6 +1061,58 @@ def test_load_accepts_flux_disk_formats():
     return True
 
 
+
+def test_boots_to_basic_with_peripherals():
+    """The CPC must reach the BASIC prompt with peripherals configured.
+
+    Nothing else in this suite boots the configured machine and checks that it
+    arrives. That gap let a real crashloop ship: anything attached into an
+    expansion ROM slot gets initialised by the firmware's ROM scan at boot, so
+    fitting a peripheral's ROM whose Device is not wired up runs its boot code
+    against absent hardware and the machine resets forever, never reaching
+    BASIC. Every unit test still passed, because the defect was in which slots
+    get fitted, not in the fitting.
+
+    The assertion is the BASIC prompt itself, read off the telnet console —
+    model-independent, and exactly the thing the user loses when this breaks.
+    """
+    with EmulatorRunner() as emu:
+        # M4 on: it owns a ROM slot and auto-loads an image into it, which is
+        # the configuration that broke.
+        if not emu.start('-O', 'peripheral.m4board=1'):
+            print("  Failed to start emulator")
+            return False
+
+        port = emu.await_logged_port('Telnet console', timeout=10.0)
+        if port is None:
+            print("  SKIP: emulator logged no telnet port")
+            return True
+
+        banner = b''
+        try:
+            with socket.create_connection(('127.0.0.1', port), timeout=5.0) as sock:
+                sock.settimeout(1.0)
+                deadline = time.monotonic() + 15.0
+                while time.monotonic() < deadline and b'Ready' not in banner:
+                    try:
+                        chunk = sock.recv(4096)
+                    except socket.timeout:
+                        continue
+                    if not chunk:
+                        break
+                    banner += chunk
+        except OSError as e:
+            print(f"  SKIP: could not reach the telnet console: {e}")
+            return True
+
+        if b'Ready' not in banner:
+            print(f"  CPC never reached the BASIC prompt. Console said: "
+                  f"{banner[:200]!r}")
+            return False
+        print("  CPC reached the BASIC prompt")
+        return True
+
+
 def main():
     """Run all IPC tests."""
     print("=" * 50)
@@ -1047,6 +1120,7 @@ def main():
     print("=" * 50)
 
     tests = [
+        test_boots_to_basic_with_peripherals,
         test_headless_runs_subcycle_engine,
         test_engine1_bp_clear_resume,
         test_z80_basic,


### PR DESCRIPTION
Covers **item 1 of beads-o0iq** (P0). ParaDOS, Utopia and Maxam loaded, showed a green dot in the ROMs dialog, and returned `loaded=true` with a CRC from `rom info` — and the CPC could not see any of them. `|HELP` never listed them.

## Where it stopped

Every path that fits a ROM filled `memmap_ROM` on the host and stopped there. The board's `roms[]` stayed empty, and **an empty slot reads as BASIC** — byte-for-byte indistinguishable from no board being fitted. Nothing anywhere reported a failure.

Three separate paths, one destination:

| Path | What it did |
|---|---|
| `[rom] slotNN` at boot | filled `memmap_ROM`, never attached |
| ROMs dialog picker | only recorded the path — **did not even load the file** until the next full init |
| IPC `rom load` | filled `memmap_ROM`, never attached |

## The fix

- The board attaches every populated slot as it comes up, and `subcycle_bridge_attach_rom_slot()` fits/unfits one at runtime.
- `load_expansion_rom_slot()` now takes a full path as well as a name under `rom_path`, replaces whatever occupied the slot, and fits the result — so the dialog and IPC share the loader that already understands AMSDOS headers, Graduate accessory ROMs and the validity checks.
- The dialog loads, fits and reports instead of silently recording a path.

## A use-after-free this surfaced

`Machine::attach_rom` ignored a `nullptr`:

```cpp
if (rom16k != nullptr && slot >= 0 && slot < 256)   // nullptr silently dropped
```

A slot could be filled but never emptied. Harmless while only the M4 and serial card attached ROMs (neither ever detaches) — but the moment `rom unload` frees the image, the memory device is still pointing at it. **I proved it live**: after `rom unload` the CPC read freed memory instead of BASIC. `nullptr` now empties the slot.

That is a bug my own change would have created, and it is exactly why the verification below runs the *unload* leg too.

## Verified live, with the CPC doing its own ROM select

`LD BC,&7F00 / LD A,&81 / OUT (C),A` to enable both ROMs, then `LD BC,&DF00 / LD A,4 / OUT (C),A`, then read `0xC000`:

| State | `0xC000` |
|---|---|
| slot 4 empty | `8001020040C03100` (BASIC) |
| `amsdos.rom` fitted | `0100050072C0C3BC` — **exactly the file's first 8 bytes** |
| after `rom unload 4` | `8001020040C03100` — BASIC again, byte-identical to empty |

No host-side shortcut: the Z80 executed the ROM select and the read went through the board's memory device.

## Test

`SubcycleMachine.ExpansionRomSlotCanBeFittedAndEmptied` drives the same three states through `mem_fast_io_write` + `mem_peek_cpu`. It cannot pass on the old code by construction — `ASSERT_NE(basic0, 0xA5)` guarantees the emptied-slot assertion fails when the `nullptr` is dropped.

1619 tests pass. `make clang-format` clean.

## Still open on beads-o0iq

Items 2 and 3 are untouched here: `ram_size` is ignored (the machine is always 128K) and a model change never rebuilds the board. Both need their own work; neither is a one-line wire-up.

---

# Update: item 2 as well — `ram_size` was ignored

The board allocated a fixed 64K of expansion whatever was asked for. A stock 64K 464 and a 576K Yarek config **both booted as a 128K 6128**, while the status bar and `config get ram_size` reported the figure you asked for.

`Machine::set_ram_size()` now sizes the expansion in whole 64K banks and the board is told before it boots. The Silicon Disc needs expansion banks 4-7, so it now *raises the floor* instead of fixing the size — it previously forced exactly 512K, which would have shrunk a larger machine the moment this became configurable.

Verified through snapshot headers, which record the machine's real RAM:

| Configured | Snapshot header | File size |
|---|---|---|
| CPC 464 @ 64K | 64K | 65,792 = 128 + 64K |
| CPC 6128 @ 128K | 128K | 131,328 |
| CPC 6128 @ 576K | 576K | 590,080 |

Before this change all three produced 128K. (Asking a 6128 for 64K still clamps to 128K — that is the config layer doing its job, which is why the 64K case is tested on a 464.)

**The test caught a crash on the way in**: `resize_expansion()` attached to the memory Device before `build()` had created it — `EXC_BAD_ACCESS` on the very first case. It now defers to `build()`, which picks the size up itself.

Two new tests cover the sizes end to end and pin the Silicon Disc floor in both directions (raises a small machine, does not shrink a large one).

**Item 3 of beads-o0iq remains open**: a model change still never rebuilds the board, so Options ▸ Apply on CPC Model re-inits the host and keeps booting the previous model's ROM. That needs a board rebuild path, not a wire-up.

---

# Update 2: this PR crashlooped the emulator, and the tests did not notice

The first version of the ROM loop attached **every** populated `memmap_ROM` slot. The M4's auto-loader puts a patched M4 boot ROM into its slot, and `rom/m4.rom` does not exist in a normal tree — so the bridge's M4 block never runs and `set_m4()` is never called. The firmware's ROM scan then ran M4 boot code against hardware that was not wired, and the CPC reset forever:

```
Emulated M4 v2.0
 BASIC 1.1
Emulated M4 v2.0
 BASIC 1.1      ← forever, never reaching the prompt
```

Fixed by fitting only the slots the **user** asked for. `CPC.rom_file` is what makes a slot the user's: the peripheral managers write straight into `memmap_ROM` and never claim a `rom_file` entry. They also free their image on their own schedule, so attaching it was a dangling-pointer bug as well.

## The coverage gap, stated plainly

Every unit test passed on the broken build. They exercised `attach_rom` on a bare `Machine` — but the defect was in **which slots the bridge decides to fit**, and its consequence only exists once the real firmware boots. **Nothing in 1619 tests booted the configured machine and checked that it arrives at BASIC.**

`test_boots_to_basic_with_peripherals` closes that: it starts the emulator with the M4 enabled and waits for the BASIC prompt on the telnet console. Verified both ways — it fails on the broken build with the loop above, and passes on this one. The assertion is the prompt itself, so it is model-independent and is exactly what the user loses when this breaks.

The harness now reads the telnet port from the emulator's own log instead of deriving it from the IPC port, for the same reason it already reads the IPC port there.

## Integration-suite state

`test_step_in_accuracy` is flaky **on master** — built `origin/master` in a clean worktree: one run failed at `PC=0x0642`, the next passed 16/16. On this branch it fails consistently at `PC=0x0B2C`. Filed as **beads-771z** with the evidence; not introduced here, and worth fixing rather than tolerating.

---

# Also in here: the binary reported the wrong commit

Folded in deliberately rather than left as an undocumented drive-by (raised in review as a separate concern — it is one, and it now has its own section instead of riding along invisibly).

Surfaced by the question "is the binary fresh?", which the binary answered **wrongly**: it printed `v6.2.0-b9fbf167` while `HEAD` was `75470fc9`.

The git hash is baked in at compile time, but *making a commit does not touch any source file*, so `make` never invalidates anything that embeds it. The reported hash silently lags until something unrelated forces a rebuild. `koncepcja --version` and the startup manifest — which external tooling parses to identify a build — both carried it.

- Only `argparse.cpp` and `kon_cpc_ja.cpp` embed the hash, so a hash stamp scoped to those rebuilds **2 objects on a commit, not 110**.
- Both stamps moved from a rule with a `FORCE` prerequisite to a parse-time refresh, so they are ordinary files with honest timestamps and `make -q koncepcja` answers the freshness question truthfully.

Checked, not assumed: a version bump still invalidates the build (the guard added in PR #16), `VersionSource.CompiledVersionMatchesTheManifest` passes, and the reported hash now matches `HEAD` exactly.

One correction to an earlier claim of mine in the makefile comment: this does **not** make bare `make -q` usable. That is always dirty because the default goal `all` depends on the phony `check_deps` — nothing to do with the stamps. The comment now says so and points at `make -q koncepcja`.
