### PR TITLE
fix(ui,docs): guard the Options restart, and stop the docs misdirecting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,16 +6,28 @@ Amstrad CPC emulator based on Caprice32, with Dear ImGui interface and IPC debug
 
 ```
 src/
-├── kon_cpc_ja.cpp     # Main emulator loop, keyboard handling
-├── z80.cpp            # Z80 CPU emulation with breakpoint support
-├── video.cpp          # Video rendering, scanlines
-├── psg.cpp            # Sound chip (AY-3-8912) emulation
-├── tape.cpp           # CDT/TZX tape playback engine
-├── slotshandler.cpp   # File loading (DSK, CDT, SNA, CPR)
-├── imgui_ui.cpp       # Dear ImGui interface (topbar, devtools, menus)
+├── hw/                # THE hardware: one Device per chip, pin-level
+│   ├── z80.cpp        #   CPU
+│   ├── crtc.cpp       #   CRTC 6845
+│   ├── gate_array.cpp #   Gate Array
+│   ├── psg.cpp        #   AY-3-8912
+│   ├── fdc.cpp        #   uPD765A + flux media
+│   ├── tape.cpp       #   cassette deck
+│   ├── memory.cpp     #   banking, ROM slots, expansion RAM
+│   ├── video.cpp      #   raster output
+│   ├── asic.cpp       #   6128+ ASIC
+│   └── …              #   ppi, mf2, m4, symbiface, amx, rs232, plotter, …
+├── subcycle/
+│   ├── machine.cpp    # the board: builds and clocks the Devices together
+│   └── record_replay.cpp
+├── subcycle_bridge.cpp       # host ↔ board seam (media, ROMs, input, views)
+├── kon_cpc_ja.cpp     # main loop, host state, config load/save, cleanup
+├── slotshandler.cpp   # file loading (DSK, IPF, flux, CDT, SNA, CPR)
+├── imgui_ui.cpp       # Dear ImGui interface (topbar, options, menus)
+├── devtools_ui.cpp    # DevTools windows (disassembly, memory, breakpoints…)
 ├── koncepcja_ipc_server.cpp  # TCP IPC server for external debugging
 ├── telnet_console.cpp # TCP text console — mirrors CPC output, injects keyboard
-└── disk.cpp           # Floppy disk emulation
+└── z80_view.cpp       # host-side Z80 view + the firmware/BDOS output hooks
 ```
 
 ## Emulated Devices
@@ -61,21 +73,28 @@ make -j$(nproc) DEBUG=1
 
 ## Command Line Arguments
 
-Run `./koncepcja --help` for the full list:
+`./koncepcja --help` is the source of truth — this table is a copy and has
+drifted before (it listed 9 of 15 flags, omitting `--headless`):
 
 ```
 Usage: koncepcja [options] <slotfile(s)>
 
 Options:
-  -a/--autocmd=<command>   Execute BASIC command after CPC boots
+  -a/--autocmd=<command>   Execute BASIC command after CPC boots (repeatable)
+  -B/--exit-on-break       Exit with code 1 when a breakpoint is hit
   -c/--cfg_file=<file>     Use custom config file
+  -D/--debug               Frame timing + audio diagnostics in the DevTools bar
+  -E/--exit-after=<spec>   Exit after N frames (100f), seconds (5s) or ms (3000ms)
+  -H/--headless            Run without display or audio (IPC and emulation only)
   -h/--help                Show help
   -i/--inject=<file>       Inject binary into memory after boot
+  -L/--list-plugins        List video plugins (index: name) and exit
   -o/--offset=<address>    Injection address (default: 0x6000)
   -O/--override=<opt=val>  Override config option (repeatable)
   -s/--sym_file=<file>     Load symbols for disassembly
   -V/--version             Show version
   -v/--verbose             Verbose logging
+     --fps                 Log once-per-second FPS to stdout
 
 Slot files: .dsk/.ipf/.raw (disk), .scp/.hfe/.a2r (flux disk, drive A only),
 .cdt/.voc (tape), .cpr (cartridge), .sna (snapshot)
@@ -115,8 +134,22 @@ socat - TCP:localhost:6543
 
 ```bash
 echo "help" | nc localhost 6543
-# Response: OK commands: ping version help pause run reset load regs reg set/get mem bp(list/add/del/clear) step wait screenshot snapshot(save/load) disasm devtools
 ```
+
+The response is categorised and far longer than the table below — ask the
+server rather than trusting any list in this file:
+
+```
+OK available commands (usage: help <command>):
+  Protocol: persistent connections, ';' chains commands, 'disconnect' closes.
+  Numbers: 0x, $, &, # hex prefixes accepted (e.g. $C000, &4000, #BB5A).
+  CORE:      disconnect, gui, load <file>, metrics, pause, ping, plugins, …
+  DEBUG:     bp …, data …, disasm …, mem …, reg …, step …, trace …, wait …
+  …
+```
+
+`help <command>` prints that command's own usage. The full protocol lives in
+[docs/ipc-protocol.md](docs/ipc-protocol.md).
 
 ### IPC Command Reference
 
@@ -148,7 +181,7 @@ echo "help" | nc localhost 6543
 | `snapshot load <path>` | Load state | `snapshot load game.sna` |
 | `load <path>` | Load file (.dsk/.sna/.cpr/.bin) | `load game.dsk` |
 | `devtools` | Open DevTools window | `devtools` → `OK` |
-| `tier` | Run-tier policy (engine=1) | `tier` → `OK policy=auto effective=fast pinned=0` |
+| `tier` | Run-tier policy | `tier` → `OK policy=auto effective=fast pinned=0` |
 | `tier set <p>` | Set policy: auto/fast/wake/soldered/faithful | `tier set wake` → `OK policy=wake` |
 | `input keydown <name>` | Press and hold a key | `input keydown SHIFT` |
 | `input keyup <name>` | Release a key | `input keyup SHIFT` |
@@ -168,8 +201,8 @@ echo "help" | nc localhost 6543
 
 `<name>` is a friendly key name (`RETURN`, `SPACE`, `ESC`, `F1`, `UP`, ...) or a
 single character (`a`, `A`, `1`). For multi-line entry or special keys inside a
-string, use `autotype` with `~KEY~` tokens — `input type` does **not** interpret
-them.
+string, either command works: `input type` is routed through the same
+AutoTypeQueue as `autotype`, so `~KEY~` tokens and newlines behave identically.
 
 ### Scripting Example
 
@@ -282,7 +315,7 @@ nc localhost 6544
 
 - `src/telnet_console.h` — TelnetConsole class, ring buffer, input mutex
 - `src/telnet_console.cpp` — TCP server thread, ANSI parsing, Z80 hook callback
-- Z80 hooks: `z80_set_txt_output_hook()` (firmware) and `z80_set_bdos_output_hook()` (CP/M) in `src/z80.cpp` / `src/z80.h`
+- Z80 hooks: `z80_set_txt_output_hook()` (firmware) and `z80_set_bdos_output_hook()` (CP/M) in `src/z80_view.cpp` / `src/z80_view.h`
 - Main loop integration: `g_telnet.start()` / `drain_input()` / `stop()` in `src/kon_cpc_ja.cpp`
 
 ## M4 HTTP Server
@@ -378,7 +411,7 @@ Malformed CDT/TZX files can crash older versions. Test files are rejected gracef
 
 The emulator uses LOG_DEBUG/LOG_INFO/LOG_ERROR macros. Key files with logging:
 - `slotshandler.cpp` - File loading errors
-- `psg.cpp` - Audio timing info
+- `src/hw/psg.cpp` - Audio timing info
 - `keyboard.cpp` - Key mapping issues
 
 ### DevTools
@@ -443,12 +476,9 @@ Config file locations (in order of precedence):
 ```ini
 [system]
 model=2           # 0=464, 1=664, 2=6128, 3=6128+
-engine=1          # 1=sub-cycle pin-level board (DEFAULT since 2026-07-10 —
-                  # beats legacy 30-49%, byte-exact, Auto tier policy);
-                  # 0=legacy Caprice32 core (kept until Gate C deletes it)
-ram_size=128      # RAM in KB
+ram_size=128      # RAM in KB: 64, 128, 192, 256, 320, 512, 576 … 4160
 speed=4           # Clock speed MHz
-run_tier=0        # Sub-cycle engine (engine=1) tier policy: 0=auto (Fast;
+run_tier=0        # Run-tier policy: 0=auto (Fast;
                   # drops to Wake while any breakpoint/watchpoint/IO-BP is
                   # set — per-cycle observability for the debugger), 1=fast,
                   # 2=wake, 3=soldered, 4=faithful. Shift+F9 cycles
@@ -466,8 +496,10 @@ vsync=1           # 1=VSYNC present (default). 0=MAILBOX/IMMEDIATE on the MAIN
                   # (decoupled from render), so FPS stays 50 either way.
 
 [sound]
-snd_enabled=1
-snd_playback_rate=2  # 0=11025, 1=22050, 2=44100, 3=48000, 4=96000
+enabled=1         # NOTE: the INI keys are enabled/playback_rate/bits/stereo/
+playback_rate=2   # volume — NOT the snd_* names of the C++ struct members.
+                  # 0=11025, 1=22050, 2=44100, 3=48000, 4=96000
+volume=80         # 0-100
 
 [input]
 lightgun=0        # Light gun: 0=off, 1=Amstrad Magnum Phaser, 2=Trojan Light

--- a/src/imgui_ui.cpp
+++ b/src/imgui_ui.cpp
@@ -1592,6 +1592,14 @@ void imgui_render_menubar() {
     ImGui::Separator();
     if (ImGui::BeginMenu("Diagnostics")) {
       RenderMenuItem(KONCPC_DEBUG);
+      if (ImGui::IsItemHovered()) {
+        // LOG_VERBOSE writes to stdout (log.h); errors and warnings go to
+        // stderr regardless of this toggle. Say where the output lands —
+        // "verbose logging" alone tells the user nothing about where to look.
+        ImGui::SetTooltip(
+            "Print detailed diagnostics to the terminal that started the "
+            "emulator.\nErrors and warnings are always printed.");
+      }
       ImGui::EndMenu();
     }
     ImGui::EndMenu();
@@ -4052,31 +4060,61 @@ void imgui_render_options() {
   ImGui::Separator();
   ImGui::Spacing();
 
-  // Bottom buttons
-  if (ImGui::Button("Save", ImVec2(80, 0))) {
-    std::string const cfg = getConfigurationFilename(true);
-    saveConfiguration(CPC, cfg);
-    // Apply changes that need re-init
-    if (CPC.model != imgui_state.old_cpc_settings.model ||
-        CPC.ram_size != imgui_state.old_cpc_settings.ram_size ||
-        CPC.keyboard != imgui_state.old_cpc_settings.keyboard ||
-        g_m4board.enabled != old_m4_enabled) {
-      emulator_init();
+  // Changing any of these rebuilds the machine: emulator_init() wipes RAM and
+  // cold-boots the CPC. Computed once, because Save and Apply have to agree on
+  // what forces it — they each carried their own copy of this condition.
+  const bool needs_restart =
+      CPC.model != imgui_state.old_cpc_settings.model ||
+      CPC.ram_size != imgui_state.old_cpc_settings.ram_size ||
+      CPC.keyboard != imgui_state.old_cpc_settings.keyboard ||
+      g_m4board.enabled != old_m4_enabled;
+  const ImVec4 kWarn(0.95f, 0.75f, 0.2f, 1.0f);
+
+  // Say so before it happens, rather than rebooting under the user.
+  if (needs_restart) {
+    ImGui::TextColored(kWarn,
+                       "These settings restart the CPC — RAM is cleared.");
+    if (driveAltered()) {
+      ImGui::TextColored(kWarn,
+                         "A disk has unsaved changes that would be lost.");
     }
-    // Start/stop M4 HTTP server based on M4 enabled state
-    // Only auto-start when M4 was just enabled (not on every Save),
-    // so that a manual "Stop" in the UI stays effective.
-    if (g_m4board.enabled && !old_m4_enabled &&
-        !g_m4board.sd_root_path.empty() && !g_m4_http.is_running()) {
-      g_m4_http.start(CPC.m4_http_port, CPC.m4_bind_ip);
-    } else if (!g_m4board.enabled && g_m4_http.is_running()) {
-      g_m4_http.stop();
+    ImGui::Spacing();
+  }
+
+  // One commit path for both buttons; `save_to_file` is the only difference.
+  auto commit_options = [&](bool save_to_file) {
+    if (save_to_file) {
+      saveConfiguration(CPC, getConfigurationFilename(true));
+    }
+    if (needs_restart) emulator_init();
+    if (save_to_file) {
+      // Start/stop M4 HTTP server based on M4 enabled state. Only auto-start
+      // when M4 was just enabled (not on every Save), so that a manual "Stop"
+      // in the UI stays effective.
+      if (g_m4board.enabled && !old_m4_enabled &&
+          !g_m4board.sd_root_path.empty() && !g_m4_http.is_running()) {
+        g_m4_http.start(CPC.m4_http_port, CPC.m4_bind_ip);
+      } else if (!g_m4board.enabled && g_m4_http.is_running()) {
+        g_m4_http.stop();
+      }
     }
     update_cpc_speed();
     video_set_palette();
     imgui_state.show_options = false;
     cpc_resume();
     first_open = true;
+  };
+
+  // 0 = nothing pending, 1 = Save awaiting confirmation, 2 = Apply.
+  static int s_pending_commit = 0;
+
+  // Bottom buttons
+  if (ImGui::Button("Save", ImVec2(80, 0))) {
+    if (needs_restart && driveAltered()) {
+      s_pending_commit = 1;  // confirm before throwing the disk edits away
+    } else {
+      commit_options(true);
+    }
   }
   if (ImGui::IsItemHovered()) {
     ImGui::SetTooltip("Apply changes and save to config file");
@@ -4097,21 +4135,39 @@ void imgui_render_options() {
   }
   ImGui::SameLine();
   if (ImGui::Button("Apply", ImVec2(80, 0))) {
-    if (CPC.model != imgui_state.old_cpc_settings.model ||
-        CPC.ram_size != imgui_state.old_cpc_settings.ram_size ||
-        CPC.keyboard != imgui_state.old_cpc_settings.keyboard ||
-        g_m4board.enabled != old_m4_enabled) {
-      emulator_init();
+    if (needs_restart && driveAltered()) {
+      s_pending_commit = 2;
+    } else {
+      commit_options(false);
     }
-    update_cpc_speed();
-    video_set_palette();
-    imgui_state.show_options = false;
-    cpc_resume();
-    first_open = true;
   }
   if (ImGui::IsItemHovered()) {
     ImGui::SetTooltip(
         "Apply changes for this session only\n(not saved to config file)");
+  }
+
+  // The same guard the quit paths use: a restart is not worth a silent loss of
+  // disk edits the user has not written back.
+  if (s_pending_commit != 0 && !ImGui::IsPopupOpen("Restart the CPC?")) {
+    ImGui::OpenPopup("Restart the CPC?");
+  }
+  if (ImGui::BeginPopupModal("Restart the CPC?", nullptr,
+                             ImGuiWindowFlags_AlwaysAutoResize)) {
+    ImGui::TextColored(kWarn, "You have unsaved changes to a disk.");
+    ImGui::TextUnformatted(
+        "These settings restart the CPC. The changes will be lost.");
+    ImGui::Spacing();
+    if (ImGui::Button("Restart anyway", ImVec2(130, 0))) {
+      commit_options(s_pending_commit == 1);
+      s_pending_commit = 0;
+      ImGui::CloseCurrentPopup();
+    }
+    ImGui::SameLine();
+    if (ImGui::Button("Cancel", ImVec2(90, 0))) {
+      s_pending_commit = 0;
+      ImGui::CloseCurrentPopup();
+    }
+    ImGui::EndPopup();
   }
 
   if (!open) {

--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -4254,7 +4254,7 @@ int koncpc_main(int argc, char** argv) {
                 break;
               case KONCPC_DEBUG:
                 log_verbose = !log_verbose;
-                set_osd_message(std::string("Debug mode: ") +
+                set_osd_message(std::string("Verbose log to console: ") +
                                 (log_verbose ? "on" : "off"));
                 break;
               case KONCPC_DELAY:

--- a/src/menu_actions.cpp
+++ b/src/menu_actions.cpp
@@ -27,7 +27,7 @@ const std::vector<MenuAction>& koncpc_menu_actions() {
       {KONCPC_PHAZER, "Light Gun (Magnum Phaser)", "", true, MenuGroup::Input},
       {KONCPC_FPS, "Show FPS", "", true, MenuGroup::View},
       {KONCPC_SPEED, "Limit Speed", "", true, MenuGroup::Input},
-      {KONCPC_DEBUG, "Verbose Logging", "", true, MenuGroup::Tools},
+      {KONCPC_DEBUG, "Verbose Log to Console", "", true, MenuGroup::Tools},
       {KONCPC_EXIT, "Quit", "", false, MenuGroup::App},
       {KONCPC_PASTE, "Paste", "", false, MenuGroup::Edit},
       // Scripting-only autocmd primitives — not user-facing menu items (F9).


### PR DESCRIPTION
Four beads from the triage. **One of them needed no code at all** — it was already fixed and just needed closing.

## beads-sgi (P2) — Options Save/Apply wiped RAM with no warning

Save and Apply both called `emulator_init()` when model, RAM size, keyboard or M4 changed — cold-booting the CPC and clearing RAM. No warning, and **no unsaved-disk check**: `driveAltered()` appeared exactly once in the whole of `imgui_ui.cpp`, in the quit modal. Change a setting with an edited disk in a drive and the edits were gone silently.

Now:

- an inline warning appears **before** you commit — *"These settings restart the CPC — RAM is cleared"*, plus a second line if a disk has unsaved changes
- if a restart would discard disk edits, both buttons route through the same confirm the quit paths already use
- the restart condition was **duplicated** in the two handlers; it is computed once, and both buttons share one commit path differing only in whether it writes the config file

## beads-nmbn (P3) — "Verbose Logging" named neither the output nor its destination

`LOG_VERBOSE` writes to **stdout**; errors and warnings go to stderr regardless of the toggle. The menu said only "Verbose Logging", and the on-screen confirmation called it **"Debug mode"** — a third name for one switch.

Now "Verbose Log to Console", with a tooltip naming the destination, and the OSD text matches the menu.

## beads-gsfc (P2) — the agent-onboarding doc was misdirecting

`CLAUDE.md` is a symlink to `AGENTS.md`, so this is what every agent reads first. I re-checked each claim against the tree rather than trusting the audit; **all of them held**:

| Claim | Reality |
|---|---|
| Project Structure lists 5 Gate C-deleted files | `z80.cpp`, `video.cpp`, `psg.cpp`, `tape.cpp`, `disk.cpp` — all gone |
| documents a `[system] engine` option | read by **0** files |
| `[sound]` keys given as `snd_enabled` | the INI keys are `enabled`/`playback_rate` — the documented names silently do nothing |
| CLI table lists 9 flags | the binary has **15**; `--headless` was missing *while the doc told agents to use the `SDL_VIDEODRIVER=dummy` workaround instead* |
| quotes an 18-command `help` | the real response is categorised and far longer |
| says `input type` ignores `~KEY~` | it interprets them — same AutoTypeQueue as `autotype` |

Structure now leads with the `src/hw` Devices; the CLI table is copied from the binary and says so; the `help` block shows the shape and points at `docs/ipc-protocol.md`.

## beads-tol2 (P3) — already done

The label is already `"Light Gun (Magnum Phaser)"` — the exact wording the bead asked for, corrected spelling included. Closed, no change.

## Verification

**1627 tests pass**, 3 skipped (absent flux fixtures). `make clang-format` clean. GUI launches and quits cleanly.

The Options guard is UI logic I could not reach from a test — it mirrors the existing quit modal's shape and adds no state beyond one pending-commit flag, but it is verified by construction and a manual launch, not by an automated case.
