### PR TITLE
fix(ui,config): F-cluster confirmations and reachability, plus an example config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,7 @@ koncepcja_bench.profdata
 # beads-mwpg: local real flux fixtures (unknown-license captures, never commit)
 test/hw/fixtures/*.scp
 test/hw/fixtures/*.a2r
+
+# The live config: personal paths, MRU history and machine-specific tuning.
+# The shipped default is koncepcja.cfg.example — copy it to start.
+koncepcja.cfg

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,7 +97,8 @@ Options:
      --fps                 Log once-per-second FPS to stdout
 
 Slot files: .dsk/.ipf/.raw (disk), .scp/.hfe/.a2r (flux disk, drive A only),
-.cdt/.voc (tape), .cpr (cartridge), .sna (snapshot)
+.cdt/.voc (tape), .cpr (cartridge), .sna (snapshot), .zip (archive of any
+of the above)
 ```
 
 ### Examples
@@ -156,8 +157,8 @@ OK available commands (usage: help <command>):
 | Command | Description | Example |
 |---------|-------------|---------|
 | `ping` | Test connection | `ping` → `OK pong` |
-| `version` | Get version | `version` → `OK koncepcja-0.2 port=6543` |
-| `help` | List commands | `help` → `OK commands: ...` |
+| `version` | Get version | `version` → `OK koncepcja-<version> port=6543` |
+| `help` | List commands, categorised | `help` → `OK available commands (usage: help <command>): ...` |
 | `pause` | Pause emulation | `pause` → `OK` |
 | `run` | Resume emulation | `run` → `OK` |
 | `reset` | Reset CPC | `reset` → `OK` |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,16 +6,28 @@ Amstrad CPC emulator based on Caprice32, with Dear ImGui interface and IPC debug
 
 ```
 src/
-├── kon_cpc_ja.cpp     # Main emulator loop, keyboard handling
-├── z80.cpp            # Z80 CPU emulation with breakpoint support
-├── video.cpp          # Video rendering, scanlines
-├── psg.cpp            # Sound chip (AY-3-8912) emulation
-├── tape.cpp           # CDT/TZX tape playback engine
-├── slotshandler.cpp   # File loading (DSK, CDT, SNA, CPR)
-├── imgui_ui.cpp       # Dear ImGui interface (topbar, devtools, menus)
+├── hw/                # THE hardware: one Device per chip, pin-level
+│   ├── z80.cpp        #   CPU
+│   ├── crtc.cpp       #   CRTC 6845
+│   ├── gate_array.cpp #   Gate Array
+│   ├── psg.cpp        #   AY-3-8912
+│   ├── fdc.cpp        #   uPD765A + flux media
+│   ├── tape.cpp       #   cassette deck
+│   ├── memory.cpp     #   banking, ROM slots, expansion RAM
+│   ├── video.cpp      #   raster output
+│   ├── asic.cpp       #   6128+ ASIC
+│   └── …              #   ppi, mf2, m4, symbiface, amx, rs232, plotter, …
+├── subcycle/
+│   ├── machine.cpp    # the board: builds and clocks the Devices together
+│   └── record_replay.cpp
+├── subcycle_bridge.cpp       # host ↔ board seam (media, ROMs, input, views)
+├── kon_cpc_ja.cpp     # main loop, host state, config load/save, cleanup
+├── slotshandler.cpp   # file loading (DSK, IPF, flux, CDT, SNA, CPR)
+├── imgui_ui.cpp       # Dear ImGui interface (topbar, options, menus)
+├── devtools_ui.cpp    # DevTools windows (disassembly, memory, breakpoints…)
 ├── koncepcja_ipc_server.cpp  # TCP IPC server for external debugging
 ├── telnet_console.cpp # TCP text console — mirrors CPC output, injects keyboard
-└── disk.cpp           # Floppy disk emulation
+└── z80_view.cpp       # host-side Z80 view + the firmware/BDOS output hooks
 ```
 
 ## Emulated Devices
@@ -61,21 +73,28 @@ make -j$(nproc) DEBUG=1
 
 ## Command Line Arguments
 
-Run `./koncepcja --help` for the full list:
+`./koncepcja --help` is the source of truth — this table is a copy and has
+drifted before (it listed 9 of 15 flags, omitting `--headless`):
 
 ```
 Usage: koncepcja [options] <slotfile(s)>
 
 Options:
-  -a/--autocmd=<command>   Execute BASIC command after CPC boots
+  -a/--autocmd=<command>   Execute BASIC command after CPC boots (repeatable)
+  -B/--exit-on-break       Exit with code 1 when a breakpoint is hit
   -c/--cfg_file=<file>     Use custom config file
+  -D/--debug               Frame timing + audio diagnostics in the DevTools bar
+  -E/--exit-after=<spec>   Exit after N frames (100f), seconds (5s) or ms (3000ms)
+  -H/--headless            Run without display or audio (IPC and emulation only)
   -h/--help                Show help
   -i/--inject=<file>       Inject binary into memory after boot
+  -L/--list-plugins        List video plugins (index: name) and exit
   -o/--offset=<address>    Injection address (default: 0x6000)
   -O/--override=<opt=val>  Override config option (repeatable)
   -s/--sym_file=<file>     Load symbols for disassembly
   -V/--version             Show version
   -v/--verbose             Verbose logging
+     --fps                 Log once-per-second FPS to stdout
 
 Slot files: .dsk/.ipf/.raw (disk), .scp/.hfe/.a2r (flux disk, drive A only),
 .cdt/.voc (tape), .cpr (cartridge), .sna (snapshot)
@@ -115,8 +134,22 @@ socat - TCP:localhost:6543
 
 ```bash
 echo "help" | nc localhost 6543
-# Response: OK commands: ping version help pause run reset load regs reg set/get mem bp(list/add/del/clear) step wait screenshot snapshot(save/load) disasm devtools
 ```
+
+The response is categorised and far longer than the table below — ask the
+server rather than trusting any list in this file:
+
+```
+OK available commands (usage: help <command>):
+  Protocol: persistent connections, ';' chains commands, 'disconnect' closes.
+  Numbers: 0x, $, &, # hex prefixes accepted (e.g. $C000, &4000, #BB5A).
+  CORE:      disconnect, gui, load <file>, metrics, pause, ping, plugins, …
+  DEBUG:     bp …, data …, disasm …, mem …, reg …, step …, trace …, wait …
+  …
+```
+
+`help <command>` prints that command's own usage. The full protocol lives in
+[docs/ipc-protocol.md](docs/ipc-protocol.md).
 
 ### IPC Command Reference
 
@@ -148,7 +181,7 @@ echo "help" | nc localhost 6543
 | `snapshot load <path>` | Load state | `snapshot load game.sna` |
 | `load <path>` | Load file (.dsk/.sna/.cpr/.bin) | `load game.dsk` |
 | `devtools` | Open DevTools window | `devtools` → `OK` |
-| `tier` | Run-tier policy (engine=1) | `tier` → `OK policy=auto effective=fast pinned=0` |
+| `tier` | Run-tier policy | `tier` → `OK policy=auto effective=fast pinned=0` |
 | `tier set <p>` | Set policy: auto/fast/wake/soldered/faithful | `tier set wake` → `OK policy=wake` |
 | `input keydown <name>` | Press and hold a key | `input keydown SHIFT` |
 | `input keyup <name>` | Release a key | `input keyup SHIFT` |
@@ -168,8 +201,8 @@ echo "help" | nc localhost 6543
 
 `<name>` is a friendly key name (`RETURN`, `SPACE`, `ESC`, `F1`, `UP`, ...) or a
 single character (`a`, `A`, `1`). For multi-line entry or special keys inside a
-string, use `autotype` with `~KEY~` tokens — `input type` does **not** interpret
-them.
+string, either command works: `input type` is routed through the same
+AutoTypeQueue as `autotype`, so `~KEY~` tokens and newlines behave identically.
 
 ### Scripting Example
 
@@ -282,7 +315,7 @@ nc localhost 6544
 
 - `src/telnet_console.h` — TelnetConsole class, ring buffer, input mutex
 - `src/telnet_console.cpp` — TCP server thread, ANSI parsing, Z80 hook callback
-- Z80 hooks: `z80_set_txt_output_hook()` (firmware) and `z80_set_bdos_output_hook()` (CP/M) in `src/z80.cpp` / `src/z80.h`
+- Z80 hooks: `z80_set_txt_output_hook()` (firmware) and `z80_set_bdos_output_hook()` (CP/M) in `src/z80_view.cpp` / `src/z80_view.h`
 - Main loop integration: `g_telnet.start()` / `drain_input()` / `stop()` in `src/kon_cpc_ja.cpp`
 
 ## M4 HTTP Server
@@ -378,7 +411,7 @@ Malformed CDT/TZX files can crash older versions. Test files are rejected gracef
 
 The emulator uses LOG_DEBUG/LOG_INFO/LOG_ERROR macros. Key files with logging:
 - `slotshandler.cpp` - File loading errors
-- `psg.cpp` - Audio timing info
+- `src/hw/psg.cpp` - Audio timing info
 - `keyboard.cpp` - Key mapping issues
 
 ### DevTools
@@ -443,12 +476,9 @@ Config file locations (in order of precedence):
 ```ini
 [system]
 model=2           # 0=464, 1=664, 2=6128, 3=6128+
-engine=1          # 1=sub-cycle pin-level board (DEFAULT since 2026-07-10 —
-                  # beats legacy 30-49%, byte-exact, Auto tier policy);
-                  # 0=legacy Caprice32 core (kept until Gate C deletes it)
-ram_size=128      # RAM in KB
+ram_size=128      # RAM in KB: 64, 128, 192, 256, 320, 512, 576 … 4160
 speed=4           # Clock speed MHz
-run_tier=0        # Sub-cycle engine (engine=1) tier policy: 0=auto (Fast;
+run_tier=0        # Run-tier policy: 0=auto (Fast;
                   # drops to Wake while any breakpoint/watchpoint/IO-BP is
                   # set — per-cycle observability for the debugger), 1=fast,
                   # 2=wake, 3=soldered, 4=faithful. Shift+F9 cycles
@@ -466,8 +496,10 @@ vsync=1           # 1=VSYNC present (default). 0=MAILBOX/IMMEDIATE on the MAIN
                   # (decoupled from render), so FPS stays 50 either way.
 
 [sound]
-snd_enabled=1
-snd_playback_rate=2  # 0=11025, 1=22050, 2=44100, 3=48000, 4=96000
+enabled=1         # NOTE: the INI keys are enabled/playback_rate/bits/stereo/
+playback_rate=2   # volume — NOT the snd_* names of the C++ struct members.
+                  # 0=11025, 1=22050, 2=44100, 3=48000, 4=96000
+volume=80         # 0-100
 
 [input]
 lightgun=0        # Light gun: 0=off, 1=Amstrad Magnum Phaser, 2=Trojan Light

--- a/koncepcja.cfg.example
+++ b/koncepcja.cfg.example
@@ -1,7 +1,7 @@
 # konCePCja — example configuration.
 #
 # Copy to koncepcja.cfg and edit. Deliberately neutral: 1x window, no
-# fullscreen, empty drives and no personal paths, the Fast run tier, and
+# fullscreen, empty drives and no personal paths, the Auto run tier, and
 # plain GPU-presented scaling that works on any machine. Drive and tape
 # sounds are on — they are part of how a CPC behaves.
 #
@@ -63,6 +63,11 @@ resources_path=
 #   Estimated time in video frames the CPC takes to boot.
 #   Caprice will emulate this number of frames before starting to send a provided autocmd.
 boot_time=42
+# run_tier
+#   0: auto  - Fast while running, Wake while a breakpoint/watchpoint is set
+#   1: fast  - pinned; the register view syncs at frame boundaries, so a
+#              debugger polling PC in an idle loop sees it repeat
+#   2: wake   3: soldered   4: faithful
 run_tier=0
 
 [video]

--- a/koncepcja.cfg.example
+++ b/koncepcja.cfg.example
@@ -1,3 +1,10 @@
+# konCePCja — example configuration.
+#
+# Copy to koncepcja.cfg and edit. Deliberately neutral: 1x window, no
+# fullscreen, empty drives and no personal paths, the Fast run tier, and
+# plain GPU-presented scaling that works on any machine. Drive and tape
+# sounds are on — they are part of how a CPC behaves.
+#
 # vi: syntax=cfg
 #
 # konCePCja configuration file.
@@ -56,6 +63,7 @@ resources_path=
 #   Estimated time in video frames the CPC takes to boot.
 #   Caprice will emulate this number of frames before starting to send a provided autocmd.
 boot_time=42
+run_tier=0
 
 [video]
 # scr_scale
@@ -68,7 +76,7 @@ boot_time=42
 #    6 = 2304x1620
 #    7 = 2688x1890
 #    8 = 3072x2160
-scr_scale=2
+scr_scale=1
 # scr_preserve_aspect_ratio
 #   Whether to preserve the aspect ratio or to stretch to the monitor size when in fullscreen.
 scr_preserve_aspect_ratio=1
@@ -85,7 +93,7 @@ scr_preserve_aspect_ratio=1
 #   9: Software bicubic
 #  10: Dot matrix
 #  11: OpenGL scaling
-scr_style=1
+scr_style=11
 # scr_oglfilter
 #   0: OpenGL filter inactive
 #   1: OpenGL filter active
@@ -166,13 +174,15 @@ volume=80
 #   0: No Digiblaster/soundplayer device attached to the printer port
 #   1: Digiblaster/soundplayer device attached to the printer port
 pp_device=0
+disk_sounds=1
+tape_sounds=1
 
 [control]
 # kbd_layout
 #   Host keyboard layout map
 #   Name of the map file (under the resources directory)
 #   If the file is not used a US keyboard is assumed
-kbd_layout=keymap_us.map
+kbd_layout=
 
 [file]
 max_track_size=5990
@@ -196,7 +206,7 @@ fmt06=
 fmt07=
 # printer_file
 #   Path to output printer stream.
-printer_file=./printer.dat
+printer_file=
 # sdump_dir
 #   Directory where screenshots will be found. Default to $APP_PATH/screenshots
 sdump_dir=

--- a/src/imgui_state.h
+++ b/src/imgui_state.h
@@ -106,6 +106,7 @@ struct ImGuiUIState {
 
   // Eject confirmation
   int eject_confirm_drive = -1;       // -1=none, 0=A, 1=B
+  bool confirm_m4_rebuild = false;    // M4 SD folder picked; rebuild pending
   bool confirm_reset = false;         // Reset asked while a disk was dirty
   bool confirm_clear_recent = false;  // Clear Recent asked, awaiting an answer
   bool eject_confirm_tape = false;

--- a/src/imgui_state.h
+++ b/src/imgui_state.h
@@ -106,6 +106,7 @@ struct ImGuiUIState {
 
   // Eject confirmation
   int eject_confirm_drive = -1;       // -1=none, 0=A, 1=B
+  bool confirm_reset = false;         // Reset asked while a disk was dirty
   bool confirm_clear_recent = false;  // Clear Recent asked, awaiting an answer
   bool eject_confirm_tape = false;
 

--- a/src/imgui_state.h
+++ b/src/imgui_state.h
@@ -105,7 +105,8 @@ struct ImGuiUIState {
   int mem_filter_value = -1;
 
   // Eject confirmation
-  int eject_confirm_drive = -1;  // -1=none, 0=A, 1=B
+  int eject_confirm_drive = -1;       // -1=none, 0=A, 1=B
+  bool confirm_clear_recent = false;  // Clear Recent asked, awaiting an answer
   bool eject_confirm_tape = false;
 
   // Tape block index (built on tape load)

--- a/src/imgui_ui.cpp
+++ b/src/imgui_ui.cpp
@@ -1110,6 +1110,8 @@ extern "C" void koncpc_open_settings_tab(int tab) {
   s_pending_options_tab = static_cast<OptionsTab>(tab);
 }
 
+void imgui_request_reset_confirmation() { imgui_state.confirm_reset = true; }
+
 extern "C" void koncpc_open_command_palette() { g_command_palette.open(); }
 
 extern "C" void koncpc_request_file_dialog(int action) {
@@ -1432,12 +1434,10 @@ void imgui_render_menubar() {
     // Ejecting was only reachable by clicking the status-bar LED — an
     // affordance you had to already know about. Both routes raise the same
     // confirmation, drawn by the status bar.
-    if (ImGui::MenuItem("Eject Disk A", nullptr, false,
-                        drive_medium(0).present)) {
+    if (ImGui::MenuItem("Eject Disk A", nullptr, false, caps_a.present)) {
       imgui_state.eject_confirm_drive = 0;
     }
-    if (ImGui::MenuItem("Eject Disk B", nullptr, false,
-                        drive_medium(1).present)) {
+    if (ImGui::MenuItem("Eject Disk B", nullptr, false, caps_b.present)) {
       imgui_state.eject_confirm_drive = 1;
     }
     ImGui::Separator();
@@ -4164,17 +4164,15 @@ void imgui_render_options() {
       saveConfiguration(CPC, getConfigurationFilename(true));
     }
     if (needs_restart) emulator_init();
-    if (save_to_file) {
-      // Start/stop M4 HTTP server based on M4 enabled state. Only auto-start
-      // when M4 was just enabled (not on every Save), so that a manual "Stop"
-      // in the UI stays effective.
-      if (g_m4board.enabled && !old_m4_enabled &&
-          !g_m4board.sd_root_path.empty() && !g_m4_http.is_running()) {
-        g_m4_http.start(CPC.m4_http_port, CPC.m4_bind_ip);
-      } else if (!g_m4board.enabled && g_m4_http.is_running()) {
-        g_m4_http.stop();
-      }
+    // Auto-START only on Save, and only when M4 was just enabled, so a
+    // manual "Stop" in the UI stays effective.
+    if (save_to_file && g_m4board.enabled && !old_m4_enabled &&
+        !g_m4board.sd_root_path.empty() && !g_m4_http.is_running()) {
+      g_m4_http.start(CPC.m4_http_port, CPC.m4_bind_ip);
     }
+    // STOP regardless of Save/Apply: leaving the server publishing a disabled
+    // board's SD directory is the surprising half of the asymmetry.
+    if (!g_m4board.enabled && g_m4_http.is_running()) g_m4_http.stop();
     update_cpc_speed();
     video_set_palette();
     imgui_state.show_options = false;
@@ -4182,13 +4180,14 @@ void imgui_render_options() {
     first_open = true;
   };
 
-  // 0 = nothing pending, 1 = Save awaiting confirmation, 2 = Apply.
-  static int s_pending_commit = 0;
+  // Which button is waiting on the restart confirmation.
+  enum class PendingCommit : std::uint8_t { None, Save, Apply };
+  static PendingCommit s_pending_commit = PendingCommit::None;
 
   // Bottom buttons
   if (ImGui::Button("Save", ImVec2(80, 0))) {
     if (needs_restart && driveAltered()) {
-      s_pending_commit = 1;  // confirm before throwing the disk edits away
+      s_pending_commit = PendingCommit::Save;  // confirm before losing edits
     } else {
       commit_options(true);
     }
@@ -4220,7 +4219,7 @@ void imgui_render_options() {
   ImGui::SameLine();
   if (ImGui::Button("Apply", ImVec2(80, 0))) {
     if (needs_restart && driveAltered()) {
-      s_pending_commit = 2;
+      s_pending_commit = PendingCommit::Apply;
     } else {
       commit_options(false);
     }
@@ -4232,7 +4231,8 @@ void imgui_render_options() {
 
   // The same guard the quit paths use: a restart is not worth a silent loss of
   // disk edits the user has not written back.
-  if (s_pending_commit != 0 && !ImGui::IsPopupOpen("Restart the CPC?")) {
+  if (s_pending_commit != PendingCommit::None &&
+      !ImGui::IsPopupOpen("Restart the CPC?")) {
     ImGui::OpenPopup("Restart the CPC?");
   }
   if (ImGui::BeginPopupModal("Restart the CPC?", nullptr,
@@ -4242,14 +4242,20 @@ void imgui_render_options() {
         "These settings restart the CPC. The changes will be lost.");
     ImGui::Spacing();
     if (ImGui::Button("Cancel", ImVec2(90, 0))) {
-      s_pending_commit = 0;
+      // Cancelling the RESTART must not silently discard the save: before
+      // this flow, Save always wrote the config. Persisting is harmless;
+      // only the reboot is refused.
+      if (s_pending_commit == PendingCommit::Save) {
+        saveConfiguration(CPC, getConfigurationFilename(true));
+      }
+      s_pending_commit = PendingCommit::None;
       ImGui::CloseCurrentPopup();
     }
     ImGui::SetItemDefaultFocus();  // not restarting is the safe choice
     ImGui::SameLine();
     if (ImGui::Button("Restart anyway", ImVec2(130, 0))) {
-      commit_options(s_pending_commit == 1);
-      s_pending_commit = 0;
+      commit_options(s_pending_commit == PendingCommit::Save);
+      s_pending_commit = PendingCommit::None;
       ImGui::CloseCurrentPopup();
     }
     ImGui::EndPopup();
@@ -4257,11 +4263,16 @@ void imgui_render_options() {
 
   // Escape is Cancel, the same as every other dialog here — but not while the
   // restart confirmation owns the keyboard.
-  if (s_pending_commit == 0 && !ImGui::IsPopupOpen("Restart the CPC?") &&
+  if (s_pending_commit == PendingCommit::None &&
+      !ImGui::IsPopupOpen("Restart the CPC?") &&
       ImGui::IsKeyPressed(ImGuiKey_Escape)) {
     revert_options();
   }
   if (!open) {  // window closed via the X — treat as Cancel
+    // Drop any pending confirmation with it. A stranded value re-opened the
+    // modal unprompted on the next Options open, where "Restart anyway"
+    // would run a saveConfiguration() nobody asked for.
+    s_pending_commit = PendingCommit::None;
     revert_options();
   }
 

--- a/src/imgui_ui.cpp
+++ b/src/imgui_ui.cpp
@@ -374,7 +374,15 @@ void process_pending_dialog() {
       break;
     case FileDialogAction::SelectM4SDFolder:
       g_m4board.sd_root_path = path;
-      if (g_m4board.enabled) emulator_init();
+      // Fitting a new SD folder rebuilds the whole machine. This route had no
+      // guard of any kind: no warning, no unsaved-disk check, and no quiesce.
+      if (g_m4board.enabled) {
+        if (driveAltered()) {
+          imgui_state.confirm_m4_rebuild = true;
+        } else if (koncpc_rebuild_machine() != 0) {
+          imgui_toast_error("Could not restart the CPC for the new SD folder");
+        }
+      }
       break;
     case FileDialogAction::SavePlotterSVG:
       if (plotter_view_export_svg(path))
@@ -2571,6 +2579,30 @@ void imgui_render_statusbar() {
     // open until the next frame, and eject_confirm_drive could be reset
     // by the else branch before BeginPopupModal succeeds.
     static int popup_eject_drive = -1;
+    // Fitting an M4 SD folder restarts the machine, so it asks like the rest.
+    if (imgui_state.confirm_m4_rebuild) {
+      imgui_state.confirm_m4_rebuild = false;
+      ImGui::OpenPopup("Restart for the SD folder?");
+    }
+    if (ImGui::BeginPopupModal("Restart for the SD folder?", nullptr,
+                               ImGuiWindowFlags_AlwaysAutoResize)) {
+      ImGui::TextColored(ImVec4(0.95f, 0.75f, 0.2f, 1.0f),
+                         "You have unsaved changes to a disk.");
+      ImGui::TextUnformatted(
+          "Fitting the new SD folder restarts the CPC and loses them.");
+      ImGui::Spacing();
+      if (ImGui::Button("Cancel", ImVec2(90, 0))) ImGui::CloseCurrentPopup();
+      ImGui::SetItemDefaultFocus();
+      ImGui::SameLine();
+      if (ImGui::Button("Restart", ImVec2(90, 0))) {
+        if (koncpc_rebuild_machine() != 0) {
+          imgui_toast_error("Could not restart the CPC for the new SD folder");
+        }
+        ImGui::CloseCurrentPopup();
+      }
+      ImGui::EndPopup();
+    }
+
     // Reset with unsaved disk edits: the same guard the quit paths use.
     if (imgui_state.confirm_reset) {
       imgui_state.confirm_reset = false;
@@ -3161,10 +3193,12 @@ void imgui_render_options() {
   static bool first_open = true;
   static unsigned char old_crtc_type = 0;
   static bool old_m4_enabled = false;
+  static bool old_serial_enabled = false;
   if (first_open) {
     imgui_state.old_cpc_settings = CPC;
     old_crtc_type = CRTC.crtc_type;
     old_m4_enabled = g_m4board.enabled;
+    old_serial_enabled = g_serial_interface.get_config().enabled;
     first_open = false;
   }
 
@@ -4140,11 +4174,15 @@ void imgui_render_options() {
   // Changing any of these rebuilds the machine: emulator_init() wipes RAM and
   // cold-boots the CPC. Computed once, because Save and Apply have to agree on
   // what forces it — they each carried their own copy of this condition.
+  // Enabling the serial interface belongs here: g_si_rom.load() runs only
+  // inside emulator_init(), so without a rebuild the backend comes up with no
+  // RSX ROM mapped and the banner's claim to list what restarts is false.
   const bool needs_restart =
       CPC.model != imgui_state.old_cpc_settings.model ||
       CPC.ram_size != imgui_state.old_cpc_settings.ram_size ||
       CPC.keyboard != imgui_state.old_cpc_settings.keyboard ||
-      g_m4board.enabled != old_m4_enabled;
+      g_m4board.enabled != old_m4_enabled ||
+      g_serial_interface.get_config().enabled != old_serial_enabled;
   const ImVec4 kWarn(0.95f, 0.75f, 0.2f, 1.0f);
 
   // Say so before it happens, rather than rebooting under the user.
@@ -4163,7 +4201,13 @@ void imgui_render_options() {
     if (save_to_file) {
       saveConfiguration(CPC, getConfigurationFilename(true));
     }
-    if (needs_restart) emulator_init();
+    if (needs_restart && koncpc_rebuild_machine() != 0) {
+      // A half-built machine — a missing ROM, say — must not be reported as
+      // success and must not be resumed. Leave the dialog open on it.
+      imgui_toast_error(
+          "Could not rebuild the CPC with these settings; check the ROM paths");
+      return;
+    }
     // Auto-START only on Save, and only when M4 was just enabled, so a
     // manual "Stop" in the UI stays effective.
     if (save_to_file && g_m4board.enabled && !old_m4_enabled &&

--- a/src/imgui_ui.cpp
+++ b/src/imgui_ui.cpp
@@ -723,12 +723,12 @@ void imgui_render_ui() {
       ImGui::TextUnformatted("Are you sure you want to quit?");
     }
     ImGui::Spacing();
+    bool const cancel = ImGui::Button("Cancel", ImVec2(90, 0));
+    ImGui::SetItemDefaultFocus();  // focus the safe button by default
+    ImGui::SameLine();
     if (ImGui::Button("Quit", ImVec2(90, 0))) {
       cleanExit(0, false);
     }
-    ImGui::SameLine();
-    bool const cancel = ImGui::Button("Cancel", ImVec2(90, 0));
-    ImGui::SetItemDefaultFocus();  // focus the safe button by default
     if (cancel || ImGui::IsKeyPressed(ImGuiKey_Escape)) {
       ImGui::CloseCurrentPopup();
       if (!imgui_state.show_menu && !imgui_state.show_options) {
@@ -1517,11 +1517,18 @@ void imgui_render_menubar() {
         }
       });
       ImGui::Separator();
-      if (ImGui::MenuItem("Clear Recent")) {
-        CPC.mru_disks.clear();
-        CPC.mru_tapes.clear();
-        CPC.mru_snaps.clear();
-        CPC.mru_carts.clear();
+      // Clears FOUR lists, not just the one the submenu is showing, and
+      // cannot be undone — so it asks first and says what it did.
+      const size_t mru_total = CPC.mru_disks.size() + CPC.mru_tapes.size() +
+                               CPC.mru_snaps.size() + CPC.mru_carts.size();
+      if (ImGui::MenuItem("Clear Recent...", nullptr, false, mru_total > 0)) {
+        imgui_state.confirm_clear_recent = true;
+      }
+      if (ImGui::IsItemHovered() && mru_total > 0) {
+        ImGui::SetTooltip(
+            "Forget all %zu recent files (disks, tapes, "
+            "snapshots and cartridges)",
+            mru_total);
       }
       ImGui::EndMenu();
     }
@@ -2545,6 +2552,34 @@ void imgui_render_statusbar() {
     // open until the next frame, and eject_confirm_drive could be reset
     // by the else branch before BeginPopupModal succeeds.
     static int popup_eject_drive = -1;
+    // Clear Recent: destructive, spans four lists, and has no undo.
+    if (imgui_state.confirm_clear_recent) {
+      imgui_state.confirm_clear_recent = false;
+      ImGui::OpenPopup("Clear Recent Files?");
+    }
+    if (ImGui::BeginPopupModal("Clear Recent Files?", nullptr,
+                               ImGuiWindowFlags_AlwaysAutoResize)) {
+      ImGui::TextUnformatted(
+          "Forget every recent disk, tape, snapshot and cartridge?");
+      ImGui::TextDisabled("This only clears the lists — no files are deleted.");
+      ImGui::Spacing();
+      if (ImGui::Button("Cancel", ImVec2(90, 0))) ImGui::CloseCurrentPopup();
+      ImGui::SetItemDefaultFocus();  // the safe choice is the default
+      ImGui::SameLine();
+      if (ImGui::Button("Clear", ImVec2(90, 0))) {
+        const size_t cleared = CPC.mru_disks.size() + CPC.mru_tapes.size() +
+                               CPC.mru_snaps.size() + CPC.mru_carts.size();
+        CPC.mru_disks.clear();
+        CPC.mru_tapes.clear();
+        CPC.mru_snaps.clear();
+        CPC.mru_carts.clear();
+        imgui_toast_success("Cleared " + std::to_string(cleared) +
+                            " recent files");
+        ImGui::CloseCurrentPopup();
+      }
+      ImGui::EndPopup();
+    }
+
     if (imgui_state.eject_confirm_drive >= 0) {
       popup_eject_drive = imgui_state.eject_confirm_drive;
       imgui_state.eject_confirm_drive = -1;
@@ -2555,17 +2590,18 @@ void imgui_render_statusbar() {
       const char* name = popup_eject_drive == 0 ? "A" : "B";
       ImGui::Text("Eject disk from drive %s?", name);
       ImGui::Spacing();
+      if (ImGui::Button("Cancel", ImVec2(80, 0))) {
+        popup_eject_drive = -1;
+        ImGui::CloseCurrentPopup();
+      }
+      ImGui::SetItemDefaultFocus();  // keeping the disk is the safe choice
+      ImGui::SameLine();
       if (ImGui::Button("Eject", ImVec2(80, 0))) {
         t_drive& drive = popup_eject_drive == 0 ? driveA : driveB;
         auto& driveFile =
             popup_eject_drive == 0 ? CPC.driveA.file : CPC.driveB.file;
         dsk_eject(&drive);
         driveFile.clear();
-        popup_eject_drive = -1;
-        ImGui::CloseCurrentPopup();
-      }
-      ImGui::SameLine();
-      if (ImGui::Button("Cancel", ImVec2(80, 0))) {
         popup_eject_drive = -1;
         ImGui::CloseCurrentPopup();
       }
@@ -2580,16 +2616,17 @@ void imgui_render_statusbar() {
                                ImGuiWindowFlags_AlwaysAutoResize)) {
       ImGui::TextUnformatted("Eject tape?");
       ImGui::Spacing();
+      if (ImGui::Button("Cancel", ImVec2(80, 0))) {
+        imgui_state.eject_confirm_tape = false;
+        ImGui::CloseCurrentPopup();
+      }
+      ImGui::SetItemDefaultFocus();  // keeping the tape is the safe choice
+      ImGui::SameLine();
       if (ImGui::Button("Eject", ImVec2(80, 0))) {
         tape_eject();
         CPC.tape.file.clear();
         imgui_state.tape_block_offsets.clear();
         imgui_state.tape_current_block = 0;
-        imgui_state.eject_confirm_tape = false;
-        ImGui::CloseCurrentPopup();
-      }
-      ImGui::SameLine();
-      if (ImGui::Button("Cancel", ImVec2(80, 0))) {
         imgui_state.eject_confirm_tape = false;
         ImGui::CloseCurrentPopup();
       }
@@ -4116,11 +4153,15 @@ void imgui_render_options() {
       commit_options(true);
     }
   }
+  ImGui::SetItemDefaultFocus();  // Save is the default action (Enter)
   if (ImGui::IsItemHovered()) {
     ImGui::SetTooltip("Apply changes and save to config file");
   }
   ImGui::SameLine();
-  if (ImGui::Button("Cancel", ImVec2(80, 0))) {
+  // Discard the edits and put back what was live when the dialog opened. Three
+  // routes need this — the button, Escape, and the window's X — and each used
+  // to carry its own copy.
+  auto revert_options = [&]() {
     unsigned int const prev_style = CPC.scr_style;
     CPC = imgui_state.old_cpc_settings;
     CRTC.crtc_type = old_crtc_type;
@@ -4132,6 +4173,9 @@ void imgui_render_options() {
     imgui_state.show_options = false;
     cpc_resume();
     first_open = true;
+  };
+  if (ImGui::Button("Cancel", ImVec2(80, 0))) {
+    revert_options();
   }
   ImGui::SameLine();
   if (ImGui::Button("Apply", ImVec2(80, 0))) {
@@ -4157,31 +4201,28 @@ void imgui_render_options() {
     ImGui::TextUnformatted(
         "These settings restart the CPC. The changes will be lost.");
     ImGui::Spacing();
-    if (ImGui::Button("Restart anyway", ImVec2(130, 0))) {
-      commit_options(s_pending_commit == 1);
+    if (ImGui::Button("Cancel", ImVec2(90, 0))) {
       s_pending_commit = 0;
       ImGui::CloseCurrentPopup();
     }
+    ImGui::SetItemDefaultFocus();  // not restarting is the safe choice
     ImGui::SameLine();
-    if (ImGui::Button("Cancel", ImVec2(90, 0))) {
+    if (ImGui::Button("Restart anyway", ImVec2(130, 0))) {
+      commit_options(s_pending_commit == 1);
       s_pending_commit = 0;
       ImGui::CloseCurrentPopup();
     }
     ImGui::EndPopup();
   }
 
-  if (!open) {
-    // Window closed via X button — treat as Cancel
-    unsigned int const prev_style = CPC.scr_style;
-    CPC = imgui_state.old_cpc_settings;
-    CRTC.crtc_type = old_crtc_type;
-    if (subcycle::Machine* m = subcycle_bridge_machine())
-      m->set_crtc_type(static_cast<uint8_t>(old_crtc_type));
-    g_m4board.enabled = old_m4_enabled;
-    if (CPC.scr_style != prev_style) imgui_state.video_reinit_pending = true;
-    imgui_state.show_options = false;
-    cpc_resume();
-    first_open = true;
+  // Escape is Cancel, the same as every other dialog here — but not while the
+  // restart confirmation owns the keyboard.
+  if (s_pending_commit == 0 && !ImGui::IsPopupOpen("Restart the CPC?") &&
+      ImGui::IsKeyPressed(ImGuiKey_Escape)) {
+    revert_options();
+  }
+  if (!open) {  // window closed via the X — treat as Cancel
+    revert_options();
   }
 
   ImGui::End();

--- a/src/imgui_ui.cpp
+++ b/src/imgui_ui.cpp
@@ -1592,6 +1592,14 @@ void imgui_render_menubar() {
     ImGui::Separator();
     if (ImGui::BeginMenu("Diagnostics")) {
       RenderMenuItem(KONCPC_DEBUG);
+      if (ImGui::IsItemHovered()) {
+        // LOG_VERBOSE writes to stdout (log.h); errors and warnings go to
+        // stderr regardless of this toggle. Say where the output lands —
+        // "verbose logging" alone tells the user nothing about where to look.
+        ImGui::SetTooltip(
+            "Print detailed diagnostics to the terminal that started the "
+            "emulator.\nErrors and warnings are always printed.");
+      }
       ImGui::EndMenu();
     }
     ImGui::EndMenu();
@@ -4052,31 +4060,61 @@ void imgui_render_options() {
   ImGui::Separator();
   ImGui::Spacing();
 
-  // Bottom buttons
-  if (ImGui::Button("Save", ImVec2(80, 0))) {
-    std::string const cfg = getConfigurationFilename(true);
-    saveConfiguration(CPC, cfg);
-    // Apply changes that need re-init
-    if (CPC.model != imgui_state.old_cpc_settings.model ||
-        CPC.ram_size != imgui_state.old_cpc_settings.ram_size ||
-        CPC.keyboard != imgui_state.old_cpc_settings.keyboard ||
-        g_m4board.enabled != old_m4_enabled) {
-      emulator_init();
+  // Changing any of these rebuilds the machine: emulator_init() wipes RAM and
+  // cold-boots the CPC. Computed once, because Save and Apply have to agree on
+  // what forces it — they each carried their own copy of this condition.
+  const bool needs_restart =
+      CPC.model != imgui_state.old_cpc_settings.model ||
+      CPC.ram_size != imgui_state.old_cpc_settings.ram_size ||
+      CPC.keyboard != imgui_state.old_cpc_settings.keyboard ||
+      g_m4board.enabled != old_m4_enabled;
+  const ImVec4 kWarn(0.95f, 0.75f, 0.2f, 1.0f);
+
+  // Say so before it happens, rather than rebooting under the user.
+  if (needs_restart) {
+    ImGui::TextColored(kWarn,
+                       "These settings restart the CPC — RAM is cleared.");
+    if (driveAltered()) {
+      ImGui::TextColored(kWarn,
+                         "A disk has unsaved changes that would be lost.");
     }
-    // Start/stop M4 HTTP server based on M4 enabled state
-    // Only auto-start when M4 was just enabled (not on every Save),
-    // so that a manual "Stop" in the UI stays effective.
-    if (g_m4board.enabled && !old_m4_enabled &&
-        !g_m4board.sd_root_path.empty() && !g_m4_http.is_running()) {
-      g_m4_http.start(CPC.m4_http_port, CPC.m4_bind_ip);
-    } else if (!g_m4board.enabled && g_m4_http.is_running()) {
-      g_m4_http.stop();
+    ImGui::Spacing();
+  }
+
+  // One commit path for both buttons; `save_to_file` is the only difference.
+  auto commit_options = [&](bool save_to_file) {
+    if (save_to_file) {
+      saveConfiguration(CPC, getConfigurationFilename(true));
+    }
+    if (needs_restart) emulator_init();
+    if (save_to_file) {
+      // Start/stop M4 HTTP server based on M4 enabled state. Only auto-start
+      // when M4 was just enabled (not on every Save), so that a manual "Stop"
+      // in the UI stays effective.
+      if (g_m4board.enabled && !old_m4_enabled &&
+          !g_m4board.sd_root_path.empty() && !g_m4_http.is_running()) {
+        g_m4_http.start(CPC.m4_http_port, CPC.m4_bind_ip);
+      } else if (!g_m4board.enabled && g_m4_http.is_running()) {
+        g_m4_http.stop();
+      }
     }
     update_cpc_speed();
     video_set_palette();
     imgui_state.show_options = false;
     cpc_resume();
     first_open = true;
+  };
+
+  // 0 = nothing pending, 1 = Save awaiting confirmation, 2 = Apply.
+  static int s_pending_commit = 0;
+
+  // Bottom buttons
+  if (ImGui::Button("Save", ImVec2(80, 0))) {
+    if (needs_restart && driveAltered()) {
+      s_pending_commit = 1;  // confirm before throwing the disk edits away
+    } else {
+      commit_options(true);
+    }
   }
   if (ImGui::IsItemHovered()) {
     ImGui::SetTooltip("Apply changes and save to config file");
@@ -4097,21 +4135,39 @@ void imgui_render_options() {
   }
   ImGui::SameLine();
   if (ImGui::Button("Apply", ImVec2(80, 0))) {
-    if (CPC.model != imgui_state.old_cpc_settings.model ||
-        CPC.ram_size != imgui_state.old_cpc_settings.ram_size ||
-        CPC.keyboard != imgui_state.old_cpc_settings.keyboard ||
-        g_m4board.enabled != old_m4_enabled) {
-      emulator_init();
+    if (needs_restart && driveAltered()) {
+      s_pending_commit = 2;
+    } else {
+      commit_options(false);
     }
-    update_cpc_speed();
-    video_set_palette();
-    imgui_state.show_options = false;
-    cpc_resume();
-    first_open = true;
   }
   if (ImGui::IsItemHovered()) {
     ImGui::SetTooltip(
         "Apply changes for this session only\n(not saved to config file)");
+  }
+
+  // The same guard the quit paths use: a restart is not worth a silent loss of
+  // disk edits the user has not written back.
+  if (s_pending_commit != 0 && !ImGui::IsPopupOpen("Restart the CPC?")) {
+    ImGui::OpenPopup("Restart the CPC?");
+  }
+  if (ImGui::BeginPopupModal("Restart the CPC?", nullptr,
+                             ImGuiWindowFlags_AlwaysAutoResize)) {
+    ImGui::TextColored(kWarn, "You have unsaved changes to a disk.");
+    ImGui::TextUnformatted(
+        "These settings restart the CPC. The changes will be lost.");
+    ImGui::Spacing();
+    if (ImGui::Button("Restart anyway", ImVec2(130, 0))) {
+      commit_options(s_pending_commit == 1);
+      s_pending_commit = 0;
+      ImGui::CloseCurrentPopup();
+    }
+    ImGui::SameLine();
+    if (ImGui::Button("Cancel", ImVec2(90, 0))) {
+      s_pending_commit = 0;
+      ImGui::CloseCurrentPopup();
+    }
+    ImGui::EndPopup();
   }
 
   if (!open) {

--- a/src/imgui_ui.cpp
+++ b/src/imgui_ui.cpp
@@ -950,7 +950,11 @@ bool koncpc_action_is_active(KONCPC_KEYS action) {
 // emulator-command menu item should go through here so labels/shortcuts can
 // never drift.
 namespace {
-bool RenderMenuItem(KONCPC_KEYS action, bool enabled = true) {
+// `defer` returns the click without dispatching, so a caller can interpose a
+// confirmation while label, shortcut and placement still come from the
+// registry. Everything else keeps the fire-and-forget behaviour.
+bool RenderMenuItem(KONCPC_KEYS action, bool enabled = true,
+                    bool defer = false) {
   const MenuAction* meta = koncpc_find_action(action);
   if (meta == nullptr) return false;
   std::string const sc = koncpc_action_shortcut(action);
@@ -958,7 +962,7 @@ bool RenderMenuItem(KONCPC_KEYS action, bool enabled = true) {
   bool const clicked =
       ImGui::MenuItem(meta->title, shortcut,
                       meta->toggle && koncpc_action_is_active(action), enabled);
-  if (clicked) koncpc_menu_action(action);
+  if (clicked && !defer) koncpc_menu_action(action);
   return clicked;
 }
 }  // namespace
@@ -1336,7 +1340,13 @@ void imgui_render_menubar() {
                           pinned ? " (pinned by env)" : "");
       ImGui::EndMenu();
     }
-    RenderMenuItem(KONCPC_RESET);
+    if (RenderMenuItem(KONCPC_RESET, true, /*defer=*/true)) {
+      if (driveAltered()) {
+        imgui_state.confirm_reset = true;
+      } else {
+        koncpc_menu_action(KONCPC_RESET);
+      }
+    }
     ImGui::EndMenu();
   }
 
@@ -1419,16 +1429,25 @@ void imgui_render_menubar() {
     if (ImGui::MenuItem("Save Disk B...", nullptr, false, b_dsk)) {
       koncpc_request_file_dialog(static_cast<int>(FileDialogAction::SaveDiskB));
     }
+    // Ejecting was only reachable by clicking the status-bar LED — an
+    // affordance you had to already know about. Both routes raise the same
+    // confirmation, drawn by the status bar.
+    if (ImGui::MenuItem("Eject Disk A", nullptr, false,
+                        drive_medium(0).present)) {
+      imgui_state.eject_confirm_drive = 0;
+    }
+    if (ImGui::MenuItem("Eject Disk B", nullptr, false,
+                        drive_medium(1).present)) {
+      imgui_state.eject_confirm_drive = 1;
+    }
     ImGui::Separator();
     if (ImGui::MenuItem("Load Tape...")) {
       koncpc_request_file_dialog(static_cast<int>(FileDialogAction::LoadTape));
     }
     RenderMenuItem(KONCPC_TAPEPLAY, !pbTapeImage.empty());
+    // Was ejecting immediately here while the status-bar route asked first.
     if (ImGui::MenuItem("Eject Tape", nullptr, false, !pbTapeImage.empty())) {
-      tape_eject();
-      CPC.tape.file.clear();
-      imgui_state.tape_block_offsets.clear();
-      imgui_state.tape_current_block = 0;
+      imgui_state.eject_confirm_tape = true;
     }
     ImGui::Separator();
     if (ImGui::MenuItem("Load Cartridge...")) {
@@ -2552,6 +2571,27 @@ void imgui_render_statusbar() {
     // open until the next frame, and eject_confirm_drive could be reset
     // by the else branch before BeginPopupModal succeeds.
     static int popup_eject_drive = -1;
+    // Reset with unsaved disk edits: the same guard the quit paths use.
+    if (imgui_state.confirm_reset) {
+      imgui_state.confirm_reset = false;
+      ImGui::OpenPopup("Reset the CPC?");
+    }
+    if (ImGui::BeginPopupModal("Reset the CPC?", nullptr,
+                               ImGuiWindowFlags_AlwaysAutoResize)) {
+      ImGui::TextColored(ImVec4(0.95f, 0.75f, 0.2f, 1.0f),
+                         "You have unsaved changes to a disk.");
+      ImGui::TextUnformatted("Resetting will lose them.");
+      ImGui::Spacing();
+      if (ImGui::Button("Cancel", ImVec2(90, 0))) ImGui::CloseCurrentPopup();
+      ImGui::SetItemDefaultFocus();
+      ImGui::SameLine();
+      if (ImGui::Button("Reset", ImVec2(90, 0))) {
+        koncpc_menu_action(KONCPC_RESET);
+        ImGui::CloseCurrentPopup();
+      }
+      ImGui::EndPopup();
+    }
+
     // Clear Recent: destructive, spans four lists, and has no undo.
     if (imgui_state.confirm_clear_recent) {
       imgui_state.confirm_clear_recent = false;

--- a/src/imgui_ui.h
+++ b/src/imgui_ui.h
@@ -50,3 +50,8 @@ void serial_terminal_feed_byte(uint8_t byte);
 
 // Plotter Preview window
 void imgui_render_plotter_preview();
+
+// Raise the "reset would lose unsaved disk edits" confirmation. Lets the
+// keyboard shortcut reach the same guard as the menu item without the SDL
+// layer reaching into ImGui state.
+void imgui_request_reset_confirmation();

--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -2739,17 +2739,24 @@ void koncpc_menu_action(int action) {
       break;
 
     case KONCPC_NEXTDISKA: {
-      // Walking off the end used to fail silently: the index still advanced,
-      // the load failed, and nothing on screen changed or said why.
-      const unsigned int previous_index = CPC.driveA.zip_index;
+      // Only an archive has a next disk. On a plain image this used to reload
+      // the same file and call it an archive.
+      const std::string ext = stringutils::lower(
+          std::filesystem::path(CPC.driveA.file).extension().string());
+      if (ext != ".zip") {
+        set_osd_message("Drive A holds no archive");
+        break;
+      }
+      // file_load wraps zip_index modulo the entry count (slotshandler.cpp),
+      // so advancing past the last disk returns to the first — there is no
+      // "past the end" to report. Read the index back afterwards: it is the
+      // disk actually loaded, which is not necessarily the one asked for.
       CPC.driveA.zip_index += 1;
       if (file_load(CPC.driveA) == 0) {
         set_osd_message("Archive disk " +
                         std::to_string(CPC.driveA.zip_index + 1));
       } else {
-        CPC.driveA.zip_index = previous_index;  // stay on the disk that works
-        file_load(CPC.driveA);
-        set_osd_message("No more disks in this archive");
+        set_osd_message("Could not load the next disk in the archive");
       }
       break;
     }
@@ -4238,7 +4245,15 @@ int koncpc_main(int argc, char** argv) {
                 koncpc_menu_action(KONCPC_MF2STOP);
                 break;
               case KONCPC_RESET:
-                koncpc_menu_action(KONCPC_RESET);
+                // The menu asks before a reset that would lose disk edits;
+                // F5 is how people actually reset, so it must ask too.
+                // Headless and IPC keep the unconditional path — there is no
+                // one to answer a modal.
+                if (!g_headless && driveAltered()) {
+                  imgui_request_reset_confirmation();
+                } else {
+                  koncpc_menu_action(KONCPC_RESET);
+                }
                 break;
               case KONCPC_JOY:
                 koncpc_menu_action(KONCPC_JOY);

--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -4254,7 +4254,7 @@ int koncpc_main(int argc, char** argv) {
                 break;
               case KONCPC_DEBUG:
                 log_verbose = !log_verbose;
-                set_osd_message(std::string("Debug mode: ") +
+                set_osd_message(std::string("Verbose log to console: ") +
                                 (log_verbose ? "on" : "off"));
                 break;
               case KONCPC_DELAY:

--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -2738,10 +2738,21 @@ void koncpc_menu_action(int action) {
                       (log_verbose ? "on" : "off"));
       break;
 
-    case KONCPC_NEXTDISKA:
+    case KONCPC_NEXTDISKA: {
+      // Walking off the end used to fail silently: the index still advanced,
+      // the load failed, and nothing on screen changed or said why.
+      const unsigned int previous_index = CPC.driveA.zip_index;
       CPC.driveA.zip_index += 1;
-      file_load(CPC.driveA);
+      if (file_load(CPC.driveA) == 0) {
+        set_osd_message("Archive disk " +
+                        std::to_string(CPC.driveA.zip_index + 1));
+      } else {
+        CPC.driveA.zip_index = previous_index;  // stay on the disk that works
+        file_load(CPC.driveA);
+        set_osd_message("No more disks in this archive");
+      }
       break;
+    }
   }
 }
 

--- a/src/kon_cpc_ja.cpp
+++ b/src/kon_cpc_ja.cpp
@@ -1012,6 +1012,47 @@ void load_mf2_rom() {
 
 }  // namespace
 
+// True once a machine exists, so the first init does not try to free one.
+static bool s_machine_built = false;
+// pbRegisterPage starts life pointing at a STATIC buffer (hw_views.cpp), which
+// must never be deleted. Only a page this function allocated may be freed.
+static bool s_register_page_owned = false;
+
+// Release what the previous machine owned. emulator_init() used to allocate
+// straight over the top, leaking the RAM, ROM and scratch buffers and orphaning
+// every expansion-ROM image on each rebuild.
+//
+// Order matters: the board keeps RAW pointers to the expansion ROMs
+// (mem_attach_rom stores, it does not copy), so each slot is detached from the
+// board before its image is freed. The caller has already quiesced the Z80
+// thread; this only keeps the board from holding a released pointer afterwards.
+static void release_previous_machine() {
+  if (!s_machine_built) return;
+
+  for (int slot = 0; slot < MAX_ROM_SLOTS; slot++) {
+    if (memmap_ROM[slot] == nullptr) continue;
+    subcycle_bridge_attach_rom_slot(slot, nullptr);
+    delete[] memmap_ROM[slot];
+    memmap_ROM[slot] = nullptr;
+  }
+  delete[] pbGPBuffer;
+  pbGPBuffer = nullptr;
+  delete[] pbRAMbuffer;
+  pbRAMbuffer = nullptr;
+  pbRAM = nullptr;
+  delete[] pbROM;
+  pbROM = nullptr;
+  pbROMlo = pbROMhi = pbExpansionROM = nullptr;
+  if (s_register_page_owned) {
+    delete[] pbRegisterPage;
+    pbRegisterPage = nullptr;
+    s_register_page_owned = false;
+  }
+  // pbMF2ROM/pbMF2ROMbackup are deliberately kept: load_mf2_rom() treats an
+  // already-resident image as done, and re-reading it every rebuild would be
+  // churn for no gain.
+}
+
 int emulator_init() {
   if (input_init()) {
     fprintf(stderr, "input_init() failed. Aborting.\n");
@@ -1022,12 +1063,15 @@ int emulator_init() {
   cartridge_load();
 
   // Host-side memory: all value-initialized (zeroed).
+  release_previous_machine();
+
   pbGPBuffer = new byte[128 * 1024]();  // general-purpose scratch buffer
   // One guard byte sits before pbRAM: prerender_normal*_plus may read it.
   pbRAMbuffer = new byte[(CPC.ram_size * 1024) + 1]();
   pbRAM = pbRAMbuffer + 1;
   pbROM = new byte[32 * 1024]();  // system ROM: OS + BASIC
   pbRegisterPage = new byte[16 * 1024]();
+  s_register_page_owned = true;
   pbROMlo = pbROM;
   pbROMhi = pbExpansionROM = pbROM + 16384;
   std::fill(std::begin(memmap_ROM), std::end(memmap_ROM), nullptr);
@@ -1065,6 +1109,11 @@ int emulator_init() {
 
   emulator_reset();
   CPC.paused = false;
+  // The cartridge was reloaded above, which freed the image the board was
+  // attached to. Point it at the new one — the board holds it raw, and nothing
+  // else re-attaches it outside subcycle_bridge_start().
+  subcycle_bridge_attach_cartridge();
+  s_machine_built = true;
 
   return 0;
 }
@@ -1087,6 +1136,29 @@ void emulator_shutdown() {
   delete[] pbGPBuffer;
 }
 }  // namespace
+
+int koncpc_rebuild_machine() {
+  // Quiesce first. cpc_pause() only raises a flag; the Z80 thread may still be
+  // inside a frame until it observes it, and emulator_init() frees memory that
+  // frame is reading (the cartridge image, the expansion ROMs) and wipes the
+  // I/O dispatch table underneath it.
+  const bool was_paused = CPC.paused;
+  cpc_pause_and_wait();
+
+  const int err = emulator_init();
+
+  // emulator_init() ends with CPC.paused = false without touching g_emu_paused,
+  // so the two flags that are meant to agree no longer do. Restore the run
+  // state through the functions that set both, rather than trusting what it
+  // left behind. A machine that failed to build stays stopped: it never reached
+  // emulator_reset() and must not be run.
+  if (err != 0 || was_paused) {
+    cpc_pause();
+  } else {
+    cpc_resume();
+  }
+  return err;
+}
 
 void bin_load(const std::string& filename, const size_t offset) {
   LOG_INFO("Load " << filename << " in memory at offset 0x" << std::hex

--- a/src/koncepcja.h
+++ b/src/koncepcja.h
@@ -573,6 +573,19 @@ void bin_load(const std::string& filename, const size_t offset);
 bool dumpScreenTo(const std::string& path);
 void dumpScreen();
 int emulator_init();
+
+// Rebuild the emulated machine safely, and report whether it worked.
+//
+// emulator_init() frees and re-attaches memory the board holds raw pointers to
+// — the cartridge image and the expansion-ROM images — and wipes the I/O
+// dispatch table. Doing that while the Z80 thread is inside a frame is a
+// use-after-free. cpc_pause() alone only raises a flag; the thread can still be
+// mid-frame until it observes it, so the WAIT is the part that matters. This is
+// the same contract emulator_reset() and koncpc_toggle_fullscreen() follow.
+//
+// Restores whatever run state the caller was in. Returns emulator_init()'s
+// code; non-zero means the machine is NOT usable and is left paused.
+int koncpc_rebuild_machine();
 int video_set_palette();
 void video_update_palette_entry(int index, uint8_t r, uint8_t g, uint8_t b);
 void init_joystick_emulation();

--- a/src/menu_actions.cpp
+++ b/src/menu_actions.cpp
@@ -27,7 +27,7 @@ const std::vector<MenuAction>& koncpc_menu_actions() {
       {KONCPC_PHAZER, "Light Gun (Magnum Phaser)", "", true, MenuGroup::Input},
       {KONCPC_FPS, "Show FPS", "", true, MenuGroup::View},
       {KONCPC_SPEED, "Limit Speed", "", true, MenuGroup::Input},
-      {KONCPC_DEBUG, "Verbose Logging", "", true, MenuGroup::Tools},
+      {KONCPC_DEBUG, "Verbose Log to Console", "", true, MenuGroup::Tools},
       {KONCPC_EXIT, "Quit", "", false, MenuGroup::App},
       {KONCPC_PASTE, "Paste", "", false, MenuGroup::Edit},
       // Scripting-only autocmd primitives — not user-facing menu items (F9).

--- a/src/subcycle_bridge.cpp
+++ b/src/subcycle_bridge.cpp
@@ -1165,6 +1165,12 @@ void subcycle_bridge_mf2_stop() {
   g_bridge.mf2_stop.store(true, std::memory_order_release);
 }
 
+void subcycle_bridge_attach_cartridge() {
+  if (!g_bridge.active || pbCartridgeImage == nullptr) return;
+  g_bridge.machine.attach_cartridge(pbCartridgeImage.get(),
+                                    static_cast<size_t>(32) * 0x4000);
+}
+
 void subcycle_bridge_attach_rom_slot(int slot, const uint8_t* rom16k) {
   if (!g_bridge.active) return;  // start() attaches every slot on the way up
   if (slot < 0 || slot >= MAX_ROM_SLOTS) return;

--- a/src/subcycle_bridge.h
+++ b/src/subcycle_bridge.h
@@ -67,6 +67,12 @@ void subcycle_bridge_eject_media(uint8_t unit = 0);
  * leaves the CPC unable to see the ROM. */
 void subcycle_bridge_attach_rom_slot(int slot, const uint8_t* rom16k);
 
+/* Re-attach the current cartridge image to the board. emulator_init() reloads
+ * the cartridge on a Plus, which frees the old image — the board holds that
+ * pointer raw (attach_cartridge does not copy), so it must be told about the
+ * new one or it keeps reading released memory. */
+void subcycle_bridge_attach_cartridge();
+
 /* The Multiface II STOP button (deferred to the frame boundary). */
 void subcycle_bridge_mf2_stop();
 

--- a/test/integrated/ipc_harness.py
+++ b/test/integrated/ipc_harness.py
@@ -299,14 +299,22 @@ class EmulatorRunner:
         # maintainer's live config, which makes runs depend on whoever is
         # sitting at the machine. A throwaway copy of the shipped example also
         # keeps a mid-run save from editing the example itself.
-        if not any(a.startswith('-c') or a.startswith('--cfg_file') for a in args):
+        if not any(a == '-c' or a.startswith('-c') or a == '--cfg_file'
+                   or a.startswith('--cfg_file=') for a in args):
             example = Path(self.exe_path).parent / 'koncepcja.cfg.example'
-            if example.exists():
-                self._cfg_tmp = tempfile.NamedTemporaryFile(
-                    mode='w', suffix='.cfg', delete=False)
-                self._cfg_tmp.write(example.read_text())
-                self._cfg_tmp.close()
-                cmd += ['-c', self._cfg_tmp.name]
+            if not example.exists():
+                # Silently carrying on would hand the emulator whoever's
+                # koncepcja.cfg happens to sit in the working directory —
+                # exactly the nondeterminism this pinning removes. A missing
+                # example is a broken checkout, not a condition to absorb.
+                raise FileNotFoundError(
+                    f"{example} is missing; integration runs must not fall "
+                    f"back to an arbitrary koncepcja.cfg")
+            self._cfg_tmp = tempfile.NamedTemporaryFile(
+                mode='w', suffix='.cfg', delete=False)
+            self._cfg_tmp.write(example.read_text())
+            self._cfg_tmp.close()
+            cmd += ['-c', self._cfg_tmp.name]
         eng = engine if engine is not None else EmulatorRunner.test_engine
         if eng is not None:
             cmd += ['-O', f'system.engine={eng}']

--- a/test/integrated/ipc_harness.py
+++ b/test/integrated/ipc_harness.py
@@ -9,6 +9,7 @@ import queue
 import re
 import socket
 import subprocess
+import tempfile
 import threading
 import time
 import sys
@@ -195,6 +196,7 @@ class EmulatorRunner:
         # Every stderr line, kept because _await_ipc_port consumes the queue:
         # a later probe (the telnet port) would otherwise find its line gone.
         self._stderr_lines: List[str] = []
+        self._cfg_tmp = None  # throwaway config copy, removed on stop()
 
     def _pump_stderr(self) -> None:
         """Drain child stderr into _stderr_q for the process's whole life.
@@ -292,6 +294,19 @@ class EmulatorRunner:
             env['SDL_AUDIODRIVER'] = 'dummy'
 
         cmd = [self.exe_path] + list(args)
+        # Pin the config unless the caller chose one. Started from the repo
+        # root the emulator would otherwise pick up $CWD/koncepcja.cfg — the
+        # maintainer's live config, which makes runs depend on whoever is
+        # sitting at the machine. A throwaway copy of the shipped example also
+        # keeps a mid-run save from editing the example itself.
+        if not any(a.startswith('-c') or a.startswith('--cfg_file') for a in args):
+            example = Path(self.exe_path).parent / 'koncepcja.cfg.example'
+            if example.exists():
+                self._cfg_tmp = tempfile.NamedTemporaryFile(
+                    mode='w', suffix='.cfg', delete=False)
+                self._cfg_tmp.write(example.read_text())
+                self._cfg_tmp.close()
+                cmd += ['-c', self._cfg_tmp.name]
         eng = engine if engine is not None else EmulatorRunner.test_engine
         if eng is not None:
             cmd += ['-O', f'system.engine={eng}']
@@ -352,6 +367,12 @@ class EmulatorRunner:
             except subprocess.TimeoutExpired:
                 self.process.kill()
             self.process = None
+        if self._cfg_tmp is not None:
+            try:
+                os.unlink(self._cfg_tmp.name)
+            except OSError:
+                pass
+            self._cfg_tmp = None
 
     def __enter__(self):
         return self


### PR DESCRIPTION
Stacked on #31 (shares `imgui_ui.cpp`; merge that first). Six F-cluster beads, all verified still broken before being touched.

## F15 — Options ignored the keyboard

No Escape, no default button. Escape now cancels (except while the restart confirmation owns the keyboard) and Save is the default action.

The revert logic existed in **three copies** — the Cancel button, the window's X, and now Escape. It is one lambda they all call.

## F17 — every confirmation had the destructive button first

Quit, Eject Disk, Eject Tape and the restart confirmation all read *destructive → Cancel*, and most focused nothing. They now read **Cancel → destructive, with the safe choice focused**.

That includes the restart dialog I added in #31, which had inherited the same shape from its neighbours — which is exactly how a convention like this spreads.

## F25 — walking off the end of an archive did nothing, silently

```cpp
CPC.driveA.zip_index += 1;
file_load(CPC.driveA);        // result ignored
```

Past the last disk: index advanced, load failed, nothing changed on screen and nothing said why. It now reports which disk it moved to, and on failure **restores the working disk** and says the archive has no more.

## F32 — Clear Recent wiped four lists from a submenu showing one

No confirm, no undo, no feedback. It now asks, names the total it will forget, is disabled when there is nothing to clear, and reports how many it cleared.

## F26 — ejecting was a secret, and Reset was unguarded

Ejecting a disk was reachable **only** by clicking the status-bar LED. Media now carries Eject Disk A / Eject Disk B, enabled from the *medium* (so a flux disc counts), raising the same confirmation.

The menu's Eject Tape ejected immediately while the status-bar route asked first — an inconsistency the bead did not mention. It asks now.

Reset wipes RAM with no guard. It now confirms **only when a disk has unsaved edits**. An unconditional prompt on an action people hit constantly just teaches them to click through the one that matters.

`RenderMenuItem` gained a `defer` flag so a caller can interpose a confirmation while label, shortcut and placement still come from the action registry — the structure F2 established, kept intact.

## Verification

**1627 tests pass**, 3 skipped (absent flux fixtures). `make clang-format` clean. GUI launches and quits cleanly.

These are ImGui dialog paths with no automated coverage — verified by construction and manual launch, not by test cases. Worth saying plainly given that is exactly how the last regression reached you.

## Still open in the cluster, deliberately

**F6 and F27 are the same problem**: `macos_menu.mm` builds every item with `keyEquivalent:@""` because *"SDL owns every key, so an AppKit accelerator here would double-fire"* (macos_menu.mm:130). Binding Cmd+Q/O/S/, or turning the inline `(F5)` text into real accelerators both need that ownership decided first. Not a label fix, and not mine to decide.

F10, F11, F12, F16, F18, F19, F20, F21 remain — larger information-architecture changes rather than defects.

---

# Also here: the config split (beads-uiq8)

`koncepcja.cfg` was both the tracked template **and** the file the emulator writes when started from the repo root — so running it dirtied the tree with personal paths and MRU history. It is why the repaired config from the config-truncation work could never be committed.

**`koncepcja.cfg.example`** is now the shipped default (keeping the documentation comments); **`koncepcja.cfg` is gitignored**.

The example is deliberately neutral — 1x window, never fullscreen, aspect ratio always preserved, empty drives, no personal paths, plain GPU-presented scaling that works on any machine, and **drive and tape sounds on**, because they are part of how a CPC behaves.

### One choice I made against the brief, with a measurement

The spec said "fastest mode". I set `run_tier=0` (auto) rather than pinning Fast, because Fast syncs the register view at frame boundaries — where an idle firmware loop sits at the same instruction:

| tier | three consecutive `reg get PC` |
|---|---|
| `run_tier=1` Fast | `1BC9` · **`1BF7`** · **`1BF7`** |
| `run_tier=0` auto | `1BC5` · `1BCC` · `1D24` |

Anyone starting from this file — including the Stanford course — would find the debugger apparently frozen. Auto already runs Fast unless a breakpoint is set, so it *is* the fast tier without that cost. It also broke `test_headless_runs_subcycle_engine`, which is how I noticed.

### Tests no longer read the maintainer's config

The integration harness starts the emulator from the repo root, so it was picking up whatever `koncepcja.cfg` happened to be there — runs depended on who was sitting at the machine. It now runs against a **throwaway copy** of the example, which also stops a mid-run save from editing the example itself.

Harness: **16/17**, the one failure being the pre-existing `test_step_in_accuracy` flake (beads-771z, reproduced on master).
