### PR TITLE
fix(ui): a dropped file is never silently ignored

### DIFF
--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -52,6 +52,7 @@ inline Uint32 MapRGBSurface(SDL_Surface* surface, Uint8 r, Uint8 g, Uint8 b) {
 #include "keyboard_manager.h"
 #include "koncepcja.h"
 #include "koncepcja_ipc_server.h"
+#include "launch_echo.h"
 #include "m4board.h"
 #include "m4board_http.h"
 #include "macos_menu.h"
@@ -2403,6 +2404,37 @@ bool saveConfiguration(t_CPC& CPC, const std::string& configFilename) {
   return conf.saveToFile(configFilename);
 }
 
+// Launch files that the window manager may echo back as a drop.
+//
+// The old guard compared *filenames* against whatever was mounted, forever —
+// so dropping a different game.dsk from another folder was silently ignored,
+// and re-dropping a mounted disk did nothing and said nothing about it. The
+// filter (src/launch_echo.h) is the narrow version: whole paths, consumed once
+// each, only during the moment after launch when an echo can arrive.
+namespace {
+LaunchEchoFilter g_launch_echo;
+
+std::string canonical_path(const std::string& p) {
+  std::error_code ec;
+  const std::filesystem::path c = std::filesystem::weakly_canonical(p, ec);
+  return ec ? p : c.string();
+}
+}  // namespace
+
+void register_launch_files(const std::vector<std::string>& slot_list) {
+  std::vector<std::string> canonical;
+  canonical.reserve(slot_list.size());
+  for (const auto& f : slot_list) canonical.push_back(canonical_path(f));
+  // Generous: the echo arrives within the first frames. Anything later is the
+  // user dropping a file they also passed on the command line, which is an
+  // ordinary thing to do and must behave like any other drop.
+  g_launch_echo.arm(canonical, SDL_GetTicks(), 5000);
+}
+
+bool drop_is_launch_echo(const std::string& drop_path) {
+  return g_launch_echo.consume(canonical_path(drop_path), SDL_GetTicks());
+}
+
 // As long as a GUI is enabled, we must show the cursor.
 // Because we can activate multiple GUIs at a time, we need to keep track of how
 // many times we've been asked to show or hide cursor.
@@ -3822,6 +3854,10 @@ int koncpc_main(int argc, char** argv) {
 
   // Extract files to be loaded from the command line args
   fillSlots(slot_list, CPC);
+  // macOS re-delivers every launch file as a DROP_FILE once the window
+  // exists, after fillSlots() has already mounted it. Register each one to be
+  // swallowed exactly once, shortly after start — see drop_is_launch_echo().
+  register_launch_files(slot_list);
 
   // Must be done before emulator_init()
   CPC.InputMapper = new InputMapper(&CPC);
@@ -3990,38 +4026,27 @@ int koncpc_main(int argc, char** argv) {
           auto drop_fname =
               std::filesystem::path(drop_path).filename().string();
 
-          // macOS re-delivers the CLI launch-file arguments as DROP_FILE
-          // events once the window exists — *after* fillSlots() has already
-          // mounted them into the drive slots. Loading every dropped disk
-          // into drive A therefore clobbered a launch that filled both
-          // drives (the 2nd CLI disk overwrote the 1st). Ignore a drop that
-          // merely re-delivers a disk already mounted in a drive; match by
-          // filename, since the CLI arg may be relative while the drop path
-          // is absolute.
-          auto already_mounted = [&](const std::string& slot_file) {
-            return !slot_file.empty() &&
-                   std::filesystem::path(slot_file).filename() ==
-                       std::filesystem::path(drop_path).filename();
-          };
+          // The window manager echoing back a command-line file is not a
+          // user action. Everything past this point is, and must produce
+          // visible feedback — a drop that changes nothing and says nothing
+          // is indistinguishable from a broken emulator.
+          if (drop_is_launch_echo(drop_path)) {
+            LOG_INFO("Ignoring launch-file echo: " << drop_fname);
+            continue;
+          }
 
           // Route by the list slotshandler actually accepts for drive A
           // (.dsk/.ipf/.raw + the flux containers .scp/.hfe/.a2r) instead of
           // a hand-kept copy — a dropped .hfe used to hit the unknown-file
           // toast because this list had drifted from the loaders.
           if (extension_in_dotted_list(drive_extensions(DRIVE::DSK_A), ext)) {
-            if (already_mounted(CPC.driveA.file) ||
-                already_mounted(CPC.driveB.file)) {
-              LOG_INFO("Ignoring drop of already-mounted disk: " << drop_fname);
+            CPC.driveA.file = drop_path;
+            if (file_load(CPC.driveA) == 0) {
+              ui_host().toast(UiToastLevel::Success, "Drive A: " + drop_fname);
+              imgui_mru_push(CPC.mru_disks, drop_path);
             } else {
-              CPC.driveA.file = drop_path;
-              if (file_load(CPC.driveA) == 0) {
-                ui_host().toast(UiToastLevel::Success,
-                                "Drive A: " + drop_fname);
-                imgui_mru_push(CPC.mru_disks, drop_path);
-              } else {
-                ui_host().toast(UiToastLevel::Error,
-                                "Failed to load disk: " + drop_fname);
-              }
+              ui_host().toast(UiToastLevel::Error,
+                              "Failed to load disk: " + drop_fname);
             }
           } else if (ext == ".cdt" || ext == ".voc") {
             CPC.tape.file = drop_path;

--- a/src/launch_echo.h
+++ b/src/launch_echo.h
@@ -1,0 +1,50 @@
+#pragma once
+
+// A window manager may echo a command-line file back to the application as a
+// drag-and-drop event once the window exists — macOS does this for every
+// launch argument, after the files have already been mounted. Such an echo is
+// not a user action and must not be handled like one: re-loading each echoed
+// disk into drive A clobbers a launch that filled both drives.
+//
+// This is the filter for exactly that, and nothing more. It matches whole
+// paths, consumes each registration once, and stops matching shortly after
+// launch. Everything it does not match is a real drop, which the application
+// must act on AND report — a drop that changes nothing and says nothing is
+// indistinguishable from a broken emulator.
+//
+// Kept free of SDL and the filesystem so it can be tested directly: the caller
+// supplies already-canonical paths and the clock.
+
+#include <cstdint>
+#include <set>
+#include <string>
+#include <vector>
+
+class LaunchEchoFilter {
+ public:
+  // Register the launch files, canonical paths, as echo candidates. Only
+  // drops arriving within `window_ms` of `now_ms` can be treated as echoes.
+  void arm(const std::vector<std::string>& canonical_files,
+           std::uint64_t now_ms, std::uint64_t window_ms) {
+    pending_.clear();
+    pending_.insert(canonical_files.begin(), canonical_files.end());
+    deadline_ms_ = now_ms + window_ms;
+  }
+
+  // True if this drop is an echo of a launch file — at most once per file,
+  // and never after the window closes. Any other drop is the user's.
+  bool consume(const std::string& canonical_path, std::uint64_t now_ms) {
+    if (pending_.empty()) return false;
+    if (now_ms > deadline_ms_) {
+      pending_.clear();  // window closed: never swallow a drop again
+      return false;
+    }
+    return pending_.erase(canonical_path) > 0;
+  }
+
+  bool armed() const { return !pending_.empty(); }
+
+ private:
+  std::set<std::string> pending_;
+  std::uint64_t deadline_ms_ = 0;
+};

--- a/test/launch_echo_test.cpp
+++ b/test/launch_echo_test.cpp
@@ -1,0 +1,70 @@
+#include "launch_echo.h"
+
+#include <gtest/gtest.h>
+
+namespace {
+constexpr std::uint64_t kWindow = 5000;
+constexpr std::uint64_t kStart = 1000;
+}  // namespace
+
+// The one thing this exists for: the window manager hands a launch file back
+// as a drop, and handling it would re-load it — over the second disk, in a
+// two-drive launch.
+TEST(LaunchEchoFilter, SwallowsAnEchoOfALaunchFile) {
+  LaunchEchoFilter f;
+  f.arm({"/games/a.dsk", "/games/b.dsk"}, kStart, kWindow);
+
+  EXPECT_TRUE(f.consume("/games/a.dsk", kStart + 50));
+  EXPECT_TRUE(f.consume("/games/b.dsk", kStart + 60));
+}
+
+// Consumed once each: the second drop of the same file is the user asking for
+// it, and must be loaded and reported like any other drop.
+TEST(LaunchEchoFilter, SwallowsEachFileOnlyOnce) {
+  LaunchEchoFilter f;
+  f.arm({"/games/a.dsk"}, kStart, kWindow);
+
+  ASSERT_TRUE(f.consume("/games/a.dsk", kStart + 50));
+  EXPECT_FALSE(f.consume("/games/a.dsk", kStart + 100))
+      << "a deliberate re-drop was swallowed";
+}
+
+// The bug the old filename-matching guard caused: a different file that merely
+// shares a basename with a mounted one was silently ignored — no load, no
+// message, nothing on the status bar.
+TEST(LaunchEchoFilter, DoesNotSwallowADifferentFileWithTheSameName) {
+  LaunchEchoFilter f;
+  f.arm({"/games/a.dsk"}, kStart, kWindow);
+
+  EXPECT_FALSE(f.consume("/elsewhere/a.dsk", kStart + 50))
+      << "same basename, different file — this is a real drop";
+}
+
+// After the launch moment, nothing is an echo. Without this the filter could
+// eat one deliberate drop hours later on a platform that never echoes.
+TEST(LaunchEchoFilter, StopsSwallowingOnceTheWindowCloses) {
+  LaunchEchoFilter f;
+  f.arm({"/games/a.dsk"}, kStart, kWindow);
+
+  EXPECT_FALSE(f.consume("/games/a.dsk", kStart + kWindow + 1));
+  EXPECT_FALSE(f.armed()) << "the expired window should disarm the filter";
+  EXPECT_FALSE(f.consume("/games/a.dsk", kStart + 10))
+      << "a closed window must not reopen";
+}
+
+// A launch with no files must never swallow anything.
+TEST(LaunchEchoFilter, UnarmedSwallowsNothing) {
+  LaunchEchoFilter f;
+  EXPECT_FALSE(f.consume("/games/a.dsk", kStart));
+
+  f.arm({}, kStart, kWindow);
+  EXPECT_FALSE(f.consume("/games/a.dsk", kStart + 50));
+}
+
+// A file that was never on the command line is always the user's.
+TEST(LaunchEchoFilter, DoesNotSwallowAnUnregisteredFile) {
+  LaunchEchoFilter f;
+  f.arm({"/games/a.dsk"}, kStart, kWindow);
+
+  EXPECT_FALSE(f.consume("/games/other.dsk", kStart + 50));
+}


### PR DESCRIPTION
Reported: *"dropping a file did not update the status bar / no OSD message either / where is my track number."*

## What was happening

The drop handler had a guard that ignored any drop whose **filename** matched a file already in a drive — permanently, and **silently**: a `LOG_INFO` and nothing else. No load, no toast, no status-bar change.

So:

- re-dropping a disk that is already mounted → nothing happens and nothing says why
- dropping a *different* `game.dsk` from another folder while one is mounted → same, silently ignored

That is all three reported symptoms at once, and it is the worst possible failure shape: the emulator looks broken.

## Why the guard existed

macOS re-delivers every command-line file as a `DROP_FILE` once the window exists — *after* `fillSlots()` has already mounted them. Handling that echo re-loaded each disk into drive A, so a two-disk launch ended with the second disk over the first. The fix at the time was to compare filenames (the CLI arg may be relative, the drop path absolute) against the mounted slots. Correct for the echo, but it never stopped applying.

## The narrow version

`LaunchEchoFilter` (`src/launch_echo.h`) does only what the workaround needs:

- **whole paths**, canonicalised — a different file with the same basename is not an echo
- **consumed once each** — the second arrival of the same file is the user asking for it
- **only during the launch moment** (5 s) — after that nothing is an echo, so the filter can never eat a deliberate drop on a platform that does not echo at all

Everything it does not match is a real drop: loaded, and reported with a toast either way.

## Testable, deliberately

The last bug I shipped got through because the decision lived somewhere no test could reach. This one is a plain class with no SDL and no filesystem — the caller supplies canonical paths and the clock. Six cases:

- swallows an echo of a launch file (the reason it exists)
- swallows each file only once — a deliberate re-drop is not swallowed
- **does not swallow a different file with the same basename** (the reported bug)
- stops swallowing once the window closes, and a closed window cannot reopen
- unarmed swallows nothing
- an unregistered file is always the user's

**1624 tests pass**, 3 skipped (absent flux fixtures). `make clang-format` clean.

Verified live that the behaviour the filter protects still works — launching with two disks fills both drives:

```
drive=A present=1 flux=0 tracks=40 image=one.dsk
drive=B present=1 flux=0 tracks=40 image=two.dsk
```

## Note on the other two symptoms

The missing filename and track number in the status bar have a second cause that #25 already fixed: a flux-backed disc reported `tracks=0`, so the status bar called it empty. If the drop that prompted this report was an `.hfe`, #25 (now on master) covers that half and this covers the silence.
