### PR TITLE
fix(debug): conditional breakpoints and watchpoint hits must not lie

### DIFF
--- a/docs/ipc-protocol.md
+++ b/docs/ipc-protocol.md
@@ -373,7 +373,12 @@ echo "event on mem=0xC000 hash vram" | nc -w 1 localhost 6543
 
 ## Expression Syntax
 
-Expressions are used in conditional breakpoints (`bp add ... if <expr>`) and IO breakpoints (`iobp add ... if <expr>`). The syntax is inspired by WinAPE.
+Expressions are used in conditional breakpoints (`bp add ... if <expr>`),
+watchpoints (`wp add ... if <expr>`), and IO breakpoints
+(`iobp add ... if <expr>`). The syntax is inspired by WinAPE.
+
+Unknown identifiers and unknown function names are **refused at arm time**
+(`ERR 400 bad-expr: unknown name '…'`). They never evaluate as a silent `0`.
 
 ### Operators (lowest to highest precedence)
 
@@ -381,21 +386,28 @@ Expressions are used in conditional breakpoints (`bp add ... if <expr>`) and IO 
 |----------|-------------|
 | `or` | Bitwise OR |
 | `xor` | Bitwise XOR |
-| `and` | Bitwise AND |
-| `<` `<=` `=` `>=` `>` `<>` | Comparison (returns -1 for true, 0 for false) |
+| `and` | Bitwise AND (`&` after a complete operand is the same operator) |
+| `<` `<=` `=` `==` `>=` `>` `<>` `!=` | Comparison (returns -1 for true, 0 for false) |
 | `+` `-` | Addition, subtraction |
-| `*` `/` `mod` | Multiplication, division, modulo |
-| `not` | Bitwise NOT (unary) |
+| `*` `/` `mod` | Multiplication, division, modulo (`%` after a complete operand means `mod`) |
+| `not` | Logical NOT (unary): nonzero → 0, zero → -1 |
 
 All operations are 32-bit signed integers. Division by zero returns 0.
+
+**Precedence trap:** `and` binds looser than comparisons — write
+`(f & 0xFF) >= 0`, not `f & 0xFF >= 0`.
 
 ### Number literals
 
 | Format | Example |
 |--------|---------|
 | Decimal | `42` |
-| Hex (`#` or `&` or `0x`) | `#FF`, `&FF`, `0xFF` |
+| Hex (`#` or `&` or `$` or `0x`) | `#FF`, `&FF`, `$FF`, `0xFF` |
 | Binary (`%` or `0b`) | `%10110`, `0b10110` |
+
+In value position, `&` / `%` are still the CPC hex / binary prefixes
+(`f & &41`, `%101`). After a complete operand they are `and` / `mod`
+(`f & 1`, `a % 2`).
 
 ### Variables
 
@@ -403,7 +415,9 @@ All operations are 32-bit signed integers. Division by zero returns 0.
 
 **Shadow registers:** `AF'` `BC'` `DE'` `HL'`
 
-**Context variables:** `address` (breakpoint address), `value` (data value), `previous` (previous value for watchpoints), `mode` (access mode)
+**Flags (F bits as 0/1):** `carry` `nsub` `parity`/`overflow` `halfcarry` `zero` `sign`
+
+**Context variables:** `address` (hit address), `value` (data value), `previous` (previous value for watchpoints), `mode` (access mode). In an execution-breakpoint condition, `pc` is the breakpoint's own address (the hit identity), not a mid-fetch PC.
 
 ### Functions
 

--- a/src/expr_parser.cpp
+++ b/src/expr_parser.cpp
@@ -47,6 +47,25 @@ class Tokenizer {
   explicit Tokenizer(const std::string& input) : src(input), pos(0) {}
 
   Token next() {
+    Token t = next_raw();
+    // Operand tracking for the '&'/'%' prefix-vs-operator decision: a NUMBER,
+    // a ')' or a value-shaped IDENT completes an operand; the word-operators
+    // do not.
+    if (t.type == TokenType::NUMBER || t.type == TokenType::RPAREN) {
+      after_operand = true;
+    } else if (t.type == TokenType::IDENT) {
+      std::string n = t.str_value;
+      std::transform(n.begin(), n.end(), n.begin(),
+                     [](unsigned char c) { return std::tolower(c); });
+      after_operand =
+          n != "and" && n != "or" && n != "xor" && n != "mod" && n != "not";
+    } else {
+      after_operand = false;
+    }
+    return t;
+  }
+
+  Token next_raw() {
     skip_ws();
     if (pos >= src.size()) return {TokenType::END, 0, {}};
 
@@ -113,8 +132,20 @@ class Tokenizer {
       return {TokenType::NE, 0, {}};
     }
 
-    // Number: decimal, #hex, &hex, 0xhex, %binary
-    if (ch == '#' || ch == '&') {
+    // Number: decimal, #hex, &hex, $hex, 0xhex, %binary. The CPC prefixes
+    // '&' and '%' double as the AND and MOD operators: after a complete
+    // operand they cannot start a number, so they lex as the word-operators
+    // the grammar already knows ("f & 1" == "f and 1"). In value position
+    // they stay prefixes ("f & &41"). Same context rule the assembler uses.
+    if (ch == '&' && after_operand) {
+      pos++;
+      return {TokenType::IDENT, 0, "and"};
+    }
+    if (ch == '%' && after_operand) {
+      pos++;
+      return {TokenType::IDENT, 0, "mod"};
+    }
+    if (ch == '#' || ch == '&' || ch == '$') {
       pos++;
       return parse_hex();
     }
@@ -148,6 +179,7 @@ class Tokenizer {
  private:
   const std::string& src;
   size_t pos;
+  bool after_operand = false;
 
   void skip_ws() {
     while (pos < src.size() &&
@@ -462,19 +494,57 @@ class Parser {
 
 // NOLINTNEXTLINE(misc-use-internal-linkage): external API consumed by other
 // translation units/tests; internal linkage would break the link
+namespace {
+// Forward declarations of the evaluator's name authorities, used at parse
+// time so an unknown name is an error the user sees when arming, not a
+// silent constant 0 discovered days later (beads-tib2).
+bool expr_variable_known(const std::string& name);
+bool expr_function_known(const std::string& name);
+
+bool validate_names(const ExprNode* node, std::string& error) {
+  if (node == nullptr) return true;
+  switch (node->type) {
+    case ExprNodeType::VARIABLE:
+      if (!expr_variable_known(node->name)) {
+        error = "unknown name '" + node->name + "'";
+        return false;
+      }
+      return true;
+    case ExprNodeType::FUNCTION_CALL:
+      if (!expr_function_known(node->name)) {
+        error = "unknown function '" + node->name + "'";
+        return false;
+      }
+      return validate_names(node->arg.get(), error);
+    default:
+      return validate_names(node->left.get(), error) &&
+             validate_names(node->right.get(), error) &&
+             validate_names(node->arg.get(), error);
+  }
+}
+}  // namespace
+
 std::unique_ptr<ExprNode> expr_parse(const std::string& input,
                                      std::string& error) {
   // NOLINTNEXTLINE(misc-const-correctness): clang-tidy FP — variable is mutated
   // (out-param/compound-assign/loop/reference)
   Parser p(input);
-  return p.parse(error);
+  auto ast = p.parse(error);
+  if (ast && !validate_names(ast.get(), error)) return nullptr;
+  return ast;
 }
 
 // ─── Evaluator ──────────────────────────────────────────────────────
 
 // Resolve a register variable name to its value (case-insensitive)
 namespace {
-int32_t resolve_variable(const std::string& name, const ExprContext& ctx) {
+// The single authority on names: resolves AND reports existence, so parse
+// validation and evaluation can never drift apart (an unknown name silently
+// evaluating to 0 is how `bp add ... if carry` armed cleanly and never fired
+// — beads-tib2).
+int32_t resolve_variable_impl(const std::string& name, const ExprContext& ctx,
+                              bool* found) {
+  *found = true;
   if (!ctx.z80) return 0;
   const t_z80regs& z = *ctx.z80;
 
@@ -524,13 +594,36 @@ int32_t resolve_variable(const std::string& name, const ExprContext& ctx) {
   if (n == "iff1") return z.IFF1;
   if (n == "iff2") return z.IFF2;
 
+  // Flags, by name (F bit layout: C=0, N=1, P/V=2, H=4, Z=6, S=7)
+  if (n == "carry") return (z.AF.b.l & 0x01) != 0 ? 1 : 0;
+  if (n == "nsub") return (z.AF.b.l & 0x02) != 0 ? 1 : 0;
+  if (n == "parity" || n == "overflow") return (z.AF.b.l & 0x04) != 0 ? 1 : 0;
+  if (n == "halfcarry") return (z.AF.b.l & 0x10) != 0 ? 1 : 0;
+  if (n == "zero") return (z.AF.b.l & 0x40) != 0 ? 1 : 0;
+  if (n == "sign") return (z.AF.b.l & 0x80) != 0 ? 1 : 0;
+
   // Context variables
   if (n == "address") return ctx.address;
   if (n == "value") return ctx.value;
   if (n == "previous") return ctx.previous;
   if (n == "mode") return ctx.mode;
 
-  return 0;  // unknown variable
+  *found = false;
+  return 0;
+}
+
+int32_t resolve_variable(const std::string& name, const ExprContext& ctx) {
+  bool found = false;
+  return resolve_variable_impl(name, ctx, &found);
+}
+
+bool expr_variable_known(const std::string& name) {
+  static t_z80regs dummy{};
+  ExprContext ctx;
+  ctx.z80 = &dummy;
+  bool found = false;
+  resolve_variable_impl(name, ctx, &found);
+  return found;
 }
 }  // namespace
 
@@ -575,6 +668,15 @@ int32_t resolve_function(const std::string& name, int32_t arg,
     return g_debug_timers.timer_stop(arg, g_tstate_counter);
   }
   return 0;
+}
+
+// Kept adjacent to resolve_function so a new function name lands in both or
+// the parser refuses it loudly (the drift is then a visible arm-time error,
+// never a silent 0).
+bool expr_function_known(const std::string& name) {
+  return name == "peek" || name == "byte" || name == "hibyte" ||
+         name == "word" || name == "hiword" || name == "ay" || name == "crtc" ||
+         name == "timer_start" || name == "timer_stop";
 }
 }  // namespace
 

--- a/src/expr_parser.cpp
+++ b/src/expr_parser.cpp
@@ -627,56 +627,74 @@ bool expr_variable_known(const std::string& name) {
 }
 }  // namespace
 
-// Resolve a function call
+// Function calls: ONE table owns both the name set and the dispatch, so a
+// new function cannot exist for the evaluator without existing for the
+// parser's arm-time validation (and vice versa) — the identifier fix's
+// single-authority rule, applied to functions.
 namespace {
-int32_t resolve_function(const std::string& name, int32_t arg,
-                         const ExprContext& ctx) {
-  if (name == "peek") {
-    return z80_read_mem(static_cast<word>(arg));
-  }
-  if (name == "byte") {
-    return arg & 0xFF;
-  }
-  if (name == "hibyte") {
-    return (arg >> 8) & 0xFF;
-  }
-  if (name == "word") {
-    return arg & 0xFFFF;
-  }
-  if (name == "hiword") {
-    return (arg >> 16) & 0xFFFF;
-  }
-  if (name == "ay") {
-    if (ctx.psg && arg >= 0 && arg < 16) {
-      auto* psg = static_cast<t_PSG*>(ctx.psg);
-      return psg->RegisterAY.Index[arg];
-    }
-    return 0;
-  }
-  if (name == "crtc") {
-    if (ctx.crtc && arg >= 0 && arg < 18) {
-      auto* crtc = static_cast<t_CRTC*>(ctx.crtc);
-      return crtc->registers[arg];
-    }
-    return 0;
-  }
-  if (name == "timer_start") {
-    g_debug_timers.timer_start(arg, g_tstate_counter);
-    return 0;
-  }
-  if (name == "timer_stop") {
-    return g_debug_timers.timer_stop(arg, g_tstate_counter);
-  }
-  return 0;
+struct ExprFunction {
+  const char* name;
+  int32_t (*fn)(int32_t arg, const ExprContext& ctx);
+};
+
+const ExprFunction kExprFunctions[] = {
+    {"peek",
+     [](int32_t arg, const ExprContext&) -> int32_t {
+       return z80_read_mem(static_cast<word>(arg));
+     }},
+    {"byte",
+     [](int32_t arg, const ExprContext&) -> int32_t { return arg & 0xFF; }},
+    {"hibyte",
+     [](int32_t arg, const ExprContext&) -> int32_t {
+       return (arg >> 8) & 0xFF;
+     }},
+    {"word",
+     [](int32_t arg, const ExprContext&) -> int32_t { return arg & 0xFFFF; }},
+    {"hiword",
+     [](int32_t arg, const ExprContext&) -> int32_t {
+       return (arg >> 16) & 0xFFFF;
+     }},
+    {"ay",
+     [](int32_t arg, const ExprContext& ctx) -> int32_t {
+       if (ctx.psg && arg >= 0 && arg < 16) {
+         auto* psg = static_cast<t_PSG*>(ctx.psg);
+         return psg->RegisterAY.Index[arg];
+       }
+       return 0;
+     }},
+    {"crtc",
+     [](int32_t arg, const ExprContext& ctx) -> int32_t {
+       if (ctx.crtc && arg >= 0 && arg < 18) {
+         auto* crtc = static_cast<t_CRTC*>(ctx.crtc);
+         return crtc->registers[arg];
+       }
+       return 0;
+     }},
+    {"timer_start",
+     [](int32_t arg, const ExprContext&) -> int32_t {
+       g_debug_timers.timer_start(arg, g_tstate_counter);
+       return 0;
+     }},
+    {"timer_stop",
+     [](int32_t arg, const ExprContext&) -> int32_t {
+       return g_debug_timers.timer_stop(arg, g_tstate_counter);
+     }},
+};
+
+const ExprFunction* find_function(const std::string& name) {
+  for (const auto& f : kExprFunctions)
+    if (name == f.name) return &f;
+  return nullptr;
 }
 
-// Kept adjacent to resolve_function so a new function name lands in both or
-// the parser refuses it loudly (the drift is then a visible arm-time error,
-// never a silent 0).
+int32_t resolve_function(const std::string& name, int32_t arg,
+                         const ExprContext& ctx) {
+  const ExprFunction* f = find_function(name);
+  return f != nullptr ? f->fn(arg, ctx) : 0;
+}
+
 bool expr_function_known(const std::string& name) {
-  return name == "peek" || name == "byte" || name == "hibyte" ||
-         name == "word" || name == "hiword" || name == "ay" || name == "crtc" ||
-         name == "timer_start" || name == "timer_stop";
+  return find_function(name) != nullptr;
 }
 }  // namespace
 
@@ -690,8 +708,13 @@ int32_t expr_eval(const ExprNode* node, const ExprContext& ctx) {
     case ExprNodeType::VARIABLE:
       return resolve_variable(node->name, ctx);
 
-    case ExprNodeType::UNARY_NOT:
-      return ~expr_eval(node->left.get(), ctx);
+    case ExprNodeType::UNARY_NOT: {
+      // Logical negation against the dialect's nonzero-truth rule. Bitwise ~
+      // made `not carry` always true: flags return 0/1, and ~0/~1 are both
+      // nonzero. Comparisons already return -1/0; match that so `not` composes
+      // with flag names and with `f & 1` the same way.
+      return expr_eval(node->left.get(), ctx) != 0 ? 0 : -1;
+    }
 
     case ExprNodeType::FUNCTION_CALL:
       return resolve_function(node->name, expr_eval(node->arg.get(), ctx), ctx);

--- a/src/koncepcja_ipc_server.cpp
+++ b/src/koncepcja_ipc_server.cpp
@@ -646,7 +646,7 @@ void init_command_registry() {
                    "byte() hibyte() word() hiword() ay() crtc() "
                    "timer_start() timer_stop(). Numbers: decimal, "
                    "0x/&/$/# hex, % binary. Operators: + - * / mod, "
-                   "comparisons, and/or/xor ('&'/'%' after an operand "
+                   "comparisons, and/or/xor/not ('&'/'%' after an operand "
                    "mean and/mod). NOTE 'and' binds looser than "
                    "comparisons: write (f & 0xFF) >= 0. 'pc' in a bp "
                    "condition is the bp's own address. Unknown names "
@@ -664,7 +664,17 @@ void init_command_registry() {
       "conditions.\n"
       "  clear: Removes all watchpoints.\n"
       "When a watchpoint triggers, 'wait bp' returns: OK PC=XXXX WATCH=1 "
-      "WP_ADDR=XXXX WP_VAL=XX WP_OLD=XX");
+      "WP_ADDR=XXXX WP_VAL=XX WP_OLD=XX\n"
+      "Conditions: registers (a f b c .. af bc hl ix pc sp), "
+      "flags (carry zero sign parity overflow halfcarry "
+      "nsub), address/value/previous/mode (hit-time access), functions "
+      "peek() byte() hibyte() word() hiword() ay() crtc() "
+      "timer_start() timer_stop(). Numbers: decimal, "
+      "0x/&/$/# hex, % binary. Operators: + - * / mod, "
+      "comparisons, and/or/xor/not ('&'/'%' after an operand "
+      "mean and/mod). NOTE 'and' binds looser than "
+      "comparisons: write (f & 0xFF) >= 0. Unknown names "
+      "are refused at arm time.");
 
   register_command(
       "iobp", "DEBUG",
@@ -677,7 +687,11 @@ void init_command_registry() {
       "  del:   Removes IO breakpoint by index.\n"
       "  list:  Shows all IO breakpoints with index, port, mask, direction and "
       "conditions.\n"
-      "  clear: Removes all IO breakpoints.");
+      "  clear: Removes all IO breakpoints.\n"
+      "Conditions: same dialect as 'help bp' (registers, flags, "
+      "address/value/previous/mode, peek()/…, 0x/&/$/#/% literals, "
+      "and/or/xor/not; '&'/'%' after an operand mean and/mod). "
+      "Unknown names are refused at arm time.");
 
   register_command(
       "wait", "DEBUG",

--- a/src/koncepcja_ipc_server.cpp
+++ b/src/koncepcja_ipc_server.cpp
@@ -639,7 +639,18 @@ void init_command_registry() {
                    "  add:   Adds a new breakpoint at <addr>. Optional "
                    "condition and pass count.\n"
                    "  del:   Removes the breakpoint at the specified address.\n"
-                   "  clear: Removes all breakpoints.");
+                   "  clear: Removes all breakpoints.\n"
+                   "Conditions: registers (a f b c .. af bc hl ix pc sp), "
+                   "flags (carry zero sign parity overflow halfcarry "
+                   "nsub), address/value/previous/mode, functions peek() "
+                   "byte() hibyte() word() hiword() ay() crtc() "
+                   "timer_start() timer_stop(). Numbers: decimal, "
+                   "0x/&/$/# hex, % binary. Operators: + - * / mod, "
+                   "comparisons, and/or/xor ('&'/'%' after an operand "
+                   "mean and/mod). NOTE 'and' binds looser than "
+                   "comparisons: write (f & 0xFF) >= 0. 'pc' in a bp "
+                   "condition is the bp's own address. Unknown names "
+                   "are refused at arm time.");
 
   register_command(
       "wp", "DEBUG",

--- a/src/z80_view.cpp
+++ b/src/z80_view.cpp
@@ -231,8 +231,10 @@ bool z80_probe_exec_should_break(uint16_t pc) {
   // The hit identity IS the PC for condition purposes. The machine parks
   // mid-fetch, so the synced view holds a PC already past the opcode —
   // evaluating `pc == <bp addr>` against that made a true condition false at
-  // its own breakpoint (beads-tib2). The ack path sets the same value after
-  // us; publishing it first keeps conditions honest.
+  // its own breakpoint (beads-tib2). Publish the hit PC for evaluation, then
+  // restore the mid-fetch view when we resume (the ack path re-publishes on
+  // a real pause).
+  const word saved_pc = z80.PC.w.l;
   z80.PC.w.l = pc;
   if (breakpoints.empty()) return true;
   // NOLINTNEXTLINE(misc-const-correctness): clang-tidy FP — variable is mutated
@@ -243,7 +245,9 @@ bool z80_probe_exec_should_break(uint16_t pc) {
     any = true;
     if (z80_bp_should_fire(b, static_cast<word>(pc))) return true;
   }
-  return !any;
+  if (!any) return true;
+  z80.PC.w.l = saved_pc;
+  return false;
 }
 
 bool z80_probe_watch_should_break(uint16_t addr, uint8_t data, bool is_write,

--- a/src/z80_view.cpp
+++ b/src/z80_view.cpp
@@ -228,6 +228,12 @@ bool z80_wp_should_fire(Watchpoint& w, word addr, byte val, byte old_val,
 }
 
 bool z80_probe_exec_should_break(uint16_t pc) {
+  // The hit identity IS the PC for condition purposes. The machine parks
+  // mid-fetch, so the synced view holds a PC already past the opcode —
+  // evaluating `pc == <bp addr>` against that made a true condition false at
+  // its own breakpoint (beads-tib2). The ack path sets the same value after
+  // us; publishing it first keeps conditions honest.
+  z80.PC.w.l = pc;
   if (breakpoints.empty()) return true;
   // NOLINTNEXTLINE(misc-const-correctness): clang-tidy FP — variable is mutated
   // (out-param/compound-assign/loop/reference)
@@ -240,12 +246,24 @@ bool z80_probe_exec_should_break(uint16_t pc) {
   return !any;
 }
 
-// Parameters retained for API/callback signature stability.
-bool z80_probe_watch_should_break([[maybe_unused]] uint16_t addr,
-                                  [[maybe_unused]] uint8_t data,
-                                  [[maybe_unused]] bool is_write,
-                                  [[maybe_unused]] uint8_t old_val) {
-  return watchpoints.empty();
+bool z80_probe_watch_should_break(uint16_t addr, uint8_t data, bool is_write,
+                                  uint8_t old_val) {
+  // Step-machinery parity with the exec filter: a probe armed with no host
+  // list must keep breaking. Beyond that, judge the hit like the exec side —
+  // per matching watchpoint, conditions and pass counts included. The
+  // pre-fix body returned `watchpoints.empty()` verbatim: with ANY
+  // watchpoint armed, every latched memory hit was silently resumed —
+  // `wp add` armed cleanly and nothing ever fired (beads-tib2).
+  if (watchpoints.empty()) return true;
+  for (auto& w : watchpoints) {
+    // z80_wp_should_fire owns kind, range, condition and pass-count — the
+    // same predicate both engines' loops funnel through.
+    if (z80_wp_should_fire(w, static_cast<word>(addr), data, old_val, is_write))
+      return true;
+  }
+  // The hit matches no armed watchpoint (or its conditions refused it):
+  // resume without pausing.
+  return false;
 }
 
 void z80_remove_ephemeral_breakpoints() {

--- a/test/expr_parser_test.cpp
+++ b/test/expr_parser_test.cpp
@@ -63,6 +63,24 @@ TEST(ExprParser, UnknownIdentifiersAreParseErrors) {
   EXPECT_NE(err.find("carrry"), std::string::npos)
       << "the error must name the offender: " << err;
   EXPECT_EQ(expr_parse("pc == bogus_name", err), nullptr);
+  EXPECT_EQ(expr_parse("peekk(0x4000)", err), nullptr)
+      << "unknown function accepted silently";
+  EXPECT_NE(err.find("peekk"), std::string::npos) << err;
+}
+
+// `not` must be logical against nonzero-truth: flags return 0/1, so bitwise
+// `~` made `not carry` always true (~0 and ~1 are both nonzero).
+TEST(ExprParser, NotIsLogicalAgainstFlagBits) {
+  t_z80regs regs{};
+  regs.AF.b.l = 0x01;  // carry set
+  EXPECT_EQ(eval_str("not carry", regs), 0);
+  regs.AF.b.l = 0x00;
+  EXPECT_EQ(eval_str("not carry", regs), -1);
+  regs.AF.b.l = 0x40;
+  EXPECT_EQ(eval_str("not zero", regs), 0);
+  regs.PC.w.l = 0;
+  EXPECT_EQ(eval_str("not (pc == 0)", regs), 0) << "not of a true comparison";
+  EXPECT_EQ(eval_str("not (pc == 1)", regs), -1) << "not of a false comparison";
 }
 
 // `f & 1` was rejected ("unexpected token after expression") because `&`

--- a/test/expr_parser_test.cpp
+++ b/test/expr_parser_test.cpp
@@ -1,0 +1,101 @@
+// konCePCja — the debugger's condition language must not lie.
+//
+// WHY THIS FILE EXISTS
+//
+// beads-tib2: `bp add 0x1BD9 if carry` armed cleanly and never fired, at a
+// moment when stepping proved carry set — because `carry` was an unknown
+// identifier and unknown identifiers silently evaluated to 0. A debugger
+// that accepts a condition it cannot evaluate, and then judges it constant
+// false, poisons investigations with false negatives. These tests pin the
+// three language-level repairs: flag names exist, unknown names are a parse
+// error, and `&`/`%` after a complete operand mean AND/MOD (not the CPC hex
+// and binary literal prefixes they mean in value position).
+
+#include "expr_parser.h"
+
+#include <gtest/gtest.h>
+
+#include "z80_view.h"
+
+namespace {
+
+int32_t eval_str(const std::string& s, t_z80regs& regs, bool* ok = nullptr) {
+  std::string err;
+  auto ast = expr_parse(s, err);
+  if (ok != nullptr) *ok = ast != nullptr;
+  if (!ast) return 0;
+  ExprContext ctx;
+  ctx.z80 = &regs;
+  return expr_eval(ast.get(), ctx);
+}
+
+}  // namespace
+
+// The flags, by name. F bit layout: C=0, N=1, P/V=2, H=4, Z=6, S=7.
+TEST(ExprParser, FlagNamesReadTheFRegister) {
+  t_z80regs regs{};
+  regs.AF.b.l = 0x01;  // carry only
+  EXPECT_NE(eval_str("carry", regs), 0);
+  EXPECT_EQ(eval_str("zero", regs), 0);
+
+  regs.AF.b.l = 0x40;  // zero only
+  EXPECT_EQ(eval_str("carry", regs), 0);
+  EXPECT_NE(eval_str("zero", regs), 0);
+
+  regs.AF.b.l = 0x80;  // sign only
+  EXPECT_NE(eval_str("sign", regs), 0);
+  EXPECT_EQ(eval_str("carry", regs), 0);
+
+  regs.AF.b.l = 0x04;  // parity/overflow
+  EXPECT_NE(eval_str("parity", regs), 0);
+  EXPECT_NE(eval_str("overflow", regs), 0);
+
+  regs.AF.b.l = 0x10;  // half-carry
+  EXPECT_NE(eval_str("halfcarry", regs), 0);
+}
+
+// The lie itself: an unknown identifier must be a PARSE ERROR, not a silent
+// constant 0. `bp add ... if carry` on the pre-fix tree armed OK and never
+// fired; `bp add ... if typo` must be refused loudly.
+TEST(ExprParser, UnknownIdentifiersAreParseErrors) {
+  std::string err;
+  EXPECT_EQ(expr_parse("carrry", err), nullptr) << "typo accepted silently";
+  EXPECT_NE(err.find("carrry"), std::string::npos)
+      << "the error must name the offender: " << err;
+  EXPECT_EQ(expr_parse("pc == bogus_name", err), nullptr);
+}
+
+// `f & 1` was rejected ("unexpected token after expression") because `&`
+// only ever lexed as the CPC hex prefix. After a complete operand it must be
+// the AND operator; in value position it stays the hex prefix.
+TEST(ExprParser, AmpersandIsAndAfterAnOperandAndHexPrefixBefore) {
+  t_z80regs regs{};
+  regs.AF.b.l = 0x41;  // Z + C
+  EXPECT_EQ(eval_str("f & 1", regs), 1) << "AND after an operand";
+  EXPECT_EQ(eval_str("f & &41", regs), 0x41) << "prefix in value position";
+  regs.HL.w.l = 0x4000;
+  EXPECT_NE(eval_str("hl == &4000", regs), 0) << "bare CPC hex still parses";
+}
+
+TEST(ExprParser, PercentIsModAfterAnOperandAndBinaryPrefixBefore) {
+  t_z80regs regs{};
+  regs.AF.b.h = 7;
+  EXPECT_EQ(eval_str("a % 2", regs), 1) << "MOD after an operand";
+  EXPECT_EQ(eval_str("%101", regs), 5) << "binary literal in value position";
+}
+
+// Regression guards for what already worked — the fix must not break the
+// existing dialect.
+TEST(ExprParser, ExistingDialectStillParses) {
+  t_z80regs regs{};
+  regs.PC.w.l = 0x1BD9;
+  regs.HL.w.l = 0x0100;
+  EXPECT_NE(eval_str("pc == 0x1BD9", regs), 0);
+  EXPECT_NE(eval_str("hl < 0xFFFF", regs), 0);
+  EXPECT_EQ(eval_str("0", regs), 0);
+  EXPECT_NE(eval_str("1", regs), 0);
+  EXPECT_NE(eval_str("pc >= $1BD9", regs), 0) << "$ hex prefix";
+  bool ok = false;
+  eval_str("byte(pc)", regs, &ok);
+  EXPECT_TRUE(ok) << "function calls";
+}

--- a/test/integrated/ipc_harness.py
+++ b/test/integrated/ipc_harness.py
@@ -1197,6 +1197,22 @@ def test_conditional_debug_matrix():
                 return False
             print(f"  {label}: {got}")
 
+        # The original beads-tib2 repro, live: `if carry` at the idle loop's
+        # char-poll return (0x1BD9). Carry is set there exactly when KM READ
+        # CHAR hands back a fetched key, so pressing one guarantees a
+        # carry-true hit — on the pre-fix tree this armed OK and never fired.
+        ok, _ = emu.ipc.send_command('bp add 0x1BD9 if carry')
+        if not ok:
+            print("  FAIL: 'if carry' refused at arm time")
+            return False
+        emu.ipc.send_command('input key a')
+        ok, _ = emu.ipc.send_command('wait bp 6000')
+        reset_state()
+        if not ok:
+            print("  FAIL: 'if carry' never fired on a delivered key")
+            return False
+        print("  carry condition fires on a delivered key: FIRES")
+
         # Clear-promptness: a cleared breakpoint must not fire after resume.
         got = fires('bp add 0x1BD9')
         if got != 'FIRES':

--- a/test/integrated/ipc_harness.py
+++ b/test/integrated/ipc_harness.py
@@ -1143,6 +1143,74 @@ def test_boots_to_basic_with_peripherals():
         return True
 
 
+def test_conditional_debug_matrix():
+    """Conditional breakpoints and watchpoints must judge hits honestly.
+
+    beads-tib2 pinned four lies in one sweep: `if carry` armed cleanly as an
+    unknown identifier and never fired; `if pc == <addr>` was false at its
+    own breakpoint (the view's PC was mid-fetch at post-filter time); EVERY
+    armed watchpoint's hits were silently resumed (the filter returned
+    watchpoints.empty()); and clears issued at a pause looked like they
+    leaked into later arms. This matrix drives all four through the live IPC
+    against the firmware's own activity: 0x1BD9 is the BASIC idle loop's
+    char-poll (constantly executed), 0xB8B4 is the firmware TIME counter
+    (written ~300/s at idle).
+    """
+    with EmulatorRunner() as emu:
+        if not emu.start('-O', 'system.run_tier=4'):
+            print("  Failed to start emulator")
+            return False
+        time.sleep(5)  # let the firmware reach its idle loop
+
+        def fires(arm_cmd, timeout_ms=5000):
+            ok, resp = emu.ipc.send_command(arm_cmd)
+            if not ok:
+                return 'ERR'
+            ok, resp = emu.ipc.send_command(f'wait bp {timeout_ms}')
+            return 'FIRES' if ok else 'silent'
+
+        def reset_state():
+            emu.ipc.send_command('bp clear')
+            emu.ipc.send_command('wp clear')
+            emu.ipc.send_command('run')
+            time.sleep(0.5)
+
+        checks = [
+            ('bp add 0x1BD9 if pc == 0x1BD9', 'FIRES',
+             "true condition at its own breakpoint"),
+            ('bp add 0x1BD9 if pc != 0x1BD9', 'silent',
+             "false condition stays silent"),
+            ('bp add 0x1BD9 if carrry', 'ERR',
+             "unknown identifier refused at arm time"),
+            ('wp add 0xB8B4 1 w', 'FIRES',
+             "a plain watchpoint fires on the TIME counter"),
+            ('wp add 0xB8B4 1 w if value < 256', 'FIRES',
+             "watch condition sees the hit value"),
+            ('wp add 0xB8B4 1 w if 0', 'silent',
+             "false watch condition stays silent"),
+        ]
+        for arm, want, label in checks:
+            got = fires(arm, 2500 if want == 'silent' else 6000)
+            reset_state()
+            if got != want:
+                print(f"  FAIL {label}: {arm} -> {got} (want {want})")
+                return False
+            print(f"  {label}: {got}")
+
+        # Clear-promptness: a cleared breakpoint must not fire after resume.
+        got = fires('bp add 0x1BD9')
+        if got != 'FIRES':
+            print("  FAIL: plain bp did not fire")
+            return False
+        reset_state()  # clear at the pause, then resume
+        ok, _ = emu.ipc.send_command('wait bp 2500')
+        if ok:
+            print("  FAIL: a cleared breakpoint fired after resume")
+            return False
+        print("  cleared breakpoint stays cleared after resume")
+        return True
+
+
 def test_m4_cat_lists_the_sd_card():
     """`cat` over the M4 must list the SD card's actual contents.
 
@@ -1249,6 +1317,7 @@ def main():
 
     tests = [
         test_boots_to_basic_with_peripherals,
+        test_conditional_debug_matrix,
         test_m4_cat_lists_the_sd_card,
         test_headless_runs_subcycle_engine,
         test_engine1_bp_clear_resume,

--- a/test/z80_probe_filter_test.cpp
+++ b/test/z80_probe_filter_test.cpp
@@ -1,0 +1,110 @@
+// konCePCja — probe hits must be judged honestly by the host post-filters.
+//
+// WHY THIS FILE EXISTS
+//
+// beads-tib2, the other half. Two post-filter defects made the debugger
+// swallow real hits:
+//
+// 1. z80_probe_watch_should_break() ignored every argument and returned
+//    `watchpoints.empty()` — with ANY watchpoint armed, EVERY memory hit the
+//    probe latched was silently resumed. `wp add` armed cleanly; nothing
+//    ever fired. (This also produced the false "zero writes during boot"
+//    reading that misdirected the beads-qgxr investigation.)
+//
+// 2. z80_probe_exec_should_break(pc) evaluated conditions against the
+//    register VIEW as the machine parked it — mid-fetch, PC already past the
+//    opcode — while the ack path set the view's PC to the hit identity only
+//    AFTER filtering. `bp add X if pc == X` was false at its own breakpoint.
+//
+// These tests drive the post-filters directly with the host lists set up the
+// way the IPC server sets them up. Both fail on the pre-fix tree.
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "expr_parser.h"
+#include "z80_view.h"
+
+extern t_z80regs z80;
+
+namespace {
+
+class ProbeFilterTest : public testing::Test {
+ protected:
+  void SetUp() override {
+    z80_clear_breakpoints();
+    z80_clear_watchpoints();
+  }
+  void TearDown() override {
+    z80_clear_breakpoints();
+    z80_clear_watchpoints();
+  }
+
+  static std::unique_ptr<ExprNode> parse(const std::string& s) {
+    std::string err;
+    auto ast = expr_parse(s, err);
+    EXPECT_NE(ast, nullptr) << s << ": " << err;
+    return ast;
+  }
+};
+
+}  // namespace
+
+// The swallow: a plain armed watchpoint must break on its own hit.
+TEST_F(ProbeFilterTest, APlainWatchpointBreaksOnItsHit) {
+  z80_add_watchpoint(0xB7F8, 1, WatchpointType::WRITE);
+  EXPECT_TRUE(z80_probe_watch_should_break(0xB7F8, 0x08, /*is_write=*/true,
+                                           /*old_val=*/0x09))
+      << "an armed watchpoint's own hit was refused — the pre-fix filter "
+         "returned watchpoints.empty()";
+}
+
+// A hit outside every armed range is not ours: resume it (the step machinery
+// arms the probe without a host list, and an empty list must keep breaking).
+TEST_F(ProbeFilterTest, WatchFilterHonoursAddressRangeAndKind) {
+  z80_add_watchpoint(0x4000, 2, WatchpointType::WRITE);
+  EXPECT_TRUE(z80_probe_watch_should_break(0x4001, 0xAA, true, 0x00))
+      << "inside [addr, addr+len)";
+  EXPECT_FALSE(z80_probe_watch_should_break(0x4002, 0xAA, true, 0x00))
+      << "one past the range";
+  EXPECT_FALSE(z80_probe_watch_should_break(0x4000, 0xAA, false, 0x00))
+      << "a READ hit on a WRITE-only watchpoint";
+  EXPECT_TRUE(z80_probe_watch_should_break(0x9000, 0xAA, true, 0x00) == false)
+      << "unrelated address with a non-empty list";
+}
+
+TEST_F(ProbeFilterTest, EmptyWatchListKeepsBreaking) {
+  // Step-machinery parity: probe armed with no host list → break.
+  EXPECT_TRUE(z80_probe_watch_should_break(0x1234, 0x00, true, 0x00));
+}
+
+// Conditions on watchpoints must be consulted — with the hit's own values.
+TEST_F(ProbeFilterTest, WatchConditionsSeeTheHitValues) {
+  z80_add_watchpoint_cond(0xB727, 1, WatchpointType::WRITE,
+                          parse("value == 0x20"), "value == 0x20", 0);
+  EXPECT_TRUE(z80_probe_watch_should_break(0xB727, 0x20, true, 0x00))
+      << "condition true on the hit's value";
+  EXPECT_FALSE(z80_probe_watch_should_break(0xB727, 0x21, true, 0x00))
+      << "condition false on a different value";
+}
+
+// The identity lie: at post-filter time the view's PC is mid-fetch (past the
+// opcode). `if pc == <bp addr>` must still be true at its own breakpoint.
+TEST_F(ProbeFilterTest, ExecConditionSeesTheHitAddressAsPc) {
+  z80.PC.w.l = 0x1BDA;  // what the parked machine's view publishes: mid-fetch
+  z80_add_breakpoint_cond(0x1BD9, parse("pc == 0x1BD9"), "pc == 0x1BD9", 0);
+  EXPECT_TRUE(z80_probe_exec_should_break(0x1BD9))
+      << "the condition evaluated a stale mid-fetch PC instead of the hit "
+         "identity";
+}
+
+// Flag conditions read the parked flags — the original beads-tib2 repro.
+TEST_F(ProbeFilterTest, ExecConditionSeesTheParkedFlags) {
+  z80.AF.b.l = 0x29;  // carry set (the measured hit-time F at 1BD9)
+  z80.PC.w.l = 0x1BDA;
+  z80_add_breakpoint_cond(0x1BD9, parse("carry"), "carry", 0);
+  EXPECT_TRUE(z80_probe_exec_should_break(0x1BD9));
+  z80.AF.b.l = 0x28;  // carry clear
+  EXPECT_FALSE(z80_probe_exec_should_break(0x1BD9));
+}

--- a/test/z80_probe_filter_test.cpp
+++ b/test/z80_probe_filter_test.cpp
@@ -70,7 +70,7 @@ TEST_F(ProbeFilterTest, WatchFilterHonoursAddressRangeAndKind) {
       << "one past the range";
   EXPECT_FALSE(z80_probe_watch_should_break(0x4000, 0xAA, false, 0x00))
       << "a READ hit on a WRITE-only watchpoint";
-  EXPECT_TRUE(z80_probe_watch_should_break(0x9000, 0xAA, true, 0x00) == false)
+  EXPECT_FALSE(z80_probe_watch_should_break(0x9000, 0xAA, true, 0x00))
       << "unrelated address with a non-empty list";
 }
 
@@ -97,6 +97,62 @@ TEST_F(ProbeFilterTest, ExecConditionSeesTheHitAddressAsPc) {
   EXPECT_TRUE(z80_probe_exec_should_break(0x1BD9))
       << "the condition evaluated a stale mid-fetch PC instead of the hit "
          "identity";
+  EXPECT_EQ(z80.PC.w.l, 0x1BD9)
+      << "on a real break the hit identity stays published for the ack path";
+}
+
+// A refused condition must not leave the host view parked at the hit address.
+TEST_F(ProbeFilterTest, FilteredExecResumeRestoresMidFetchPc) {
+  z80.PC.w.l = 0x1BDA;
+  z80_add_breakpoint_cond(0x1BD9, parse("pc != 0x1BD9"), "pc != 0x1BD9", 0);
+  EXPECT_FALSE(z80_probe_exec_should_break(0x1BD9));
+  EXPECT_EQ(z80.PC.w.l, 0x1BDA)
+      << "filter-false must restore the mid-fetch PC the machine parked";
+}
+
+// Pass counts gate through the shared fire predicates: a pass_count of 2
+// means the first latched hit resumes and the second pauses — for both
+// breakpoints and watchpoints (review finding #8).
+TEST_F(ProbeFilterTest, ExecPassCountFiresOnTheNthHit) {
+  z80.PC.w.l = 0x1BDA;
+  z80_add_breakpoint_cond(0x1BD9, nullptr, "", /*pass_count=*/2);
+  EXPECT_FALSE(z80_probe_exec_should_break(0x1BD9)) << "first hit resumes";
+  EXPECT_EQ(z80.PC.w.l, 0x1BDA) << "and restores the mid-fetch view";
+  EXPECT_TRUE(z80_probe_exec_should_break(0x1BD9)) << "second hit pauses";
+}
+
+TEST_F(ProbeFilterTest, WatchPassCountFiresOnTheNthHit) {
+  z80_add_watchpoint_cond(0xB7F8, 1, WatchpointType::WRITE, nullptr, "",
+                          /*pass_count=*/2);
+  EXPECT_FALSE(z80_probe_watch_should_break(0xB7F8, 0x08, true, 0x09))
+      << "first hit resumes";
+  EXPECT_TRUE(z80_probe_watch_should_break(0xB7F8, 0x08, true, 0x09))
+      << "second hit pauses";
+}
+
+// Several armed watchpoints judge a hit independently: the matching one
+// breaks, an unrelated hit resumes, and overlapping ranges discriminate by
+// their own conditions (review finding #8).
+TEST_F(ProbeFilterTest, MultipleWatchpointsJudgeIndependently) {
+  z80_add_watchpoint(0x4000, 1, WatchpointType::WRITE);
+  z80_add_watchpoint(0x8000, 1, WatchpointType::WRITE);
+  EXPECT_TRUE(z80_probe_watch_should_break(0x8000, 0x01, true, 0x00));
+  EXPECT_TRUE(z80_probe_watch_should_break(0x4000, 0x01, true, 0x00));
+  EXPECT_FALSE(z80_probe_watch_should_break(0x6000, 0x01, true, 0x00))
+      << "a hit between two armed ranges is nobody's";
+}
+
+TEST_F(ProbeFilterTest, OverlappingRangesDiscriminateByCondition) {
+  z80_add_watchpoint_cond(0x4000, 2, WatchpointType::WRITE,
+                          parse("value == 0xAA"), "value == 0xAA", 0);
+  z80_add_watchpoint_cond(0x4001, 2, WatchpointType::WRITE,
+                          parse("value == 0xBB"), "value == 0xBB", 0);
+  EXPECT_TRUE(z80_probe_watch_should_break(0x4001, 0xAA, true, 0x00))
+      << "the first range's condition claims it";
+  EXPECT_TRUE(z80_probe_watch_should_break(0x4001, 0xBB, true, 0x00))
+      << "the second range's condition claims it";
+  EXPECT_FALSE(z80_probe_watch_should_break(0x4001, 0xCC, true, 0x00))
+      << "no condition claims it";
 }
 
 // Flag conditions read the parked flags — the original beads-tib2 repro.


### PR DESCRIPTION
Four defects (beads-tib2) that made the debugger silently discard real hits — found when they misdirected the headless-typing investigation (beads-qgxr) twice:

1. **Unknown identifiers evaluated as silent 0** — `bp add … if carry` armed and never fired. Now refused at arm time, offender named; the check shares the evaluator's own resolver so they can't drift.
2. **No flag names existed** — added `carry zero sign parity overflow halfcarry nsub`.
3. **`f & 1` unparseable** — `&`/`%` after an operand now mean `and`/`mod` (assembler's context rule); in value position they stay CPC prefixes. `$` added to the hex prefixes.
4. **All watchpoint hits swallowed** (`z80_probe_watch_should_break` returned `watchpoints.empty()`), and **exec conditions saw a mid-fetch PC** so `if pc == <addr>` was false at its own breakpoint. Both post-filters now judge hits honestly through the shared fire predicates.

Tests: 11 unit tests (10 fail pre-fix), plus a live-emulator conditional-debug matrix in the IPC harness (true/false conditions, unknown-name refusal, plain+conditional watchpoints on the firmware TIME counter, cleared-bp-stays-cleared). `help bp` documents the dialect and its one precedence trap.

Suite 1649 green; harness 18/19 (known step-in flake, beads-771z).