### PR TITLE
fix(audio): release the tape line I/O before SDL_Quit (hazard, not the reported crash)

### DIFF
--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -2864,6 +2864,9 @@ void doCleanUp() {
   symbiface_cleanup();
   m4board_cleanup();
   joysticks_shutdown();
+  // Before audio_shutdown()/SDL_Quit(): the tape line I/O owns SDL audio
+  // streams and an audio-device event watch that neither of them knows about.
+  tape_line_audio_shutdown();
   audio_shutdown();
   video_clear_topbar();
   video_shutdown();

--- a/src/tape_line_in.cpp
+++ b/src/tape_line_in.cpp
@@ -95,6 +95,19 @@ void tape_line_out_disarm(subcycle::Machine& machine) {
 
 bool tape_line_out_active() { return g_out_stream != nullptr; }
 
+void tape_line_audio_shutdown() {
+  // Watch first: it is the thing that could re-enter SDL during teardown.
+  SDL_RemoveEventWatch(out_device_watch, nullptr);
+  if (g_out_stream != nullptr) {
+    SDL_DestroyAudioStream(g_out_stream);
+    g_out_stream = nullptr;
+  }
+  if (g_stream != nullptr) {
+    SDL_DestroyAudioStream(g_stream);
+    g_stream = nullptr;
+  }
+}
+
 void tape_line_out_set_volume(float level) {
   // NOLINTNEXTLINE(readability-avoid-nested-conditional-operator): nested
   // conditional kept intentionally; no clang-tidy auto-fix

--- a/src/tape_line_in.h
+++ b/src/tape_line_in.h
@@ -39,6 +39,13 @@ void tape_line_out_pump(subcycle::Machine& machine);
  * Applied live in the pump (scales both the data square and the motor carrier);
  * persisted as [sound] tape_data_volume (percent). */
 void tape_line_out_set_volume(float level);
+
+// Release every SDL audio object this module owns, without touching the
+// machine. MUST run before SDL_Quit(): the device-change watch installed by
+// tape_line_out_arm() calls SDL_DestroyAudioStream, and SDL_QuitAudio fires
+// device-removed events *while* it destroys those devices — the watch would
+// then re-enter SDL's teardown and mutate the list it is walking.
+void tape_line_audio_shutdown();
 float tape_line_out_volume();
 
 #endif /* KONCPC_TAPE_LINE_IN_H */


### PR DESCRIPTION
Removes a real re-entrancy hazard in shutdown. **Not confirmed as the cause of the reported SIGSEGV** — see below.

## The hazard

`tape_line_out_arm()` installs an SDL audio-device event watch:

```cpp
SDL_AddEventWatch(out_device_watch, nullptr);   // calls SDL_DestroyAudioStream
```

Nothing removes it at shutdown. `doCleanUp()` tears down the emulator's own two streams and then calls `SDL_Quit()`. **`SDL_QuitAudio` fires device-removed events while it is destroying those devices**, so the watch re-enters SDL's teardown and destroys a stream out from under the loop walking the device list.

The two line I/O streams were also simply left for `SDL_QuitAudio` to collect. They are now closed explicitly — watch removed first, since that is the part that can re-enter.

## Why this is easy to hit

The line-out is armed automatically whenever the deck plays, gated only on `CPC.tape_play_button` (`subcycle_bridge.cpp:843`) — **not** on `[sound] tape_sounds`. So pressing Play once arms the watch even with tape sound switched off, and any later exit runs `SDL_Quit()` with it live.

## Honesty about the reported crash

It matches the reported trace shape exactly:

```
DestroyLogicalAudioDevice ← DestroyPhysicalAudioDevice ← SDL_QuitAudio ← SDL_Quit ← doCleanUp()
```

**But I could not reproduce it.** I armed the line-out over IPC and quit, with and without it armed, on a real audio driver: clean exit both times. The reporter's session was a GUI run (video subsystem live) and mine was not, which is one difference I did not chase.

So this is committed as *removing a hazard that is real regardless*, not as a verified fix. If the crash recurs after this lands, this was not it, and the next thing to look at is whichever SDL audio object is still outliving `SDL_Quit`.

The crash report on disk identifies the build: it ran for 74 seconds and died at 07:37:54, two minutes before #25 merged — i.e. the `fix/rom-slots` build, with the M4 crashloop already fixed. So this is a separate fault, not a tail of that one.
